### PR TITLE
check doi links

### DIFF
--- a/app/controllers/dois_controller.rb
+++ b/app/controllers/dois_controller.rb
@@ -2,7 +2,7 @@ require 'uri'
 
 class DoisController < ApplicationController
   prepend_before_action :authenticate_user!
-  before_action :set_doi, only: [:show, :update, :destroy]
+  before_action :set_doi, only: [:show, :update, :destroy, :status]
   before_action :set_user_hash, only: [:create, :update, :destroy]
   before_action :set_include
   authorize_resource :except => [:index, :show, :random]
@@ -90,6 +90,10 @@ class DoisController < ApplicationController
       response.headers["Allow"] = "HEAD, GET, POST, PATCH, PUT, OPTIONS"
       render json: { errors: [{ status: "405", title: "Method not allowed" }] }.to_json, status: :method_not_allowed
     end
+  end
+
+  def status
+    render json: @doi.get_landing_page_info.to_json, status: :ok
   end
 
   def random

--- a/app/models/concerns/checkable.rb
+++ b/app/models/concerns/checkable.rb
@@ -1,0 +1,29 @@
+module Checkable
+  extend ActiveSupport::Concern
+
+  included do
+    def get_landing_page_info
+      return nil unless doi.present?
+
+      return { "status" => 404, "content_type" => nil, "checked" => Time.zone.now.utc.iso8601 } unless
+        url.present?
+
+      response = Maremma.head(url, timeout: 5)
+      if response.headers && response.headers["Content-Type"].present?
+        content_type = response.headers["Content-Type"].split(";").first
+      else
+        content_type = nil
+      end
+
+      checked = Time.zone.now
+
+      write_attribute(:last_landing_page_status, response.status)
+      write_attribute(:last_landing_page_content_type, content_type)
+      write_attribute(:last_landing_page_status_check, checked)
+
+      { "status" => response.status,
+        "content-type" => content_type,
+        "checked" => checked.utc.iso8601 }
+    end
+  end
+end

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -1,13 +1,15 @@
 require 'maremma'
 
 class Doi < ActiveRecord::Base
-  include Helpable
   include Metadatable
   include Cacheable
   include Licensable
 
   # include helper module for generating random DOI suffixes
   include Helpable
+
+  # include helper module for link checking
+  include Checkable
 
   # include state machine
   include AASM
@@ -112,7 +114,7 @@ class Doi < ActiveRecord::Base
   end
 
   def identifier
-    doi_as_url(doi)
+    normalize_doi(doi, sandbox: !Rails.env.production?)
   end
 
   def resource_type

--- a/app/serializers/doi_serializer.rb
+++ b/app/serializers/doi_serializer.rb
@@ -2,7 +2,7 @@ class DoiSerializer < ActiveModel::Serializer
   include Bolognese::Utils
   include Bolognese::DoiUtils
 
-  attributes :doi, :identifier, :url, :author, :title, :container_title, :description, :resource_type_subtype, :license, :version, :related_identifier, :schema_version, :state, :is_active, :reason, :xml, :published, :registered, :updated
+  attributes :doi, :identifier, :url, :author, :title, :container_title, :description, :resource_type_subtype, :landing_page, :license, :version, :related_identifier, :schema_version, :state, :is_active, :reason, :xml, :published, :registered, :updated
 
   belongs_to :client, serializer: ClientSerializer
   belongs_to :provider, serializer: ProviderSerializer
@@ -48,6 +48,12 @@ class DoiSerializer < ActiveModel::Serializer
 
   def registered
     object.date_registered
+  end
+
+  def landing_page
+    { status: object.last_landing_page_status,
+      content_type: object.last_landing_page_content_type,
+      checked: object.last_landing_page_status_check }
   end
 
   def license

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   post 'reset', :to => 'sessions#reset'
 
   # manage DOIs
+  post 'dois/status', :to => 'dois#status'
   post 'dois/set-state', :to => 'dois#set_state'
   post 'dois/set-minted', :to => 'dois#set_minted'
   post 'dois/set-url', :to => 'dois#set_url'

--- a/spec/concerns/checkable_spec.rb
+++ b/spec/concerns/checkable_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe Doi, vcr: true do
+  subject { create(:doi, url: "https://blog.datacite.org/re3data-science-europe/") }
+
+  context "landing page" do
+    it 'get info' do
+      expect(subject.get_landing_page_info["status"]).to eq(200)
+      expect(subject.get_landing_page_info["content-type"]).to eq("text/html")
+    end
+
+    it 'content type pdf' do
+      subject = create(:doi, url: "https://schema.datacite.org/meta/kernel-4.1/doc/DataCite-MetadataKernel_v4.1.pdf")
+      expect(subject.get_landing_page_info["status"]).to eq(200)
+      expect(subject.get_landing_page_info["content-type"]).to eq("application/pdf")
+    end
+
+    it 'not found' do
+      subject = create(:doi, url: "https://blog.datacite.org/xxx")
+      expect(subject.get_landing_page_info["status"]).to eq(404)
+    end
+
+    it 'no url' do
+      subject = create(:doi, url: nil)
+      expect(subject.get_landing_page_info["status"]).to eq(404)
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/Doi/landing_page/content_type_pdf.yml
+++ b/spec/fixtures/vcr_cassettes/Doi/landing_page/content_type_pdf.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://schema.datacite.org/meta/kernel-4.1/doc/DataCite-MetadataKernel_v4.1.pdf
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Maremma - http://df07e5739183
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/pdf
+      Content-Length:
+      - '1196918'
+      Connection:
+      - keep-alive
+      Date:
+      - Sat, 03 Mar 2018 07:02:00 GMT
+      Last-Modified:
+      - Thu, 01 Feb 2018 18:04:54 GMT
+      Etag:
+      - '"401f5e585e3c29b9c0310fafed9688b6"'
+      Server:
+      - AmazonS3
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 7b48191d48ad0a2b3616c20acd7fbc1c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 0Pbr2DitlZLjObeaqWUjnngbrG1vWfncW7o_OR25ICE4jW_XIWXYtw==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sat, 03 Mar 2018 07:01:59 GMT
+- request:
+    method: head
+    uri: https://schema.datacite.org/meta/kernel-4.1/doc/DataCite-MetadataKernel_v4.1.pdf
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Maremma - http://df07e5739183
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/pdf
+      Content-Length:
+      - '1196918'
+      Connection:
+      - keep-alive
+      Date:
+      - Sat, 03 Mar 2018 07:02:00 GMT
+      Last-Modified:
+      - Thu, 01 Feb 2018 18:04:54 GMT
+      Etag:
+      - '"401f5e585e3c29b9c0310fafed9688b6"'
+      Server:
+      - AmazonS3
+      Age:
+      - '1'
+      X-Cache:
+      - Hit from cloudfront
+      Via:
+      - 1.1 e98abde3c6a5bc27d4bdd4168baa587d.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - lF-kmUXoo_U9P8VxXzBPOQxkppI1izH_R2kihhK8vp338jOPB7OYeQ==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sat, 03 Mar 2018 07:01:59 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Doi/landing_page/get_info.yml
+++ b/spec/fixtures/vcr_cassettes/Doi/landing_page/get_info.yml
@@ -1,0 +1,89 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://blog.datacite.org/re3data-science-europe/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Maremma - http://df07e5739183
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '17629'
+      Connection:
+      - keep-alive
+      Date:
+      - Sat, 03 Mar 2018 07:03:33 GMT
+      Cache-Control:
+      - max-age=31536000
+      Last-Modified:
+      - Wed, 28 Feb 2018 20:13:40 GMT
+      Etag:
+      - '"1920e368fefb9ce45b3a103f9378853d"'
+      Server:
+      - AmazonS3
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e0ece2fc930e4eafcacb21a60126c353.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - e4_iFRz9kuW6jhnCmiZ8WnCPM_avBX1ewEFdW7mQq-HHLYoAUh3Uxg==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sat, 03 Mar 2018 07:03:32 GMT
+- request:
+    method: head
+    uri: https://blog.datacite.org/re3data-science-europe/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Maremma - http://df07e5739183
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '17629'
+      Connection:
+      - keep-alive
+      Date:
+      - Sat, 03 Mar 2018 07:03:33 GMT
+      Cache-Control:
+      - max-age=31536000
+      Last-Modified:
+      - Wed, 28 Feb 2018 20:13:40 GMT
+      Etag:
+      - '"1920e368fefb9ce45b3a103f9378853d"'
+      Server:
+      - AmazonS3
+      X-Cache:
+      - Hit from cloudfront
+      Via:
+      - 1.1 49c1155716008869942c0b84162e51aa.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - pbKfd4h5NC41DJAYUkuVOyLCXXgPUzo3pjtxjp6NgjRzvaK9voWZLQ==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sat, 03 Mar 2018 07:03:32 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Doi/landing_page/not_found.yml
+++ b/spec/fixtures/vcr_cassettes/Doi/landing_page/not_found.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://blog.datacite.org/xxx
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Maremma - http://df07e5739183
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Connection:
+      - keep-alive
+      X-Amz-Error-Code:
+      - NoSuchKey
+      X-Amz-Error-Message:
+      - The specified key does not exist.
+      X-Amz-Error-Detail-Key:
+      - xxx
+      Date:
+      - Sat, 03 Mar 2018 06:57:12 GMT
+      Server:
+      - AmazonS3
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 462cdb6020d941cbe166e3fece73ca6d.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - wZrAvd0hhuPRzjSRscqAh8gPhDl_WnDKJ-e4ThFwTkUB-H_W3cfUvQ==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sat, 03 Mar 2018 06:57:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/dois/POST_/dois/status/returns_landing_page_status.yml
+++ b/spec/fixtures/vcr_cassettes/dois/POST_/dois/status/returns_landing_page_status.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://blog.datacite.org/re3data-science-europe/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Maremma - http://df07e5739183
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '17629'
+      Connection:
+      - keep-alive
+      Date:
+      - Sat, 03 Mar 2018 07:03:33 GMT
+      Cache-Control:
+      - max-age=31536000
+      Last-Modified:
+      - Wed, 28 Feb 2018 20:13:40 GMT
+      Etag:
+      - '"1920e368fefb9ce45b3a103f9378853d"'
+      Server:
+      - AmazonS3
+      Age:
+      - '630'
+      X-Cache:
+      - Hit from cloudfront
+      Via:
+      - 1.1 bd5652a800046ffa43683320c0e731b4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - YXz4vrgqXN44skrSoCxYLBUJZrtnAnPrZ9ejRbw24zp_Hhl2xoetJQ==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sat, 03 Mar 2018 07:14:02 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/dois/POST_/dois/status/returns_status_code_200.yml
+++ b/spec/fixtures/vcr_cassettes/dois/POST_/dois/status/returns_status_code_200.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://blog.datacite.org/re3data-science-europe/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Maremma - http://df07e5739183
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '17629'
+      Connection:
+      - keep-alive
+      Date:
+      - Sat, 03 Mar 2018 07:03:33 GMT
+      Cache-Control:
+      - max-age=31536000
+      Last-Modified:
+      - Wed, 28 Feb 2018 20:13:40 GMT
+      Etag:
+      - '"1920e368fefb9ce45b3a103f9378853d"'
+      Server:
+      - AmazonS3
+      Age:
+      - '630'
+      X-Cache:
+      - Hit from cloudfront
+      Via:
+      - 1.1 029f15a661be82d29f31e88713b71d65.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - SOH50ev23cx3aIvkG8lIp0sX302ciNT0k2x9P4mRN1RyOuXgjvb2Dw==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sat, 03 Mar 2018 07:14:03 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/dois/POST_/dois/status_pdf/returns_landing_page_status.yml
+++ b/spec/fixtures/vcr_cassettes/dois/POST_/dois/status_pdf/returns_landing_page_status.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://schema.datacite.org/meta/kernel-4.1/doc/DataCite-MetadataKernel_v4.1.pdf
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Maremma - http://df07e5739183
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/pdf
+      Content-Length:
+      - '1196918'
+      Connection:
+      - keep-alive
+      Date:
+      - Sat, 03 Mar 2018 07:02:00 GMT
+      Last-Modified:
+      - Thu, 01 Feb 2018 18:04:54 GMT
+      Etag:
+      - '"401f5e585e3c29b9c0310fafed9688b6"'
+      Server:
+      - AmazonS3
+      Age:
+      - '980'
+      X-Cache:
+      - Hit from cloudfront
+      Via:
+      - 1.1 d5e8c461ea4d131327b2ba97a2d7f473.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 4mZSv_xy1H3ufsKnvnpYsUdMezFgWyyRBC7AeIsL9n6b7D3Bx7uyMA==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sat, 03 Mar 2018 07:18:20 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/dois/POST_/dois/status_pdf/returns_status_code_200.yml
+++ b/spec/fixtures/vcr_cassettes/dois/POST_/dois/status_pdf/returns_status_code_200.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://schema.datacite.org/meta/kernel-4.1/doc/DataCite-MetadataKernel_v4.1.pdf
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Maremma - http://df07e5739183
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/pdf
+      Content-Length:
+      - '1196918'
+      Connection:
+      - keep-alive
+      Date:
+      - Sat, 03 Mar 2018 07:02:00 GMT
+      Last-Modified:
+      - Thu, 01 Feb 2018 18:04:54 GMT
+      Etag:
+      - '"401f5e585e3c29b9c0310fafed9688b6"'
+      Server:
+      - AmazonS3
+      Age:
+      - '980'
+      X-Cache:
+      - Hit from cloudfront
+      Via:
+      - 1.1 2d2eb60d814c8202a5a69fa957cd569d.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - j-DHk10z2rkL2X3ZTbAxb4bBnZNwu3uE0hmjmHdOAcFXefeqBBIP_g==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sat, 03 Mar 2018 07:18:20 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/dois_spec.rb
+++ b/spec/requests/dois_spec.rb
@@ -321,4 +321,34 @@ describe "dois", type: :request do
       expect(response).to have_http_status(200)
     end
   end
+
+  describe 'POST /dois/status', vcr: true do
+    let(:doi) { create(:doi, url: "https://blog.datacite.org/re3data-science-europe/") }
+
+    before { post "/dois/status?id=#{doi.doi}", headers: headers }
+
+    it 'returns landing page status' do
+      expect(json['status']).to eq(200)
+      expect(json['content-type']).to eq("text/html")
+    end
+
+    it 'returns status code 200' do
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'POST /dois/status pdf', vcr: true do
+    let(:doi) { create(:doi, url: "https://schema.datacite.org/meta/kernel-4.1/doc/DataCite-MetadataKernel_v4.1.pdf") }
+
+    before { post "/dois/status?id=#{doi.doi}", headers: headers }
+
+    it 'returns landing page status' do
+      expect(json['status']).to eq(200)
+      expect(json['content-type']).to eq("application/pdf")
+    end
+
+    it 'returns status code 200' do
+      expect(response).to have_http_status(200)
+    end
+  end
 end


### PR DESCRIPTION
We are using the `url` field for two reasons: if the DOI is not registered in the handle system there is no need to check the link. Secondly the handle server in our test system doesn't return a 404 status if a DOI is not found.

This is on demand link checking for DOI Fabrica, very different from the systematic link checking in https://github.com/datacite/pidcheck. The results are written to the database and exposed in the API.