### PR TITLE
Bug xml differs from input

### DIFF
--- a/app/models/concerns/crosscitable.rb
+++ b/app/models/concerns/crosscitable.rb
@@ -74,14 +74,14 @@ module Crosscitable
     end
 
     def xml
-      datacite
+      current_metadata.xml
     end
 
     def xml=(value)
       return nil unless value.present?
 
       input = Base64.decode64(value).force_encoding("UTF-8")
-
+      
       options = {
         doi: doi,
         sandbox: !Rails.env.production?,
@@ -103,7 +103,7 @@ module Crosscitable
 
       @schema_version = bolognese.schema_version || "http://datacite.org/schema/kernel-4"
       @from = bolognese.from
-      @raw = bolognese.raw
+      @raw = value
 
       metadata.build(doi: self, xml: datacite, namespace: @schema_version)
     rescue NoMethodError, ArgumentError => exception

--- a/spec/requests/dois_spec.rb
+++ b/spec/requests/dois_spec.rb
@@ -280,6 +280,43 @@ describe "dois", type: :request do
       end
     end
 
+    context 'when the request contains subject scheme is valid' do
+      let(:xml) { "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48cmVzb3VyY2UgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSIgeG1sbnM9Imh0dHA6Ly9kYXRhY2l0ZS5vcmcvc2NoZW1hL2tlcm5lbC00IiB4c2k6c2NoZW1hTG9jYXRpb249Imh0dHA6Ly9kYXRhY2l0ZS5vcmcvc2NoZW1hL2tlcm5lbC00IGh0dHA6Ly9zY2hlbWEuZGF0YWNpdGUub3JnL21ldGEva2VybmVsLTQvbWV0YWRhdGEueHNkIj48aWRlbnRpZmllciBpZGVudGlmaWVyVHlwZT0iRE9JIj4xMC4yNTQ5OS94dWRhMnB6cmFocm9lcXBlZnZucTV6dDZkYzwvaWRlbnRpZmllcj48Y3JlYXRvcnM+PGNyZWF0b3I+PGNyZWF0b3JOYW1lPklhbiBQYXJyeTwvY3JlYXRvck5hbWU+PG5hbWVJZGVudGlmaWVyIHNjaGVtZVVSST0iaHR0cDovL29yY2lkLm9yZy8iIG5hbWVJZGVudGlmaWVyU2NoZW1lPSJPUkNJRCI+MDAwMC0wMDAxLTYyMDItNTEzWDwvbmFtZUlkZW50aWZpZXI+PC9jcmVhdG9yPjwvY3JlYXRvcnM+PHRpdGxlcz48dGl0bGU+U3VibWl0dGVkIGNoZW1pY2FsIGRhdGEgZm9yIEluQ2hJS2V5PVlBUFFCWFFZTEpSWFNBLVVIRkZGQU9ZU0EtTjwvdGl0bGU+PC90aXRsZXM+PHB1Ymxpc2hlcj5Sb3lhbCBTb2NpZXR5IG9mIENoZW1pc3RyeTwvcHVibGlzaGVyPjxwdWJsaWNhdGlvblllYXI+MjAxNzwvcHVibGljYXRpb25ZZWFyPjxyZXNvdXJjZVR5cGUgcmVzb3VyY2VUeXBlR2VuZXJhbD0iRGF0YXNldCI+U3Vic3RhbmNlPC9yZXNvdXJjZVR5cGU+PHJpZ2h0c0xpc3Q+PHJpZ2h0cyByaWdodHNVUkk9Imh0dHBzOi8vY3JlYXRpdmVjb21tb25zLm9yZy9zaGFyZS15b3VyLXdvcmsvcHVibGljLWRvbWFpbi9jYzAvIj5ObyBSaWdodHMgUmVzZXJ2ZWQ8L3JpZ2h0cz48L3JpZ2h0c0xpc3Q+PC9yZXNvdXJjZT4=" }
+      let(:valid_attributes) do
+        {
+          "data" => {
+            "type" => "dois",
+            "attributes" => {
+              "doi" => "10.4122/10703",
+              "url" => "http://www.bl.uk/pdf/patspec.pdf",
+              "xml" => xml,
+              "event" => "register"
+            },
+            "relationships"=> {
+              "client"=>  {
+                "data"=> {
+                  "type"=> "clients",
+                  "id"=> client.symbol.downcase
+                }
+              }
+            }
+          }
+        }
+      end
+
+      before { post '/dois', params: valid_attributes.to_json, headers: headers }
+
+      it 'creates a Doi' do
+        puts json.inspect
+        expect(json.dig('data', 'attributes', 'url')).to eq("http://www.bl.uk/pdf/patspec.pdf")
+        expect(json.dig('data', 'attributes', 'doi')).to eq("10.4122/10703")
+        expect(json.dig('data', 'attributes', 'title')).to eq("Submitted chemical data for InChIKey=YAPQBXQYLJRXSA-UHFFFAOYSA-N")
+        expect(json.dig('data', 'attributes', 'xml')).to eq(xml)
+        expect(response).to have_http_status(201)
+        expect(json.dig('data', 'attributes', 'state')).to eq("registered")
+      end
+    end
+
     describe 'POST /dois/validate' do
       context 'validates' do
         let(:xml) { ::Base64.strict_encode64(File.read(file_fixture('datacite.xml'))) }


### PR DESCRIPTION
unfortunately this change break test for /validate
I put it such a way that it will never ask bolognese to create the XML. It should always ask for the database metadata.

However, that breaks the validate action. This is a new action, i am unsure what do we use it for. I will need to check further but I will manage the issue from here. 

this is related to datacite/bolognese#23