### PR TITLE
Feature batch loading and new field for citation_id

### DIFF
--- a/app/controllers/concerns/facetable.rb
+++ b/app/controllers/concerns/facetable.rb
@@ -265,6 +265,14 @@ module Facetable
       end
     end
 
+    def facet_citations_by_dois(arr)
+      arr.map do |hsh|
+        { "id" => hsh["key"],
+          "title" => hsh["key"],
+          "citations" => hsh.dig("unique_citations", "value")}
+      end
+    end
+
     def providers_totals(arr)
       providers = Provider.all.pluck(:symbol, :name).to_h
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -114,7 +114,8 @@ class EventsController < ApplicationController
     dois = total.positive? && params[:extra] ? facet_by_dois(response.response.aggregations.dois.buckets) : nil
     dois_usage = total.positive? && params[:extra] ? facet_by_dois(response.response.aggregations.dois_usage.dois.buckets) : nil
     dois_citations = total.positive? && params[:extra] ? facet_citations_by_year(response.response.aggregations.dois_citations) : nil
-
+    # unique_citations = total.positive? && params[:extra] ? facet_citations_by_dois(response.response.aggregations.unique_citations.dois.buckets) : nil
+ 
     results = response.results
 
     options = {}
@@ -130,7 +131,8 @@ class EventsController < ApplicationController
       registrants: registrants,
       "doisRelationTypes": dois,
       "doisUsageTypes": dois_usage,
-      "doisCitations": dois_citations
+      "doisCitations": dois_citations,
+      # "uniqueCitations": unique_citations
     }.compact
 
     options[:links] = {

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -97,6 +97,7 @@ class EventsController < ApplicationController
                              publication_year: params[:publication_year],
                              occurred_at: params[:occurred_at],
                              year_month: params[:year_month],
+                             unique: params[:unique],
                              page: page,
                              sort: sort)
     end

--- a/app/models/concerns/batch_loader_helper.rb
+++ b/app/models/concerns/batch_loader_helper.rb
@@ -3,10 +3,21 @@ module BatchLoaderHelper
 
   class_methods do
     def load_doi(object)
-      Doi.find_by_id(object.doi).results
-      # BatchLoader.for(object.doi).batch do |dois, loader|
-      #   Doi.find_by_id(object.doi).results.each { |doi| loader.call(doi.uid, doi) }
-      # end
+      # Doi.find_by_id(object.doi).results
+      # BatchLoader::Executor.clear_current
+
+      BatchLoader.for(object.uuid).batch do |dois, loader|
+
+        dois = object.doi
+        # dois = ["10.17876/musewide/dr.1/05555","10.0166/fk2.stagefigshare.6420615.v1","10.1234/rr763th5wp.1,10.1234/7rdf2ryxjn.1"]
+        # Doi.find_by_id(dois).results.each do |doi| 
+        #   puts doi.doi
+        #   loader.call(object.uuid, [doi]) 
+        # end
+
+        results = Doi.find_by_id(dois).results
+        loader.call(object.uuid, results) 
+      end
     end
   end
 end

--- a/app/models/concerns/batch_loader_helper.rb
+++ b/app/models/concerns/batch_loader_helper.rb
@@ -3,18 +3,10 @@ module BatchLoaderHelper
 
   class_methods do
     def load_doi(object)
-      # Doi.find_by_id(object.doi).results
-      # BatchLoader::Executor.clear_current
 
       BatchLoader.for(object.uuid).batch do |dois, loader|
 
         dois = object.doi
-        # dois = ["10.17876/musewide/dr.1/05555","10.0166/fk2.stagefigshare.6420615.v1","10.1234/rr763th5wp.1,10.1234/7rdf2ryxjn.1"]
-        # Doi.find_by_id(dois).results.each do |doi| 
-        #   puts doi.doi
-        #   loader.call(object.uuid, [doi]) 
-        # end
-
         results = Doi.find_by_id(dois).results
         loader.call(object.uuid, results) 
       end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -126,7 +126,7 @@ class Event < ActiveRecord::Base
     indexes :updated_at,       type: :date
     indexes :indexed_at,       type: :date
     indexes :occurred_at,      type: :date
-    indexes :my_hash,          type: :keyword
+    indexes :citation_id,      type: :keyword
     indexes :cache_key,        type: :keyword
   end
 
@@ -160,12 +160,12 @@ class Event < ActiveRecord::Base
       "updated_at" => updated_at,
       "indexed_at" => indexed_at,
       "occurred_at" => occurred_at,
-      "my_hash" => my_hash,
+      "citation_id" => citation_id,
       "cache_key" => cache_key
     }
   end
 
-  def my_hash
+  def citation_id
     [subj_id, obj_id].compact.sort.join("-")
   end
 
@@ -206,14 +206,16 @@ class Event < ActiveRecord::Base
           }
         },
         aggs: { years: { date_histogram: { field: 'occurred_at', interval: 'year', min_doc_count: 1 }, aggs: { "total_by_year" => { sum: { field: 'total' }}}},"sum_distribution"=>sum_year_distribution}
-      },
-      unique_citations: {
-        filter: {
-          script: {
-            script: "#{INCLUDED_RELATION_TYPES}.contains(doc['relation_type_id'].value)"
-          }
-        },
-        aggs: { type_count: { cardinality: { field: 'my_hash' }}}
+      # },
+      # unique_citations: {
+      #   filter: {
+      #     script: {
+      #       script: "#{INCLUDED_RELATION_TYPES}.contains(doc['relation_type_id'].value)"
+      #     }
+      #   },
+      #   aggs: { dois: {
+      #      terms: { field: 'obj_id', size: 50, min_doc_count: 1 }, aggs: { unique_citations: { cardinality: { field: 'citation_id' }}}
+      #   }}
       }
     }
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -166,7 +166,7 @@ class Event < ActiveRecord::Base
   end
 
   def citation_id
-    [subj_id, obj_id].compact.sort.join("-")
+    [subj_id, obj_id].sort.join("-")
   end
 
   def self.query_fields

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -1,5 +1,3 @@
-require 'benchmark'
-
 
 class EventSerializer
   include FastJsonapi::ObjectSerializer

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -12,17 +12,6 @@ class EventSerializer
   attributes :subj_id, :obj_id, :source_id, :relation_type_id, :total, :message_action, :source_token, :license, :occurred_at, :timestamp
   
   has_many :dois, record_type: :dois, serializer: DoiSerializer, id_method_name: :uid do |object|
-    # logger = Logger.new(STDOUT)
-    # bmp = Benchmark.ms {
-    #   load_doi(object)
-    # }
-    # if bmp > 10000
-    #   logger.warn "[Benchmark Warning] batchloading " + bmp.to_s + " ms"
-    # else
-    #   logger.info "[Benchmark] batchloading " + bmp.to_s + " ms"
-    # end
-    # puts "ouside"
-    # puts object.uuid
     load_doi(object)
   end
   

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -1,3 +1,6 @@
+require 'benchmark'
+
+
 class EventSerializer
   include FastJsonapi::ObjectSerializer
   include BatchLoaderHelper
@@ -9,6 +12,17 @@ class EventSerializer
   attributes :subj_id, :obj_id, :source_id, :relation_type_id, :total, :message_action, :source_token, :license, :occurred_at, :timestamp
   
   has_many :dois, record_type: :dois, serializer: DoiSerializer, id_method_name: :uid do |object|
+    # logger = Logger.new(STDOUT)
+    # bmp = Benchmark.ms {
+    #   load_doi(object)
+    # }
+    # if bmp > 10000
+    #   logger.warn "[Benchmark Warning] batchloading " + bmp.to_s + " ms"
+    # else
+    #   logger.info "[Benchmark] batchloading " + bmp.to_s + " ms"
+    # end
+    # puts "ouside"
+    # puts object.uuid
     load_doi(object)
   end
   


### PR DESCRIPTION
this PR aims to address

-  Including DOIs with events serializer has n+1 problem. We address this problem using batch-loading. https://github.com/datacite/lupo/issues/300
- There can be duplicated citations in the events index. We flag duplicates by adding an id for citations pairs. We create subsequent interfaces to obtain citations filter by such flag. https://github.com/datacite/lupo/issues/232
