### PR TITLE
register DOI in the handle system

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -75,7 +75,7 @@ class ApplicationController < ActionController::API
       if status == 404
         message = "The resource you are looking for doesn't exist."
       elsif status == 401
-        message = "You are not authorized to access this page."
+        message = "You are not authorized to access this resource."
       else
         message = exception.message
       end

--- a/app/controllers/random_controller.rb
+++ b/app/controllers/random_controller.rb
@@ -4,7 +4,6 @@ class RandomController < ApplicationController
 
   def index
     phrase = Phrase.new
-    response.headers['X-Consumer-Role'] = current_user && current_user.role_id || 'anonymous'
 
     render json: { phrase: phrase.string }.to_json
   end

--- a/app/jobs/handle_job.rb
+++ b/app/jobs/handle_job.rb
@@ -1,0 +1,8 @@
+class HandleJob < ActiveJob::Base
+  queue_as :lupo
+
+  def perform(doi, options={})
+    Rails.logger.debug "Update handle record for #{doi.doi}"
+    doi.send(:set_url)
+  end
+end

--- a/app/jobs/handle_job.rb
+++ b/app/jobs/handle_job.rb
@@ -2,7 +2,6 @@ class HandleJob < ActiveJob::Base
   queue_as :lupo
 
   def perform(doi, options={})
-    Rails.logger.debug "Update handle record for #{doi.doi}"
-    doi.send(:set_url)
+    doi.register_url(options)
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -43,7 +43,7 @@ class Ability
       # else
       #   can [:read, :update], Doi, :client_id => user.client_id
       # end
-      can [:manage], Doi, :client_id => user.client_id
+      can [:manage, :register_url], Doi, :client_id => user.client_id
 
       can [:read], User
       can [:read], Phrase

--- a/app/models/concerns/authenticable.rb
+++ b/app/models/concerns/authenticable.rb
@@ -54,10 +54,10 @@ module Authenticable
 
       uid = username.downcase
 
-      get_payload(uid: uid, user: user)
+      get_payload(uid: uid, user: user, password: password.to_s)
     end
 
-    def get_payload(uid: nil, user: nil)
+    def get_payload(uid: nil, user: nil, password: nil)
       roles = {
         "ROLE_ADMIN" => "staff_admin",
         "ROLE_ALLOCATOR" => "provider_admin",
@@ -70,10 +70,12 @@ module Authenticable
         "email" => user.contact_email
       }
 
+      # we only need password for clients registering DOIs in the handle system
       if uid.include? "."
         payload.merge!({
           "provider_id" => uid.split(".", 2).first,
-          "client_id" => uid
+          "client_id" => uid,
+          "password" => password
         })
       elsif uid != "admin"
         payload.merge!({
@@ -131,7 +133,7 @@ module Authenticable
       encode_token(payload)
     end
 
-    def get_payload(uid: nil, user: nil)
+    def get_payload(uid: nil, user: nil, password: nil)
       roles = {
         "ROLE_ADMIN" => "staff_admin",
         "ROLE_ALLOCATOR" => "provider_admin",
@@ -144,10 +146,12 @@ module Authenticable
         "email" => user.contact_email
       }
 
+      # we only need password for clients registering DOIs in the handle system
       if uid.include? "."
         payload.merge!({
           "provider_id" => uid.split(".", 2).first,
-          "client_id" => uid
+          "client_id" => uid,
+          "password" => password
         })
       elsif uid != "admin"
         payload.merge!({

--- a/app/models/concerns/helpable.rb
+++ b/app/models/concerns/helpable.rb
@@ -7,6 +7,27 @@ module Helpable
   included do
     include Bolognese::DoiUtils
     include Cirneco::Utils
+    include Cirneco::Api
+
+    attr_accessor :username, :password
+
+    def register_url
+      return OpenStruct.new(body: { "errors" => [{ "title" => "Username or password missing" }] }) unless username.present? && password.present?
+
+      response = put_doi(doi, url: url,
+                         username: username,
+                         password: password,
+                         sandbox: !Rails.env.production?)
+
+      if response.status == 201
+        Rails.logger.info "[Handle] Updated to URL " + url + " for DOI " + doi + "."
+        response
+      else
+        Rails.logger.info "[Handle] Error updating URL " + url + " for DOI " + doi + "."
+        Rails.logger.info response.body["errors"].inspect
+        response
+      end
+    end
 
     def generate_random_doi(str, options={})
       prefix = validate_prefix(str)

--- a/app/models/concerns/helpable.rb
+++ b/app/models/concerns/helpable.rb
@@ -11,13 +11,13 @@ module Helpable
 
     attr_accessor :username, :password
 
-    def register_url
-      return OpenStruct.new(body: { "errors" => [{ "title" => "Username or password missing" }] }) unless username.present? && password.present?
+    def register_url(options={})
+      return OpenStruct.new(body: { "errors" => [{ "title" => "Username or password missing" }] }) unless options[:username].present? && options[:password].present?
 
-      response = put_doi(doi, url: url,
-                         username: username,
-                         password: password,
-                         sandbox: !Rails.env.production?)
+      response = put_doi(doi, url: options[:url],
+                              username: options[:username],
+                              password: options[:password],
+                              sandbox: !Rails.env.production?)
 
       if response.status == 201
         Rails.logger.info "[Handle] Updated to URL " + url + " for DOI " + doi + "."

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -70,16 +70,14 @@ class Doi < ActiveRecord::Base
   # update cached doi count for client
   before_destroy :update_doi_count
   after_create :update_doi_count
-  after_update :update_doi_count, if: :datacentre_changed?
+  after_update :update_doi_count, if: :saved_change_to_datacentre?
+
+  # update url in handle system
+  after_save :update_url, if: :saved_change_to_url?
 
   before_save :set_defaults
   before_create { self.created = Time.zone.now.utc.iso8601 }
   before_save { self.updated = Time.zone.now.utc.iso8601 }
-  # after_save do
-  #   unless Rails.env.test?
-  #     UrlJob.perform_later(self)
-  #   end
-  # end
 
   scope :query, ->(query) { where("dataset.doi = ?", query) }
 
@@ -121,6 +119,13 @@ class Doi < ActiveRecord::Base
     return nil unless resource_type_general.present?
     r = ResourceType.where(id: resource_type_general.downcase.underscore.dasherize)
     r[:data] if r.present?
+  end
+
+  # update URL in handle system, don't do that for draft state
+  def update_url
+    return nil if draft? || Rails.env.test?
+
+    register_url
   end
 
   # attributes to be sent to elasticsearch index

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -125,7 +125,10 @@ class Doi < ActiveRecord::Base
   def update_url
     return nil if draft? || Rails.env.test?
 
-    register_url
+    HandleJob.perform_later(doi, url: url,
+                       username: username,
+                       password: password,
+                       sandbox: !Rails.env.production?)
   end
 
   # attributes to be sent to elasticsearch index

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User
   # include helper module for setting emails via Mailgun API
   include Mailable
 
-  attr_accessor :name, :uid, :email, :role_id, :jwt, :provider_id, :client_id, :beta_tester
+  attr_accessor :name, :uid, :email, :role_id, :jwt, :password, :provider_id, :client_id, :beta_tester
 
   def initialize(credentials, options={})
     if credentials.present? && options.fetch(:type, "").downcase == "basic"
@@ -24,6 +24,7 @@ class User
       @uid = payload.fetch("uid", nil)
       @name = payload.fetch("name", nil)
       @email = payload.fetch("email", nil)
+      @password = payload.fetch("password", nil)
       @role_id = payload.fetch("role_id", nil)
       @provider_id = payload.fetch("provider_id", nil)
       @client_id = payload.fetch("client_id", nil)

--- a/spec/concerns/authenticable_spec.rb
+++ b/spec/concerns/authenticable_spec.rb
@@ -67,7 +67,7 @@ describe Client, type: :model do
 
   describe 'decode_auth_param' do
     it "works" do
-      expect(subject.decode_auth_param(username: subject.symbol, password: 12345)).to eq("uid"=>subject.symbol.downcase, "name"=>subject.name, "email"=>subject.contact_email, "role_id"=>"client_admin", "provider_id"=>subject.symbol.downcase.split(".").first, "client_id"=>subject.symbol.downcase)
+      expect(subject.decode_auth_param(username: subject.symbol, password: 12345)).to eq("uid"=>subject.symbol.downcase, "name"=>subject.name, "email"=>subject.contact_email, "password" => "12345", "role_id"=>"client_admin", "provider_id"=>subject.symbol.downcase.split(".").first, "client_id"=>subject.symbol.downcase)
     end
   end
 end

--- a/spec/concerns/helpable_spec.rb
+++ b/spec/concerns/helpable_spec.rb
@@ -60,4 +60,24 @@ describe Doi, vcr: true do
       expect { subject.generate_random_doi(str) }.to raise_error(IdentifierError, "No valid prefix found")
     end
   end
+
+  context "register_doi" do
+    let(:client) { create(:client) }
+
+    subject { build(:doi, doi: "10.5438/mcnv-ga6n", url: "https://blog.datacite.org/re3data-science-europe/", client: client, username: ENV['MDS_USERNAME'], password: ENV['MDS_PASSWORD']) }
+
+    it 'should register' do
+      expect(subject.register_url.body).to eq("data"=>"OK")
+    end
+
+    it 'missing username and password' do
+      subject = build(:doi, doi: "10.5438/mcnv-ga6n", url: "https://blog.datacite.org/re3data-science-europe/", client: client)
+      expect(subject.register_url.body).to eq("errors"=>[{"title"=>"Username or password missing"}])
+    end
+
+    it 'wrong username and password' do
+      subject = build(:doi, doi: "10.5438/mcnv-ga6n", url: "https://blog.datacite.org/re3data-science-europe/", client: client, username: ENV['MDS_USERNAME'], password: 12345)
+      expect(subject.register_url.body).to eq("errors"=>[{"status"=>401, "title"=>"Unauthorized"}])
+    end
+  end
 end

--- a/spec/concerns/helpable_spec.rb
+++ b/spec/concerns/helpable_spec.rb
@@ -64,20 +64,21 @@ describe Doi, vcr: true do
   context "register_doi" do
     let(:client) { create(:client) }
 
-    subject { build(:doi, doi: "10.5438/mcnv-ga6n", url: "https://blog.datacite.org/re3data-science-europe/", client: client, username: ENV['MDS_USERNAME'], password: ENV['MDS_PASSWORD']) }
+    subject { build(:doi, doi: "10.5438/mcnv-ga6n", client: client) }
 
     it 'should register' do
-      expect(subject.register_url.body).to eq("data"=>"OK")
+      options = { url: "https://blog.datacite.org/re3data-science-europe/", username: ENV['MDS_USERNAME'], password: ENV['MDS_PASSWORD'] }
+      expect(subject.register_url(options).body).to eq("data"=>"OK")
     end
 
     it 'missing username and password' do
-      subject = build(:doi, doi: "10.5438/mcnv-ga6n", url: "https://blog.datacite.org/re3data-science-europe/", client: client)
-      expect(subject.register_url.body).to eq("errors"=>[{"title"=>"Username or password missing"}])
+      options = { url: "https://blog.datacite.org/re3data-science-europe/" }
+      expect(subject.register_url(options).body).to eq("errors"=>[{"title"=>"Username or password missing"}])
     end
 
     it 'wrong username and password' do
-      subject = build(:doi, doi: "10.5438/mcnv-ga6n", url: "https://blog.datacite.org/re3data-science-europe/", client: client, username: ENV['MDS_USERNAME'], password: 12345)
-      expect(subject.register_url.body).to eq("errors"=>[{"status"=>401, "title"=>"Unauthorized"}])
+      options = { url: "https://blog.datacite.org/re3data-science-europe/", username: ENV['MDS_USERNAME'], password: 12345 }
+      expect(subject.register_url(options).body).to eq("errors"=>[{"status"=>401, "title"=>"Unauthorized"}])
     end
   end
 end

--- a/spec/fixtures/vcr_cassettes/Doi/register_doi/should_register.yml
+++ b/spec/fixtures/vcr_cassettes/Doi/register_doi/should_register.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://mds.test.datacite.org/doi/10.5438/MCNV-GA6N
+    body:
+      encoding: UTF-8
+      string: |-
+        doi=10.5438/MCNV-GA6N
+        url=https://blog.datacite.org/re3data-science-europe/
+    headers:
+      User-Agent:
+      - Maremma - http://f0fe072f8321
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Authorization:
+      - Basic <MDS_TOKEN>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 28 Feb 2018 12:17:51 GMT
+      Content-Type:
+      - text/html;charset=UTF-8
+      Content-Length:
+      - '2'
+      Connection:
+      - keep-alive
+      Server:
+      - Apache-Coyote/1.1
+      Pragma:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Cache-Control:
+      - no-cache, no-store
+    body:
+      encoding: UTF-8
+      string: OK
+    http_version: 
+  recorded_at: Wed, 28 Feb 2018 12:18:04 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Doi/register_doi/should_register.yml
+++ b/spec/fixtures/vcr_cassettes/Doi/register_doi/should_register.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 28 Feb 2018 12:17:51 GMT
+      - Wed, 28 Feb 2018 13:46:53 GMT
       Content-Type:
       - text/html;charset=UTF-8
       Content-Length:
@@ -42,5 +42,5 @@ http_interactions:
       encoding: UTF-8
       string: OK
     http_version: 
-  recorded_at: Wed, 28 Feb 2018 12:18:04 GMT
+  recorded_at: Wed, 28 Feb 2018 13:47:12 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Doi/register_doi/wrong_username_and_password.yml
+++ b/spec/fixtures/vcr_cassettes/Doi/register_doi/wrong_username_and_password.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: Unauthorized
     headers:
       Date:
-      - Wed, 28 Feb 2018 12:50:03 GMT
+      - Wed, 28 Feb 2018 13:46:53 GMT
       Content-Length:
       - '15'
       Connection:
@@ -36,5 +36,5 @@ http_interactions:
       encoding: UTF-8
       string: Bad credentials
     http_version: 
-  recorded_at: Wed, 28 Feb 2018 12:50:18 GMT
+  recorded_at: Wed, 28 Feb 2018 13:47:13 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Doi/register_doi/wrong_username_and_password.yml
+++ b/spec/fixtures/vcr_cassettes/Doi/register_doi/wrong_username_and_password.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://mds.test.datacite.org/doi/10.5438/MCNV-GA6N
+    body:
+      encoding: UTF-8
+      string: |-
+        doi=10.5438/MCNV-GA6N
+        url=https://blog.datacite.org/re3data-science-europe/
+    headers:
+      User-Agent:
+      - Maremma - http://f0fe072f8321
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Authorization:
+      - Basic REFUQUNJVEUuREFUQUNJVEU6MTIzNDU=
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Wed, 28 Feb 2018 12:50:03 GMT
+      Content-Length:
+      - '15'
+      Connection:
+      - keep-alive
+      Server:
+      - Apache-Coyote/1.1
+      Www-Authenticate:
+      - Basic realm="mds.datacite.org"
+    body:
+      encoding: UTF-8
+      string: Bad credentials
+    http_version: 
+  recorded_at: Wed, 28 Feb 2018 12:50:18 GMT
+recorded_with: VCR 3.0.3

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,6 +48,7 @@ RSpec.configure do |config|
 end
 
 VCR.configure do |c|
+  mds_token = Base64.strict_encode64("#{ENV['MDS_USERNAME']}:#{ENV['MDS_PASSWORD']}")
   mailgun_token = Base64.strict_encode64("api:#{ENV['MAILGUN_API_KEY']}")
   sqs_host = "sqs.#{ENV['AWS_REGION'].to_s}.amazonaws.com"
 
@@ -55,6 +56,7 @@ VCR.configure do |c|
   c.hook_into :webmock
   c.ignore_localhost = true
   c.ignore_hosts "codeclimate.com", "api.mailgun.net", sqs_host
+  c.filter_sensitive_data("<MDS_TOKEN>") { mds_token }
   c.filter_sensitive_data("<MAILGUN_TOKEN>") { mailgun_token }
   c.filter_sensitive_data("<VOLPINO_TOKEN>") { ENV["VOLPINO_TOKEN"] }
   c.configure_rspec_metadata!


### PR DESCRIPTION
This pull request adds DOI registration in the handle system. It does so by calling the MDS API. This is the only MDS API functionality used by the Lupo API, and can over time be replaced by a direct call to the Handle REST API.

One requirement is basic authentication, and only clients (not providers and admins) have permissions. This is implemented by storing the password in the jwt for clients. Not ideal, but probably the best workaround for enabling DOI Fabrica integration.