### PR TITLE
Publisher in citation does not show on lupo for datapaper type

### DIFF
--- a/spec/fixtures/files/datapaper.xml
+++ b/spec/fixtures/files/datapaper.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resource
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
+    <identifier identifierType="DOI">10.17912/Z4Z9-CE10</identifier>
+    <creators>
+        <creator>
+            <creatorName>McKillop, Alexandra N.</creatorName>
+            <givenName>Alexandra N.</givenName>
+            <familyName>McKillop</familyName>
+        </creator>
+        <creator>
+            <creatorName>Shi, Herong</creatorName>
+            <givenName>Herong</givenName>
+            <familyName>Shi</familyName>
+        </creator>
+        <creator>
+            <creatorName>Liu, Jun</creatorName>
+            <givenName>Jun</givenName>
+            <familyName>Liu</familyName>
+        </creator>
+    </creators>
+    <titles>
+        <title>A new deletion allele of sma-4</title>
+    </titles>
+    <publisher>microPublication Biology </publisher>
+    <publicationYear>2018</publicationYear>
+    <resourceType resourceTypeGeneral="DataPaper">Journal article</resourceType>
+    <dates>
+        <date dateType="Issued">2018</date>
+    </dates>
+    <version/>
+    <descriptions>
+        <description descriptionType="Abstract">sma-4 encodes the co-Smad of the BMP pathway in C. elegans, which is also known as the Sma/Mab pathway (Savage et al. 1996). Null mutations in core components of this pathway, including the BMP ligand DBL-1, the receptors SMA-6 and DAF-4, and the R-Smads SMA-2 and SMA-3, all result in a small body size phenotype without significantly compromising viability (Gumienny and Savage-Dunn 2013). However, we found that even after multiple rounds of out-crossing, two deletion alleles of sma-4, ok3140 and tm4731, caused late larval lethality and embryonic lethality, respectively. This observation suggests that either SMA-4 has DBL-1/BMP-independent functions that are required for viability, or ok3140 and tm4731 have closely linked lethal mutations. To distinguish between these two possibilities, we generated a deletion allele of sma-4 using CRISPR/Cas9-mediated non-homologous end joining. This allele, jj278, contains a 3,556bp deletion (position: Chromosome III: 5,816,203….5,819,759) that deletes almost the entire coding region of sma-4 (Figure 1A) and represents a true molecular null. jj278 animals are viable and fertile, but are smaller than wild-type animals (Figure 1B), like loss-of-function mutants in other core BMP pathway members (SAVAGE et al. 1996; KRISHNA et al. 1999). This result suggests that ok3140 and tm4731 likely have closely linked lethal mutations not caused by their respective sma-4 deletions.</description>
+    </descriptions>
+</resource>

--- a/spec/requests/index_spec.rb
+++ b/spec/requests/index_spec.rb
@@ -363,6 +363,21 @@ describe "content_negotation", type: :request do
       end
     end
 
+    context "apa for datapaper style link" do
+      let(:mxml) { Base64.strict_encode64(file_fixture('datapaper.xml').read) }
+      let(:doi) { create(:doi, xml: mxml, client: client, aasm_state: "findable") }
+      
+      before { get "/#{doi.doi}?style=apa", headers: { "HTTP_ACCEPT" => "text/x-bibliography", 'Authorization' => 'Bearer ' + bearer  }  }
+
+      it 'returns the Doi' do
+        expect(response.body).to end_with(" microPublication Biology. https://doi.org/10.17912/z4z9-ce10")
+      end
+
+      it 'returns status code 200' do
+        expect(response).to have_http_status(200)
+      end
+    end
+
     context "style and locale" do
       before { get "/#{doi.doi}?style=vancouver&locale=de", headers: { "HTTP_ACCEPT" => "text/x-bibliography", 'Authorization' => 'Bearer ' + bearer  } }
 


### PR DESCRIPTION
related to https://github.com/datacite/lupo/issues/133

DataPaper was added in metadata schema 4.1

the citation doesn't show publishe using the aPI https://api.datacite.org/10.17912/Z4Z9-CE10?style=apa

but using the crosscite website it does

https://citation.crosscite.org/

doesn;t appear in CSL for APA https://github.com/citation-style-language/styles/blob/master/apa.csl

it calls all the way here https://github.com/datacite/bolognese/blob/e0f41e8ce78bccd390678cab07e733efb71d02cd/lib/bolognese/writers/citation_writer.rb#L7

content negotiation also works

https://data.datacite.org/text/x-bibliography;style=apa/10.17912/Z4Z9-CE10

and bolonese as well :

➜ bolognese 10.17912/z4z9-ce10 -t citation

it works with bolognese 1.0.7 and 0.15.7