### PR TITLE
added prefixes for filtering

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -127,6 +127,7 @@ class Client < ActiveRecord::Base
       params["data"]["attributes"]["updated"]= params["data"]["attributes"]["updated"].to_s
       params["data"]["attributes"]["created"]= params["data"]["attributes"]["created"].to_s
       params["data"]["attributes"]["provider-id"]= client.provider_id if client.provider_id.present?
+      params["data"]["attributes"]["prefixes"]= self.find_by(symbol: client.symbol).prefixes.map {|p| p.prefix }.join(', ')
       ElasticsearchJob.perform_later(params, "index")
     end
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -127,6 +127,7 @@ class Provider < ActiveRecord::Base
       params = { "data" => { "type" => "providers", "attributes" => provider.attributes } }
       params["data"]["attributes"]["updated"]= params["data"]["attributes"]["updated"].to_s
       params["data"]["attributes"]["created"]= params["data"]["attributes"]["created"].to_s
+      params["data"]["attributes"]["prefixes"]= Provider.find_by(symbol: provider.symbol).prefixes.map {|p| p.prefix }.join(', ')
       ElasticsearchJob.perform_later(params, "index")
     end
   end


### PR DESCRIPTION
I thought there might be 3 ways to add prefixes relationship at this moment.

1. Include them in the rake task
2. Make calls to app.datacite.org for prefixes relationships
3. implement the prefixes model

I leaned for (1) as we can move to the number (3) later with little effort involved.
