### PR TITLE
Avoid using an instance variable for results.

### DIFF
--- a/app/controllers/dois_controller.rb
+++ b/app/controllers/dois_controller.rb
@@ -185,8 +185,6 @@ class DoisController < ApplicationController
         format.any(:bibtex, :citeproc, :codemeta, :crosscite, :datacite, :datacite_json, :jats, :ris, :csv, :schema_org) { render request.format.to_sym => response.records.to_a }
       end
     rescue Elasticsearch::Transport::Transport::Errors::BadRequest => exception
-      Raven.capture_exception(exception)
-
       message = JSON.parse(exception.message[6..-1]).to_h.dig("error", "root_cause", 0, "reason")
 
       render json: { "errors" => { "title" => message }}.to_json, status: :bad_request

--- a/app/controllers/dois_controller.rb
+++ b/app/controllers/dois_controller.rb
@@ -135,7 +135,6 @@ class DoisController < ApplicationController
 
       respond_to do |format|
         format.json do
-          @dois = results
           options = {}
           options[:meta] = {
             total: total,
@@ -161,11 +160,11 @@ class DoisController < ApplicationController
 
           options[:links] = {
             self: request.original_url,
-            next: @dois.size < page[:size] ? nil : request.base_url + "/dois?" + {
+            next: results.size < page[:size] ? nil : request.base_url + "/dois?" + {
               query: params[:query],
               "provider-id" => params[:provider_id],
               "client-id" => params[:client_id],
-              "page[cursor]" => page[:cursor].present? ? Array.wrap(@dois.to_a.last[:sort]).first : nil,
+              "page[cursor]" => page[:cursor].present? ? Array.wrap(results.to_a.last[:sort]).first : nil,
               "page[number]" => page[:cursor].blank? && page[:number].present? ? page[:number] + 1 : nil,
               "page[size]" => page[:size] }.compact.to_query
             }.compact
@@ -176,7 +175,7 @@ class DoisController < ApplicationController
           }
 
           logger.info "[Benchmark] render " + Benchmark.ms {
-            render json: DoiSerializer.new(@dois, options).serialized_json, status: :ok
+            render json: DoiSerializer.new(results, options).serialized_json, status: :ok
           }.to_s + " ms"
         end
         format.citation do
@@ -187,7 +186,7 @@ class DoisController < ApplicationController
       end
     rescue Elasticsearch::Transport::Transport::Errors::BadRequest => exception
       Raven.capture_exception(exception)
-      
+
       message = JSON.parse(exception.message[6..-1]).to_h.dig("error", "root_cause", 0, "reason")
 
       render json: { "errors" => { "title" => message }}.to_json, status: :bad_request
@@ -395,7 +394,7 @@ class DoisController < ApplicationController
     head :no_content and return unless client_prefix.present?
 
     dois = Doi.get_dois(prefix: client_prefix.prefix, username: current_user.uid.upcase, password: current_user.password)
-    if dois.length > 0 
+    if dois.length > 0
       render json: { dois: dois }.to_json, status: :ok
     else
       head :no_content

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -108,6 +108,10 @@ module Indexable
         from = 0
         search_after = [options.dig(:page, :cursor)]
         sort = [{ _id: { order: 'asc' }}]
+      elsif self.name == "Activity" && options.dig(:page, :cursor).present?
+        from = 0
+        search_after = [options.dig(:page, :cursor)]
+        sort = [{ created: { order: 'asc' }}]
       else
         from = (options.dig(:page, :number) - 1) * options.dig(:page, :size)
         search_after = nil

--- a/config/application.rb
+++ b/config/application.rb
@@ -77,6 +77,7 @@ module Lupo
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
+    config.log_level = ENV['LOG_LEVEL'].to_sym
 
     # configure caching
     config.cache_store = :dalli_store, nil, { :namespace => ENV['APPLICATION'] }

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -10,7 +10,6 @@ Rails.application.configure do
     event.payload.inspect.length > 100000
   end
   config.lograge.base_controller_class = 'ActionController::API'
-  config.log_level = ENV['LOG_LEVEL'].to_sym
 
   config.lograge.custom_options = lambda do |event|
     exceptions = %w(controller action format id)


### PR DESCRIPTION
This was a performance related change.
My belief is that the serializer has to do a method call for every single DOI in the result set and as the size is increased, this adds a significant overhead of 2-3 seconds overall.