### PR TITLE
Add support for storing link check result

### DIFF
--- a/app/controllers/dois_controller.rb
+++ b/app/controllers/dois_controller.rb
@@ -36,7 +36,7 @@ class DoisController < ApplicationController
       end
 
       page = params[:page] || {}
-      if page[:size].present? 
+      if page[:size].present?
         page[:size] = [page[:size].to_i, 1000].min
         max_number = page[:size] > 0 ? 10000/page[:size] : 1
       else
@@ -61,7 +61,7 @@ class DoisController < ApplicationController
         "total-pages" => total_pages,
         page: page[:number].to_i
       }.compact
-  
+
       options[:links] = {
         self: request.original_url,
         next: @dois.blank? ? nil : request.base_url + "/dois?" + {
@@ -74,7 +74,7 @@ class DoisController < ApplicationController
         }.compact
       options[:include] = @include
       options[:is_collection] = true
-  
+
       render json: DoiSerializer.new(@dois, options).serialized_json, status: :ok
     else
       sort = case params[:sort]
@@ -87,7 +87,7 @@ class DoisController < ApplicationController
             end
 
       page = params[:page] || {}
-      if page[:size].present? 
+      if page[:size].present?
         page[:size] = [page[:size].to_i, 1000].min
         max_number = page[:size] > 0 ? 10000/page[:size] : 1
       else
@@ -97,21 +97,21 @@ class DoisController < ApplicationController
       page[:number] = page[:number].to_i > 0 ? [page[:number].to_i, max_number].min : 1
 
       if params[:id].present?
-        response = Doi.find_by_id(params[:id]) 
+        response = Doi.find_by_id(params[:id])
       elsif params[:ids].present?
         response = Doi.find_by_ids(params[:ids], page: page, sort: sort)
       else
-        response = Doi.query(params[:query], 
-                            state: params[:state], 
-                            year: params[:year], 
-                            created: params[:created], 
-                            provider_id: params[:provider_id], 
-                            client_id: params[:client_id], 
-                            prefix: params[:prefix], 
-                            person_id: params[:person_id], 
-                            resource_type_id: camelize_str(params[:resource_type_id]), 
-                            schema_version: params[:schema_version], 
-                            source: params[:source], 
+        response = Doi.query(params[:query],
+                            state: params[:state],
+                            year: params[:year],
+                            created: params[:created],
+                            provider_id: params[:provider_id],
+                            client_id: params[:client_id],
+                            prefix: params[:prefix],
+                            person_id: params[:person_id],
+                            resource_type_id: camelize_str(params[:resource_type_id]),
+                            schema_version: params[:schema_version],
+                            source: params[:source],
                             page: page,
                             sort: sort)
       end
@@ -146,7 +146,7 @@ class DoisController < ApplicationController
         schema_versions: schema_versions,
         sources: sources
       }.compact
-  
+
       options[:links] = {
         self: request.original_url,
         next: @dois.blank? ? nil : request.base_url + "/dois?" + {
@@ -159,7 +159,7 @@ class DoisController < ApplicationController
         }.compact
       options[:include] = @include
       options[:is_collection] = true
-  
+
       render json: DoiSerializer.new(@dois, options).serialized_json, status: :ok
     end
   end
@@ -190,7 +190,7 @@ class DoisController < ApplicationController
       options = {}
       options[:include] = @include
       options[:is_collection] = false
-  
+
       render json: DoiSerializer.new(@doi, options).serialized_json, status: :ok
     end
   end
@@ -211,7 +211,7 @@ class DoisController < ApplicationController
       options = {}
       options[:include] = @include
       options[:is_collection] = false
-  
+
       render json: DoiSerializer.new(@doi, options).serialized_json, status: :created, location: @doi
     else
       logger.warn @doi.errors.inspect
@@ -252,7 +252,7 @@ class DoisController < ApplicationController
       options = {}
       options[:include] = @include
       options[:is_collection] = false
-  
+
       render json: DoiSerializer.new(@doi, options).serialized_json, status: exists ? :ok : :created
     else
       logger.warn @doi.errors.inspect
@@ -292,7 +292,7 @@ class DoisController < ApplicationController
 
   def set_state
     authorize! :set_state, Doi
-    
+
     Doi.set_state
     render json: { message: "DOI state updated." }.to_json, status: :ok
   end
@@ -308,7 +308,7 @@ class DoisController < ApplicationController
 
       if response.status == 200
         url = response.body.dig("data", "values", 0, "data", "value")
-      elsif response.status == 400 && response.body.dig("errors", 0, "title", "responseCode") == 301 
+      elsif response.status == 400 && response.body.dig("errors", 0, "title", "responseCode") == 301
         response = OpenStruct.new(status: 403, body: { "errors" => [{ "status" => 403, "title" => "SERVER NOT RESPONSIBLE FOR HANDLE" }] })
         url = nil
       else
@@ -384,7 +384,7 @@ class DoisController < ApplicationController
 
   def safe_params
     fail JSON::ParserError, "You need to provide a payload following the JSONAPI spec" unless params[:data].present?
-    attributes = [:doi, "confirm-doi", :identifier, :url, :title, :publisher, :published, :created, :prefix, :suffix, "resource-type-subtype", "last-landing-page", "last-landing-page-status", "last-landing-page-status-check", "last-landing-page-content-type", "content-url", "content-size", "content-format", :description, :license, :xml, :validate, :source, :version, "metadata-version", "schema-version", :state, "is-active", :reason, :registered, :updated, :mode, :event, :regenerate, :client, "resource_type", author: [:type, :id, :name, "given-name", "family-name", "givenName", "familyName"]]
+    attributes = [:doi, "confirm-doi", :identifier, :url, :title, :publisher, :published, :created, :prefix, :suffix, "resource-type-subtype", "last-landing-page", "last-landing-page-status", "last-landing-page-status-check", "last-landing-page-status-result", "last-landing-page-content-type", "content-url", "content-size", "content-format", :description, :license, :xml, :validate, :source, :version, "metadata-version", "schema-version", :state, "is-active", :reason, :registered, :updated, :mode, :event, :regenerate, :client, "resource_type", author: [:type, :id, :name, "given-name", "family-name", "givenName", "familyName"]]
     relationships = [{ client: [data: [:type, :id]] },  { provider: [data: [:type, :id]] }, { "resource-type" => [:data, data: [:type, :id]] }]
     p = params.require(:data).permit(:type, :id, attributes: attributes, relationships: relationships)
     p = p.fetch("attributes").merge(client_id: p.dig("relationships", "client", "data", "id"), resource_type_general: camelize_str(p.dig("relationships", "resource-type", "data", "id")))
@@ -394,8 +394,9 @@ class DoisController < ApplicationController
       last_landing_page: p["last-landing-page"],
       last_landing_page_status: p["last-landing-page-status"],
       last_landing_page_status_check: p["last-landing-page-status-check"],
+      last_landing_page_status_result: p["last-landing-page-status-result"],
       last_landing_page_content_type: p["last-landing-page-content-type"]
-    ).except("confirm-doi", :identifier, :prefix, :suffix, "resource-type-subtype", "metadata-version", "schema-version", :state, :mode, "is-active", :created, :registered, :updated, "last-landing-page", "last-landing-page-status", "last-landing-page-status-check", "last-landing-page-content-type")
+    ).except("confirm-doi", :identifier, :prefix, :suffix, "resource-type-subtype", "metadata-version", "schema-version", :state, :mode, "is-active", :created, :registered, :updated, "last-landing-page", "last-landing-page-status", "last-landing-page-status-check", "last-landing-page-status-result", "last-landing-page-content-type")
   end
 
   def underscore_str(str)

--- a/app/controllers/dois_controller.rb
+++ b/app/controllers/dois_controller.rb
@@ -384,8 +384,66 @@ class DoisController < ApplicationController
 
   def safe_params
     fail JSON::ParserError, "You need to provide a payload following the JSONAPI spec" unless params[:data].present?
-    attributes = [:doi, "confirm-doi", :identifier, :url, :title, :publisher, :published, :created, :prefix, :suffix, "resource-type-subtype", "last-landing-page", "last-landing-page-status", "last-landing-page-status-check", "last-landing-page-status-result", "last-landing-page-content-type", "content-url", "content-size", "content-format", :description, :license, :xml, :validate, :source, :version, "metadata-version", "schema-version", :state, "is-active", :reason, :registered, :updated, :mode, :event, :regenerate, :client, "resource_type", author: [:type, :id, :name, "given-name", "family-name", "givenName", "familyName"]]
-    relationships = [{ client: [data: [:type, :id]] },  { provider: [data: [:type, :id]] }, { "resource-type" => [:data, data: [:type, :id]] }]
+
+    attributes = [
+      :doi,
+      "confirm-doi",
+      :identifier,
+      :url, :title,
+      :publisher,
+      :published,
+      :created,
+      :prefix,
+      :suffix,
+      "resource-type-subtype",
+      "last-landing-page",
+      "last-landing-page-status",
+      "last-landing-page-status-check",
+      {
+        "last-landing-page-status-result" => [
+          "error",
+          "redirect-count",
+          { "redirect-urls" => [] },
+          "download-latency",
+          "has-schema-org",
+          "schema-org-id",
+          "dc-identifier",
+          "citation-doi",
+          { "doi-meta-match" => [] },
+          { "doi-meta-different" => [] },
+          "body-has-pid"
+        ]
+      },
+      "last-landing-page-content-type",
+      "content-url",
+      "content-size",
+      "content-format",
+      :description,
+      :license,
+      :xml,
+      :validate,
+      :source,
+      :version,
+      "metadata-version",
+      "schema-version",
+      :state, "is-active",
+      :reason,
+      :registered,
+      :updated,
+      :mode,
+      :event,
+      :regenerate,
+      :client,
+      "resource_type",
+      author: [:type, :id, :name, "given-name", "family-name", "givenName", "familyName"]
+    ]
+
+    relationships = [
+      { client: [data: [:type, :id]] },
+      { provider: [data: [:type, :id]] },
+      { "resource-type" => [:data, data: [:type, :id]] }
+    ]
+
     p = params.require(:data).permit(:type, :id, attributes: attributes, relationships: relationships)
     p = p.fetch("attributes").merge(client_id: p.dig("relationships", "client", "data", "id"), resource_type_general: camelize_str(p.dig("relationships", "resource-type", "data", "id")))
     p.merge(
@@ -396,7 +454,12 @@ class DoisController < ApplicationController
       last_landing_page_status_check: p["last-landing-page-status-check"],
       last_landing_page_status_result: p["last-landing-page-status-result"],
       last_landing_page_content_type: p["last-landing-page-content-type"]
-    ).except("confirm-doi", :identifier, :prefix, :suffix, "resource-type-subtype", "metadata-version", "schema-version", :state, :mode, "is-active", :created, :registered, :updated, "last-landing-page", "last-landing-page-status", "last-landing-page-status-check", "last-landing-page-status-result", "last-landing-page-content-type")
+    ).except(
+      "confirm-doi", :identifier, :prefix, :suffix, "resource-type-subtype",
+      "metadata-version", "schema-version", :state, :mode, "is-active",
+      :created, :registered, :updated, "last-landing-page",
+      "last-landing-page-status", "last-landing-page-status-check",
+      "last-landing-page-status-result", "last-landing-page-content-type")
   end
 
   def underscore_str(str)

--- a/app/controllers/dois_controller.rb
+++ b/app/controllers/dois_controller.rb
@@ -409,8 +409,6 @@ class DoisController < ApplicationController
           "schema-org-id",
           "dc-identifier",
           "citation-doi",
-          { "doi-meta-match" => [] },
-          { "doi-meta-different" => [] },
           "body-has-pid"
         ]
       },

--- a/app/serializers/doi_serializer.rb
+++ b/app/serializers/doi_serializer.rb
@@ -45,6 +45,7 @@ class DoiSerializer
   attribute :landing_page do |object|
     { status: object.last_landing_page_status,
       "content-type" => object.last_landing_page_content_type,
-      checked: object.last_landing_page_status_check }
+      checked: object.last_landing_page_status_check,
+      "result" => object.last_landing_page_status_result }
   end
 end

--- a/spec/requests/dois_spec.rb
+++ b/spec/requests/dois_spec.rb
@@ -1632,7 +1632,17 @@ describe "dois", type: :request do
     context 'landing page' do
       let(:url) { "https://blog.datacite.org/re3data-science-europe/" }
       let(:xml) { "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48cmVzb3VyY2UgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSIgeG1sbnM9Imh0dHA6Ly9kYXRhY2l0ZS5vcmcvc2NoZW1hL2tlcm5lbC00IiB4c2k6c2NoZW1hTG9jYXRpb249Imh0dHA6Ly9kYXRhY2l0ZS5vcmcvc2NoZW1hL2tlcm5lbC00IGh0dHA6Ly9zY2hlbWEuZGF0YWNpdGUub3JnL21ldGEva2VybmVsLTQvbWV0YWRhdGEueHNkIj48aWRlbnRpZmllciBpZGVudGlmaWVyVHlwZT0iRE9JIj4xMC4yNTQ5OS94dWRhMnB6cmFocm9lcXBlZnZucTV6dDZkYzwvaWRlbnRpZmllcj48Y3JlYXRvcnM+PGNyZWF0b3I+PGNyZWF0b3JOYW1lPklhbiBQYXJyeTwvY3JlYXRvck5hbWU+PG5hbWVJZGVudGlmaWVyIHNjaGVtZVVSST0iaHR0cDovL29yY2lkLm9yZy8iIG5hbWVJZGVudGlmaWVyU2NoZW1lPSJPUkNJRCI+MDAwMC0wMDAxLTYyMDItNTEzWDwvbmFtZUlkZW50aWZpZXI+PC9jcmVhdG9yPjwvY3JlYXRvcnM+PHRpdGxlcz48dGl0bGU+U3VibWl0dGVkIGNoZW1pY2FsIGRhdGEgZm9yIEluQ2hJS2V5PVlBUFFCWFFZTEpSWFNBLVVIRkZGQU9ZU0EtTjwvdGl0bGU+PC90aXRsZXM+PHB1Ymxpc2hlcj5Sb3lhbCBTb2NpZXR5IG9mIENoZW1pc3RyeTwvcHVibGlzaGVyPjxwdWJsaWNhdGlvblllYXI+MjAxNzwvcHVibGljYXRpb25ZZWFyPjxyZXNvdXJjZVR5cGUgcmVzb3VyY2VUeXBlR2VuZXJhbD0iRGF0YXNldCI+U3Vic3RhbmNlPC9yZXNvdXJjZVR5cGU+PHJpZ2h0c0xpc3Q+PHJpZ2h0cyByaWdodHNVUkk9Imh0dHBzOi8vY3JlYXRpdmVjb21tb25zLm9yZy9zaGFyZS15b3VyLXdvcmsvcHVibGljLWRvbWFpbi9jYzAvIj5ObyBSaWdodHMgUmVzZXJ2ZWQ8L3JpZ2h0cz48L3JpZ2h0c0xpc3Q+PC9yZXNvdXJjZT4=" }
-      let(:raw_result) { {"pid" => "10.5072/exampledoi"}.to_json }
+      let(:link_check_result) { {
+        "error" => nil,
+        "redirect-count" => 0,
+        "redirect-urls" => [],
+        "download-latency" => 200,
+        "has-schema-org" => true,
+        "schema-org-id" => "10.14454/10703",
+        "dc-identifier" => nil,
+        "citation-doi" => nil,
+        "body-has-pid" => true
+      } }
       let(:valid_attributes) do
         {
           "data" => {
@@ -1645,7 +1655,7 @@ describe "dois", type: :request do
               "last-landing-page-status" => 200,
               "last-landing-page-status-check" => Time.zone.now,
               "last-landing-page-content-type" => "text/html",
-              "last-landing-page-status-result" => raw_result,
+              "last-landing-page-status-result" => link_check_result,
               "event" => "register"
             },
             "relationships"=> {
@@ -1663,10 +1673,11 @@ describe "dois", type: :request do
       before { post '/dois', params: valid_attributes.to_json, headers: headers }
 
       it 'creates a Doi' do
+        puts json
         expect(json.dig('data', 'attributes', 'url')).to eq(url)
         expect(json.dig('data', 'attributes', 'doi')).to eq("10.14454/10703")
         expect(json.dig('data', 'attributes', 'landing-page', 'status')).to eq(200)
-        expect(json.dig('data', 'attributes', 'landing-page', 'result')).to eq(raw_result)
+        expect(json.dig('data', 'attributes', 'landing-page', 'result')).to eq(link_check_result)
       end
 
       it 'returns status code 201' do

--- a/spec/requests/dois_spec.rb
+++ b/spec/requests/dois_spec.rb
@@ -273,7 +273,7 @@ describe "dois", type: :request do
         expect(json.dig('data', 'attributes', 'url')).to eq("http://www.bl.uk/pdf/pat.pdf")
         expect(json.dig('data', 'attributes', 'doi')).to eq(doi.doi.downcase)
         expect(json.dig('data', 'attributes', 'title')).to eq("Automated quantitative histology reveals vascular morphodynamics during Arabidopsis hypocotyl secondary growth")
-      
+
         xml = Maremma.from_xml(Base64.decode64(json.dig('data', 'attributes', 'xml'))).fetch("resource", {})
         expect(xml.dig("titles", "title")).to eq("Automated quantitative histology reveals vascular morphodynamics during Arabidopsis hypocotyl secondary growth")
       end
@@ -522,7 +522,7 @@ describe "dois", type: :request do
     before(:each) do
       Rails.cache.clear
     end
-    
+
     context 'when the request is valid' do
       let(:xml) { Base64.strict_encode64(file_fixture('datacite.xml').read) }
       let(:valid_attributes) do
@@ -594,7 +594,7 @@ describe "dois", type: :request do
     #       }
     #     }
     #   end
-      
+
     #   before { patch "/dois/10.14454/8na3-9s47", params: valid_attributes.to_json, headers: headers }
 
     #   it 'updates the record' do
@@ -1632,6 +1632,7 @@ describe "dois", type: :request do
     context 'landing page' do
       let(:url) { "https://blog.datacite.org/re3data-science-europe/" }
       let(:xml) { "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48cmVzb3VyY2UgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSIgeG1sbnM9Imh0dHA6Ly9kYXRhY2l0ZS5vcmcvc2NoZW1hL2tlcm5lbC00IiB4c2k6c2NoZW1hTG9jYXRpb249Imh0dHA6Ly9kYXRhY2l0ZS5vcmcvc2NoZW1hL2tlcm5lbC00IGh0dHA6Ly9zY2hlbWEuZGF0YWNpdGUub3JnL21ldGEva2VybmVsLTQvbWV0YWRhdGEueHNkIj48aWRlbnRpZmllciBpZGVudGlmaWVyVHlwZT0iRE9JIj4xMC4yNTQ5OS94dWRhMnB6cmFocm9lcXBlZnZucTV6dDZkYzwvaWRlbnRpZmllcj48Y3JlYXRvcnM+PGNyZWF0b3I+PGNyZWF0b3JOYW1lPklhbiBQYXJyeTwvY3JlYXRvck5hbWU+PG5hbWVJZGVudGlmaWVyIHNjaGVtZVVSST0iaHR0cDovL29yY2lkLm9yZy8iIG5hbWVJZGVudGlmaWVyU2NoZW1lPSJPUkNJRCI+MDAwMC0wMDAxLTYyMDItNTEzWDwvbmFtZUlkZW50aWZpZXI+PC9jcmVhdG9yPjwvY3JlYXRvcnM+PHRpdGxlcz48dGl0bGU+U3VibWl0dGVkIGNoZW1pY2FsIGRhdGEgZm9yIEluQ2hJS2V5PVlBUFFCWFFZTEpSWFNBLVVIRkZGQU9ZU0EtTjwvdGl0bGU+PC90aXRsZXM+PHB1Ymxpc2hlcj5Sb3lhbCBTb2NpZXR5IG9mIENoZW1pc3RyeTwvcHVibGlzaGVyPjxwdWJsaWNhdGlvblllYXI+MjAxNzwvcHVibGljYXRpb25ZZWFyPjxyZXNvdXJjZVR5cGUgcmVzb3VyY2VUeXBlR2VuZXJhbD0iRGF0YXNldCI+U3Vic3RhbmNlPC9yZXNvdXJjZVR5cGU+PHJpZ2h0c0xpc3Q+PHJpZ2h0cyByaWdodHNVUkk9Imh0dHBzOi8vY3JlYXRpdmVjb21tb25zLm9yZy9zaGFyZS15b3VyLXdvcmsvcHVibGljLWRvbWFpbi9jYzAvIj5ObyBSaWdodHMgUmVzZXJ2ZWQ8L3JpZ2h0cz48L3JpZ2h0c0xpc3Q+PC9yZXNvdXJjZT4=" }
+      let(:raw_result) { {"pid" => "10.5072/exampledoi"}.to_json }
       let(:valid_attributes) do
         {
           "data" => {
@@ -1644,6 +1645,7 @@ describe "dois", type: :request do
               "last-landing-page-status" => 200,
               "last-landing-page-status-check" => Time.zone.now,
               "last-landing-page-content-type" => "text/html",
+              "last-landing-page-status-result" => raw_result,
               "event" => "register"
             },
             "relationships"=> {
@@ -1664,6 +1666,7 @@ describe "dois", type: :request do
         expect(json.dig('data', 'attributes', 'url')).to eq(url)
         expect(json.dig('data', 'attributes', 'doi')).to eq("10.14454/10703")
         expect(json.dig('data', 'attributes', 'landing-page', 'status')).to eq(200)
+        expect(json.dig('data', 'attributes', 'landing-page', 'result')).to eq(raw_result)
       end
 
       it 'returns status code 201' do
@@ -1906,7 +1909,7 @@ describe "dois", type: :request do
   describe 'GET /dois/DOI/get-url no permission', vcr: true do
     let(:other_client) { create(:client, provider: provider) }
     let(:doi) { create(:doi, client: other_client, doi: "10.5438/8syz-ym47", event: "publish") }
-    
+
     before { get "/dois/#{doi.doi}/get-url", headers: headers }
 
     it 'returns error' do


### PR DESCRIPTION
This is to allow requests to be made to store raw results found by our crawler to avoid losing potential information or for later processing.
Note I've not indexed it in ES as it's not intended to be searched upon.