### PR TITLE
added basic authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,21 +42,21 @@ class ApplicationController < ActionController::API
     params.transform_keys! { |key| key.tr('-', '_') }
   end
 
-  def authenticate_user_from_token!
-    token = token_from_request_headers
-    return false unless token.present?
+  def authenticate_user!
+    type, credentials = type_and_credentials_from_request_headers
+    return false unless credentials.present?
 
-    @current_user = User.new(token)
+    @current_user = User.new(credentials, type: type)
   end
 
   def current_ability
     @current_ability ||= Ability.new(current_user)
   end
 
-  # from https://github.com/nsarno/knock/blob/master/lib/knock/authenticable.rb
-  def token_from_request_headers
+  # based on https://github.com/nsarno/knock/blob/master/lib/knock/authenticable.rb
+  def type_and_credentials_from_request_headers
     unless request.headers['Authorization'].nil?
-      request.headers['Authorization'].split.last
+      request.headers['Authorization'].split
     end
   end
 

--- a/app/controllers/client_prefixes_controller.rb
+++ b/app/controllers/client_prefixes_controller.rb
@@ -3,7 +3,7 @@ require 'uri'
 
 class ClientPrefixesController < ApplicationController
   before_action :set_client_prefix, only: [:show, :update, :destroy]
-  before_action :authenticate_user_from_token!
+  before_action :authenticate_user!
   before_action :set_include
   load_and_authorize_resource :except => [:index, :show]
 

--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -1,6 +1,6 @@
 class ClientsController < ApplicationController
   before_action :set_client, only: [:show, :update, :destroy]
-  before_action :authenticate_user_from_token!
+  before_action :authenticate_user!
   before_action :set_include
   load_and_authorize_resource :except => [:index, :show]
 
@@ -138,8 +138,8 @@ class ClientsController < ApplicationController
   def safe_params
     fail JSON::ParserError, "You need to provide a payload following the JSONAPI spec" unless params[:data].present?
     ActiveModelSerializers::Deserialization.jsonapi_parse!(
-      params, only: [:symbol, :name, "contact-name", "contact-email", :domains, :provider, :repository, "target-id", "is-active", :password, "set-password"],
-              keys: { "contact-name" => :contact_name, "contact-email" => :contact_email, "target-id" => :target_id, "is-active" => :is_active, "set-password" => :set_password }
+      params, only: [:symbol, :name, "contact-name", "contact-email", :domains, :provider, :repository, "target-id", "is-active", "password-input"],
+              keys: { "contact-name" => :contact_name, "contact-email" => :contact_email, "target-id" => :target_id, "is-active" => :is_active, "password-input" => :password_input }
     )
   end
 end

--- a/app/controllers/dois_controller.rb
+++ b/app/controllers/dois_controller.rb
@@ -3,7 +3,7 @@ require 'uri'
 class DoisController < ApplicationController
   before_action :set_doi, only: [:show, :update, :destroy]
   before_action :set_include
-  before_action :authenticate_user_from_token!
+  before_action :authenticate_user!
   authorize_resource :except => [:index, :show]
 
   def index

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,6 +1,6 @@
 class MediaController < ApplicationController
   before_action :set_media, only: [:show, :update, :destroy]
-  before_action :authenticate_user_from_token!
+  before_action :authenticate_user!
   load_and_authorize_resource :except => [:index, :show]
   # GET /media
   def index

--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -1,6 +1,6 @@
 class MetadataController < ApplicationController
   before_action :set_metadata, only: [:show, :update, :destroy]
-  before_action :authenticate_user_from_token!
+  before_action :authenticate_user!
   load_and_authorize_resource :except => [:index, :show]
   # GET /metadata
   def index

--- a/app/controllers/prefixes_controller.rb
+++ b/app/controllers/prefixes_controller.rb
@@ -1,6 +1,6 @@
 class PrefixesController < ApplicationController
   before_action :set_prefix, only: [:show, :update, :destroy]
-  before_action :authenticate_user_from_token!
+  before_action :authenticate_user!
   before_action :set_include
   load_and_authorize_resource :except => [:index, :show]
 

--- a/app/controllers/provider_prefixes_controller.rb
+++ b/app/controllers/provider_prefixes_controller.rb
@@ -1,6 +1,6 @@
 class ProviderPrefixesController < ApplicationController
   before_action :set_provider_prefix, only: [:show, :update, :destroy]
-  before_action :authenticate_user_from_token!
+  before_action :authenticate_user!
   before_action :set_include
   load_and_authorize_resource :except => [:index, :show]
 

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -1,6 +1,6 @@
 class ProvidersController < ApplicationController
   before_action :set_provider, only: [:show, :update, :destroy]
-  before_action :set_include, :authenticate_user_from_token!
+  before_action :set_include, :authenticate_user!
   load_and_authorize_resource :except => [:index, :show]
 
   def index
@@ -138,8 +138,8 @@ class ProvidersController < ApplicationController
   def safe_params
     fail JSON::ParserError, "You need to provide a payload following the JSONAPI spec" unless params[:data].present?
     ActiveModelSerializers::Deserialization.jsonapi_parse!(
-      params, only: [:name, :symbol, "contact-name", "contact-email", :country, "is_active", :password, "set-password"],
-              keys: { country: :country_code, "contact-name" => :contact_name, "contact-email" => :contact_email, "is-active" => :is_active, "set-password" => :set_password }
+      params, only: [:name, :symbol, "contact-name", "contact-email", :country, "is_active", "password-input"],
+              keys: { country: :country_code, "contact-name" => :contact_name, "contact-email" => :contact_email, "is-active" => :is_active, "password-input" => :password_input }
     )
   end
 end

--- a/app/models/concerns/authenticable.rb
+++ b/app/models/concerns/authenticable.rb
@@ -53,6 +53,11 @@ module Authenticable
       return {} unless user && secure_compare(user.password, encrypt_password_sha256(password))
 
       uid = username.downcase
+
+      get_payload(uid: uid, user: user)
+    end
+
+    def get_payload(uid: nil, user: nil)
       roles = {
         "ROLE_ADMIN" => "staff_admin",
         "ROLE_ALLOCATOR" => "provider_admin",

--- a/app/models/concerns/authenticable.rb
+++ b/app/models/concerns/authenticable.rb
@@ -2,16 +2,20 @@ module Authenticable
   extend ActiveSupport::Concern
 
   require 'jwt'
+  require "base64"
 
   included do
-    # encode token using SHA-256 hash algorithm
+    # encode JWT token using SHA-256 hash algorithm
     def encode_token(payload)
       # replace newline characters with actual newlines
       private_key = OpenSSL::PKey::RSA.new(ENV['JWT_PRIVATE_KEY'].to_s.gsub('\n', "\n"))
       JWT.encode(payload, private_key, 'RS256')
+    rescue JSON::GeneratorError => error
+      Rails.logger.error "JSON::GeneratorError: " + error.message + " for " + payload
+      return nil
     end
 
-    # decode token using SHA-256 hash algorithm
+    # decode JWT token using SHA-256 hash algorithm
     def decode_token(token)
       public_key = OpenSSL::PKey::RSA.new(ENV['JWT_PUBLIC_KEY'].to_s.gsub('\n', "\n"))
       payload = (JWT.decode token, public_key, true, { :algorithm => 'RS256' }).first
@@ -28,6 +32,63 @@ module Authenticable
       Rails.logger.error "OpenSSL::PKey::RSAError: " + error.message + " for " + public_key
       return {}
     end
+
+    # basic auth
+    def encode_auth_param(username: nil, password: nil)
+      return nil unless username.present? && password.present?
+
+      ::Base64.strict_encode64("#{username}:#{password}")
+    end
+
+    # basic auth
+    def decode_auth_param(credentials)
+      username, password = ::Base64.decode64(credentials).split(":", 2)
+
+      if username.include?(".")
+        user = Client.where(symbol: username.upcase).first
+      else
+        user = Provider.unscoped.where(symbol: username.upcase).first
+      end
+
+      return {} unless user && secure_compare(user.password, encrypt_password_sha256(password))
+
+      uid = username.downcase
+      roles = {
+        "ROLE_ADMIN" => "staff_admin",
+        "ROLE_ALLOCATOR" => "provider_admin",
+        "ROLE_DATACENTRE" => "client_admin"
+      }
+      payload = {
+        "uid" => uid,
+        "role_id" => roles.fetch(user.role_name, "user"),
+        "name" => user.contact_name,
+        "email" => user.contact_email
+      }
+
+      if uid.include? "."
+        payload.merge!({
+          "provider_id" => uid.split(".", 2).first,
+          "client_id" => uid
+        })
+      elsif uid != "admin"
+        payload.merge!({
+          "provider_id" => uid
+        })
+      end
+
+      payload
+    end
+
+    # constant-time comparison algorithm to prevent timing attacks
+    # from Devise
+    def secure_compare(a, b)
+      return false if a.blank? || b.blank? || a.bytesize != b.bytesize
+      l = a.unpack "C#{a.bytesize}"
+
+      res = 0
+      b.each_byte { |byte| res |= byte ^ l.shift }
+      res == 0
+    end
   end
 
   module ClassMethods
@@ -38,7 +99,7 @@ module Authenticable
       JWT.encode(payload, private_key, 'RS256')
     rescue OpenSSL::PKey::RSAError => e
       Rails.logger.error e.inspect
-      
+
       nil
     end
 

--- a/app/models/concerns/passwordable.rb
+++ b/app/models/concerns/passwordable.rb
@@ -5,10 +5,14 @@ module Passwordable
 
   included do
     # "yes", "not set" (used in serializer) and a blank value are not allowed for new password
-    def encrypt_password(password)
+    def encrypt_password_sha256(password)
       return nil unless ENV["SESSION_ENCRYPTED_COOKIE_SALT"].present? && password.present? && !["yes", "not set"].include?(password)
 
       Digest::SHA256.hexdigest password + "{#{ENV["SESSION_ENCRYPTED_COOKIE_SALT"]}}"
+    end
+
+    def authenticate_sha256(unencrypted_password)
+      password == encrypt_password_sha256(unencrypted_password) && self
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,13 +2,20 @@ class User
   # include jwt encode and decode
   include Authenticable
 
+  # include helper module for setting password
+  include Passwordable
+
   attr_accessor :name, :uid, :email, :role_id, :jwt, :orcid, :provider_id, :client_id, :beta_tester, :allocator, :datacentre
 
-  def initialize(token)
-    if token.present?
-      payload = decode_token(token)
+  def initialize(credentials, options={})
+    if credentials.present? && options.fetch(:type, "").downcase == "basic"
+      payload = decode_auth_param(credentials)
+    elsif credentials.present?
+      payload = decode_token(credentials)
+      @jwt = credentials
+    end
 
-      @jwt = token
+    if payload.present?
       @uid = payload.fetch("uid", nil)
       @name = payload.fetch("name", nil)
       @email = payload.fetch("email", nil)

--- a/spec/concerns/authenticable_spec.rb
+++ b/spec/concerns/authenticable_spec.rb
@@ -1,5 +1,76 @@
-# require 'rails_helper'
-#
-# describe User do
-#
-# end
+require 'rails_helper'
+
+describe User, type: :model do
+  let(:token) { User.generate_token }
+  subject { User.new(token) }
+
+  describe 'decode_token' do
+    it "has name" do
+      payload = subject.decode_token(token)
+      expect(payload["name"]).to eq("Josiah Carberry")
+    end
+
+    it "empty token" do
+      payload = subject.decode_token("")
+      expect(payload).to be_empty
+    end
+
+    it "invalid token" do
+      payload = subject.decode_token("abc")
+      expect(payload).to be_empty
+    end
+  end
+
+  describe 'encode_token' do
+    it "with name" do
+      token = subject.encode_token("name" => "Josiah Carberry")
+      expect(token).to start_with("eyJhbG")
+    end
+
+    it "empty string" do
+      token = subject.encode_token("")
+      expect(token).to be_nil
+    end
+  end
+end
+
+describe Provider, type: :model do
+  subject { create(:provider, password_input: "12345") }
+
+  describe 'encode_auth_param' do
+    it "works" do
+      credentials = subject.encode_auth_param(username: subject.symbol, password: 12345)
+      expect(credentials).to start_with("VEVTVD")
+    end
+
+    it "no password" do
+      subject = create(:provider)
+      credentials = subject.encode_auth_param(username: subject.symbol)
+      expect(credentials).to be_nil
+    end
+  end
+
+  describe 'decode_auth_param' do
+    it "provider" do
+      credentials = subject.encode_auth_param(username: subject.symbol, password: "12345")
+      expect(subject.decode_auth_param(credentials)).to eq("uid"=>subject.symbol.downcase, "name"=>subject.contact_name, "email"=>subject.contact_email, "role_id"=>"provider_admin", "provider_id"=>subject.symbol.downcase)
+    end
+
+    it "admin" do
+      subject = create(:provider, symbol: "ADMIN", role_name: "ROLE_ADMIN", password_input: "12345")
+      credentials = subject.encode_auth_param(username: subject.symbol, password: "12345")
+      expect(subject.decode_auth_param(credentials)).to eq("uid"=>subject.symbol.downcase, "name"=>subject.contact_name, "email"=>subject.contact_email, "role_id"=>"staff_admin")
+    end
+  end
+end
+
+describe Client, type: :model do
+  subject { create(:client, password_input: "12345") }
+
+  describe 'decode_auth_param' do
+    it "works" do
+      credentials = subject.encode_auth_param(username: subject.symbol, password: 12345)
+      expect(subject.decode_auth_param(credentials)).to eq("uid"=>subject.symbol.downcase, "name"=>subject.contact_name, "email"=>subject.contact_email, "role_id"=>"client_admin", "provider_id"=>subject.symbol.downcase.split(".").first, "client_id"=>subject.symbol.downcase)
+    end
+  end
+end

--- a/spec/concerns/passwordable_spec.rb
+++ b/spec/concerns/passwordable_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe Provider, type: :model do
+describe Provider, type: :model do
   subject { create(:provider) }
 
-  describe "encrypt_password" do
+  describe "encrypt_password_sha256" do
     it "should encrypt the password" do
       password = "Credible=Hangover8tighten"
-      encrypted_password = subject.encrypt_password(password)
+      encrypted_password = subject.encrypt_password_sha256(password)
       expect(encrypted_password).to be_present
       expect(subject.password).not_to eq(password)
     end

--- a/spec/factories/default.rb
+++ b/spec/factories/default.rb
@@ -9,6 +9,8 @@ FactoryBot.define do
     sequence(:symbol) { |n| provider.symbol + ".TEST#{n}" }
     name "My data center"
     role_name "ROLE_DATACENTRE"
+    password_input "12345"
+    is_active true
 
     initialize_with { Client.where(symbol: symbol).first_or_initialize }
   end
@@ -65,6 +67,8 @@ FactoryBot.define do
     sequence(:symbol) { |n| "TEST#{n}" }
     name "My provider"
     country_code "DE"
+    password_input "12345"
+    is_active true
 
     initialize_with { Provider.where(symbol: symbol).first_or_initialize }
   end

--- a/spec/fixtures/vcr_cassettes/Clients/PUT_/clients/_id/using_basic_auth/returns_status_code_200.yml
+++ b/spec/fixtures/vcr_cassettes/Clients/PUT_/clients/_id/using_basic_auth/returns_status_code_200.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://profiles.test.datacite.org/api/flipper/features/delete_doi
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Flipper HTTP Adapter v0.11.0
+      Authorization:
+      - Bearer <VOLPINO_TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 13 Jan 2018 12:40:47 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - AWSALB=wkFikpkIWX2V58JrN5QpzyFw/8HGEMrHrIQ72l9jIg2WxdQQvlpcIdGkHParh0wSp5Jwkbk54kqHlW9U38OwnOzkkBlCMMBaClYseXvqN6JsOb6dybZYM5RJGkGc;
+        Expires=Sat, 20 Jan 2018 12:40:47 GMT; Path=/
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      X-Request-Id:
+      - 62d0838d-e315-47be-ad12-77f5402553a2
+      Etag:
+      - W/"1a819802b061706cd3cdd8e2847d7e04"
+      X-Runtime:
+      - '0.002837'
+      X-Powered-By:
+      - Phusion Passenger 5.1.12
+      Server:
+      - nginx/1.12.2 + Phusion Passenger 5.1.12
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,Authorization
+      Access-Control-Expose-Headers:
+      - DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,Authorization
+    body:
+      encoding: UTF-8
+      string: '{"key":"delete_doi","state":"conditional","gates":[{"key":"boolean","name":"boolean","value":null},{"key":"groups","name":"group","value":["staff"]},{"key":"actors","name":"actor","value":[]},{"key":"percentage_of_actors","name":"percentage_of_actors","value":null},{"key":"percentage_of_time","name":"percentage_of_time","value":null}]}'
+    http_version: 
+  recorded_at: Sat, 13 Jan 2018 12:41:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Clients/PUT_/clients/_id/using_basic_auth/updates_the_record.yml
+++ b/spec/fixtures/vcr_cassettes/Clients/PUT_/clients/_id/using_basic_auth/updates_the_record.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://profiles.test.datacite.org/api/flipper/features/delete_doi
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Flipper HTTP Adapter v0.11.0
+      Authorization:
+      - Bearer <VOLPINO_TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 13 Jan 2018 12:40:46 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - AWSALB=cuN53QYnjgGZClPBw92WLyOXMGPu9NK8XVQvZc8KkNlj2eaJFYXceoCExEd3IzBJzhQiTYdNowqPHf9UA/JsmUBVGN9o7jyuwU2ZQkcvZPNlVDLWI03xFbf+CLVr;
+        Expires=Sat, 20 Jan 2018 12:40:46 GMT; Path=/
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      X-Request-Id:
+      - 1e6d82b3-33c0-40a2-a873-be1c284329ad
+      Etag:
+      - W/"1a819802b061706cd3cdd8e2847d7e04"
+      X-Runtime:
+      - '0.063650'
+      X-Powered-By:
+      - Phusion Passenger 5.1.12
+      Server:
+      - nginx/1.12.2 + Phusion Passenger 5.1.12
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,Authorization
+      Access-Control-Expose-Headers:
+      - DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,Authorization
+    body:
+      encoding: UTF-8
+      string: '{"key":"delete_doi","state":"conditional","gates":[{"key":"boolean","name":"boolean","value":null},{"key":"groups","name":"group","value":["staff"]},{"key":"actors","name":"actor","value":[]},{"key":"percentage_of_actors","name":"percentage_of_actors","value":null},{"key":"percentage_of_time","name":"percentage_of_time","value":null}]}'
+    http_version: 
+  recorded_at: Sat, 13 Jan 2018 12:41:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Client, type: :model do
+describe Client, type: :model do
   let(:provider)  { create(:provider) }
   let(:client)  { create(:client, provider: provider) }
   let(:target) { create(:client, provider: provider, symbol: provider.symbol + ".TARGET") }
@@ -19,7 +19,7 @@ RSpec.describe Client, type: :model do
       expect(client.reload.symbol).to eq(client.symbol)
     end
 
-    it "transfer all DOIS" do
+    it "transfer all DOIs" do
       original_dois = Doi.where(client: client.symbol)
       expect(Doi.where(datacentre: client.id).count).to eq(5)
       expect(Doi.where(datacentre: target.id).count).to eq(0)

--- a/spec/models/media_spec.rb
+++ b/spec/models/media_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Media, type: :model do
+describe Media, type: :model do
   it { should validate_presence_of(:url) }
   it { should validate_presence_of(:media_type) }
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -1,9 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Provider, type: :model do
-  # let!(:providers_factory)  { create_list(:provider, 25) }
-  # let!(:provider) { providers_factory.first }
-
+describe Provider, type: :model do
   describe "validations" do
     it { should validate_presence_of(:symbol) }
     it { should validate_presence_of(:name) }
@@ -11,102 +8,26 @@ RSpec.describe Provider, type: :model do
     it { should validate_presence_of(:contact_name) }
   end
 
-  describe "methods" do
+  describe "admin" do
+    subject { create(:provider, role_name: "ROLE_ADMIN", name: "Admin", symbol: "ADMIN") }
 
-    # it "providers all" do
-    #   collection = Provider.all
-    #   expect(collection.length).to eq(providers_factory.length)
-    #   single = collection.first
-    #   expect(single.name).to eq(provider.name)
-    #   expect(single.role_name).to eq(provider.role_name)
-    #   # meta = providers[:meta]
-    #   # expect(meta["resource-types"]).not_to be_empty
-    #   # expect(meta["years"]).not_to be_empty
-    #   # expect(meta).not_to be_empty
-    # end
-    #
-    # it "providers with where year" do
-    #   collection = Provider.where("YEAR(allocator.created) = ?", provider.created)
-    #   single = collection.first
-    #   expect(single.year).to eq(provider.created.year)
-    #   expect(single.name).to eq(provider.name)
-    #   expect(single.symbol).to eq(provider.symbol)
-    # end
-    #
-    # it "should not update the symbol" do
-    #   provider.update_attributes :symbol => provider.symbol + 'foo.bar'
-    #   expect(provider.reload.symbol).to eq(provider.symbol)
-    # end
-
-    # it "providers with where sort by role_name" do
-    #   collection = Provider.where(name: "australia", sort: "role_name")
-    #   expect(collection.length).to eq(1)
-    #   provider = collection.first
-    #   expect(provider.name).to eq("Australian National Data Service")
-    #   expect(provider.symbol).to eq("ands")
-    # end
-    #
-    # it "providers with where and resource-type-id" do
-    #   collection = Provider.where(where: "cancer", "resource-type-id" => "dataset")
-    #   expect(collection[:data].length).to eq(3)
-    #   provider = collection[:data].first
-    #   expect(provider.title).to eq("Landings of European lobster (Homarus gammarus) and edible crab (Cancer pagurus) in 2011, Helgoland, North Sea")
-    #   expect(provider.resource_type.title).to eq("Dataset")
-    # end
-    #
-    # it "providers with where and resource-type-id and data-center-id" do
-    #   collection = Provider.where(where: "cancer", "resource-type-id" => "dataset", "data-center-id" => "FIGSHARE.ARS")
-    #   expect(collection[:data].length).to eq(25)
-    #   provider = collection[:data].first
-    #   expect(provider.title).to eq("Achilles_v3.3.7_README.txt")
-    #   expect(provider.resource_type.title).to eq("Dataset")
-    # end
-
-    # it "provider" do
-    #   single = Provider.where(symbol: provider.symbol).first
-    #   expect(single.name).to eq(provider.name)
-    #   expect(single.symbol).to eq(provider.symbol)
-    #   expect(single.role_name).to eq(provider.role_name)
-    #   expect(single.created).to be_truthy
-    #   expect(single.updated).to be_truthy
-    #   expect(single.region).to be_truthy
-    #   expect(single.is_active).to be_truthy
-    #   expect(single.doi_quota_allowed).to be_truthy
-    #   expect(single.doi_quota_used).to be_truthy
-    # end
+    it "works" do
+      expect(subject.role_name).to eq("ROLE_ADMIN")
+    end
   end
 
-  # describe "password" do
-  #   it "should not update the password" do
-  #     password = "Credible=Hangover8tighten"
-  #     subject = create(:provider, set_password: false, password: password)
-  #     expect(subject.password).to be_nil
-  #   end
-  #
-  #   it "should update the password when set_password is true" do
-  #     password = "Credible=Hangover8tighten"
-  #     subject = create(:provider, set_password: true, password: password)
-  #     expect(subject.password).to be_present
-  #     expect(subject.password).not_to eq(password)
-  #   end
-  #
-  #   it "should not update the password when password is blank" do
-  #     password = ""
-  #     subject = create(:provider, set_password: true, password: password)
-  #     expect(subject.reload.password).to be_nil
-  #   end
-  #
-  #   # API shows password as either "yes" or "not set"
-  #   it "should not update the password when password is blank" do
-  #     password = "yes"
-  #     subject = create(:provider, set_password: true, password: password)
-  #     expect(subject.password).to be_nil
-  #   end
-  #
-  #   it "should not update the password when password is blank" do
-  #     password = "not set"
-  #     subject = create(:provider, set_password: true, password: password)
-  #     expect(subject.password).to be_nil
-  #   end
-  # end
+  describe "password" do
+    let(:password_input) { "Credible=Hangover8tighten" }
+    subject { create(:provider, password_input: password_input) }
+
+    it "should use password_input" do
+      expect(subject.password).to eq(subject.encrypt_password_sha256(password_input))
+    end
+
+    it "should not use password_input when it is blank" do
+      password_input = ""
+      subject = create(:provider, password_input: password_input)
+      expect(subject.password).to be_nil
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,12 +1,82 @@
 require 'rails_helper'
 
 describe User, type: :model do
-  let(:token) { User.generate_token }
-  let(:user) { User.new(token) }
+  describe "from token" do
+    let(:token) { User.generate_token }
+    let(:user) { User.new(token) }
 
-  describe 'User attributes', :order => :defined do
-    it "ha name" do
-      expect(user.name).to eq("Josiah Carberry")
+    describe 'User attributes' do
+      it "has role_id" do
+        expect(user.role_id).to eq("staff_admin")
+      end
+
+      it "has name" do
+        expect(user.name).to eq("Josiah Carberry")
+      end
+    end
+  end
+
+  describe "from basic_auth admin" do
+    let(:provider) { create(:provider, role_name: "ROLE_ADMIN", symbol: "ADMIN", password_input: "12345") }
+    let(:credentials) { provider.encode_auth_param(username: provider.symbol, password: 12345) }
+    let(:user) { User.new(credentials, type: "basic") }
+
+    describe 'User attributes' do
+      it "has role_id" do
+        expect(user.role_id).to eq("staff_admin")
+      end
+
+      it "has no provider_id" do
+        expect(user.provider_id).to be_nil
+      end
+
+      it "has name" do
+        expect(user.name).to eq("Josiah Carberry")
+      end
+    end
+  end
+
+  describe "from basic_auth provider" do
+    let(:provider) { create(:provider, password_input: "12345") }
+    let(:credentials) { provider.encode_auth_param(username: provider.symbol, password: 12345) }
+    let(:user) { User.new(credentials, type: "basic") }
+
+    describe 'User attributes' do
+      it "has role_id" do
+        expect(user.role_id).to eq("provider_admin")
+      end
+
+      it "has provider_id" do
+        expect(user.provider_id).to eq(provider.symbol.downcase)
+      end
+
+      it "has name" do
+        expect(user.name).to eq("Josiah Carberry")
+      end
+    end
+  end
+
+  describe "from basic_auth client" do
+    let(:client) { create(:client, password_input: "12345") }
+    let(:credentials) { client.encode_auth_param(username: client.symbol, password: 12345) }
+    let(:user) { User.new(credentials, type: "basic") }
+
+    describe 'User attributes' do
+      it "has role_id" do
+        expect(user.role_id).to eq("client_admin")
+      end
+
+      it "has provider_id" do
+        expect(user.provider_id).to eq(client.symbol.downcase.split(".").first)
+      end
+
+      it "has client_id" do
+        expect(user.client_id).to eq(client.symbol.downcase)
+      end
+
+      it "has name" do
+        expect(user.name).to eq("Josiah Carberry")
+      end
     end
   end
 end

--- a/spec/requests/dois_spec.rb
+++ b/spec/requests/dois_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "dois", type: :request do
+describe "dois", type: :request do
   let(:provider)  { create(:provider, symbol: "ADMIN") }
   let(:client)  { create(:client, provider: provider) }
   let!(:dois) { create_list(:doi, 10, client: client) }

--- a/spec/requests/prefixes_spec.rb
+++ b/spec/requests/prefixes_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Prefixes", type: :request   do
+describe "Prefixes", type: :request   do
   # initialize test data
   let!(:prefixes)  { create_list(:prefix, 10) }
   let(:bearer) { User.generate_token }

--- a/spec/requests/provider_prefixes_spec.rb
+++ b/spec/requests/provider_prefixes_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Provider Prefixes", type: :request   do
+describe "Provider Prefixes", type: :request   do
   let!(:provider_prefixes)  { create_list(:provider_prefix, 5) }
   let(:provider_prefix) { create(:provider_prefix) }
   let(:bearer) { User.generate_token(role_id: "staff_admin") }

--- a/spec/routing/clients_routing_spec.rb
+++ b/spec/routing/clients_routing_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ClientsController, type: :routing do
+describe ClientsController, type: :routing do
   describe "routing" do
 
     it "routes to #index" do

--- a/spec/routing/dois_routing_spec.rb
+++ b/spec/routing/dois_routing_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe DoisController, type: :routing do
+describe DoisController, type: :routing do
   describe "routing" do
 
     it "routes to #index" do

--- a/spec/routing/media_routing_spec.rb
+++ b/spec/routing/media_routing_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe MediaController, type: :routing do
+describe MediaController, type: :routing do
   describe "routing" do
 
     it "routes to #index" do

--- a/spec/routing/prefixes_routing_spec.rb
+++ b/spec/routing/prefixes_routing_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe PrefixesController, type: :routing do
+describe PrefixesController, type: :routing do
   describe "routing" do
 
     it "routes to #index" do

--- a/spec/routing/providers_routing_spec.rb
+++ b/spec/routing/providers_routing_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ProvidersController, type: :routing do
+describe ProvidersController, type: :routing do
   describe "routing" do
 
     it "routes to #index" do


### PR DESCRIPTION
This enables the same authentication, and using the same username and password with associated permissions as in the MDS and EZID-compatible APIs.