### PR TITLE
only delete dois in draft state

### DIFF
--- a/app/controllers/dois_controller.rb
+++ b/app/controllers/dois_controller.rb
@@ -77,11 +77,16 @@ class DoisController < ApplicationController
   end
 
   def destroy
-    if @doi.destroy
-      head :no_content
+    if @doi.draft?
+      if @doi.destroy
+        head :no_content
+      else
+        Rails.logger.warn @doi.errors.inspect
+        render jsonapi: serialize(@doi.errors), status: :unprocessable_entity
+      end
     else
-      Rails.logger.warn @doi.errors.inspect
-      render jsonapi: serialize(@doi.errors), status: :unprocessable_entity
+      response.headers["Allow"] = "HEAD, GET, POST, PATCH, PUT, OPTIONS"
+      render json: { errors: [{ status: "405", title: "Method not allowed" }] }.to_json, status: :method_not_allowed
     end
   end
 

--- a/spec/requests/dois_spec.rb
+++ b/spec/requests/dois_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "dois", type: :request do
   # Test suite for DELETE /dois/:id
   describe 'DELETE /dois/:id' do
     before do
-      doi.start
+      doi = create(:doi, client: client, aasm_state: "draft")
       delete "/dois/#{doi.doi}", headers: headers
     end
 
@@ -161,6 +161,21 @@ RSpec.describe "dois", type: :request do
 
     it 'deletes the record' do
       expect(response.body).to be_empty
+    end
+  end
+
+  describe 'DELETE /dois/:id findable state' do
+    before do
+      doi = create(:doi, client: client, aasm_state: "findable")
+      delete "/dois/#{doi.doi}", headers: headers
+    end
+
+    it 'returns status code 405' do
+      expect(response).to have_http_status(405)
+    end
+
+    it 'deletes the record' do
+      expect(json["errors"]).to eq([{"status"=>"405", "title"=>"Method not allowed"}])
     end
   end
 end


### PR DESCRIPTION
`draft` is used for DOIs that have never been registered in the handle system. This is the only DOI state where DOIs can be deleted. This also includes **reserved** DOIs. 