### PR TITLE
Add support for cursor navigation based on created + doi for tie-break

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -15,7 +15,7 @@ class ActivitiesController < ApplicationController
     page = page_from_params(params)
 
     if params[:id].present?
-      response = Activity.find_by_id(params[:id]) 
+      response = Activity.find_by_id(params[:id])
     elsif params[:ids].present?
       response = Activity.find_by_id(params[:ids], page: page, sort: sort)
     else
@@ -24,24 +24,24 @@ class ActivitiesController < ApplicationController
 
     begin
       total = response.results.total
-      total_for_pages = page[:cursor].present? ? total.to_f : [total.to_f, 10000].min
+      total_for_pages = page[:cursor].nil? ? total.to_f : [total.to_f, 10000].min
       total_pages = page[:size] > 0 ? (total_for_pages / page[:size]).ceil : 0
-      
+
       @activities = response.results
 
       options = {}
       options[:meta] = {
         total: total,
         "totalPages" => total_pages,
-        page: page[:cursor].blank? && page[:number].present? ? page[:number] : nil,
+        page: page[:cursor].nil? && page[:number].present? ? page[:number] : nil,
       }.compact
 
       options[:links] = {
         self: request.original_url,
         next: @activities.size < page[:size] ? nil : request.base_url + "/activities?" + {
           query: params[:query],
-          "page[cursor]" => page[:cursor].present? ? Array.wrap(@activities.to_a.last[:sort]).first : nil,
-          "page[number]" => page[:cursor].blank? && page[:number].present? ? page[:number] + 1 : nil,
+          "page[cursor]" => page[:cursor] ? Base64.strict_encode64(Array.wrap(@activities.to_a.last[:sort]).join(',')) : nil,
+          "page[number]" => page[:cursor].nil? && page[:number].present? ? page[:number] + 1 : nil,
           "page[size]" => page[:size],
           sort: params[:sort] }.compact.to_query
         }.compact

--- a/app/controllers/concerns/paginatable.rb
+++ b/app/controllers/concerns/paginatable.rb
@@ -16,6 +16,12 @@ module Paginatable
         page = {}
       end
 
+      # All cursors will need to be decoded from the param
+      if page[:cursor].present?
+        # When we decode and split, we'll always end up with an array
+        page[:cursor] = Base64.strict_decode64(page[:cursor]).split(",")
+      end
+
       if page[:size].present?
         page[:size] = [page[:size].to_i, 10000].min
         max_number = page[:size] > 0 ? 10000/page[:size] : 1

--- a/app/controllers/concerns/paginatable.rb
+++ b/app/controllers/concerns/paginatable.rb
@@ -22,7 +22,8 @@ module Paginatable
           # When we decode and split, we'll always end up with an array
           page[:cursor] = Base64.strict_decode64(page[:cursor]).split(",")
         rescue ArgumentError
-          raise "Invalid base64 used for cursor pased from query params"
+          # If we fail to decode we'll just default back to an empty cursor
+          page[:cursor] = []
         end
       end
 

--- a/app/controllers/concerns/paginatable.rb
+++ b/app/controllers/concerns/paginatable.rb
@@ -18,8 +18,12 @@ module Paginatable
 
       # All cursors will need to be decoded from the param
       if page[:cursor].present?
-        # When we decode and split, we'll always end up with an array
-        page[:cursor] = Base64.strict_decode64(page[:cursor]).split(",")
+        begin
+          # When we decode and split, we'll always end up with an array
+          page[:cursor] = Base64.strict_decode64(page[:cursor]).split(",")
+        rescue ArgumentError
+          raise "Invalid base64 used for cursor pased from query params"
+        end
       end
 
       if page[:size].present?

--- a/app/controllers/dois_controller.rb
+++ b/app/controllers/dois_controller.rb
@@ -181,7 +181,7 @@ class DoisController < ApplicationController
               "provider-id" => params[:provider_id],
               "client-id" => params[:client_id],
               # The cursor link should be an array of values, but we want to encode it into a single string for the URL
-              "page[cursor]" => !page[:cursor].nil? ? Base64.strict_encode64(Array.wrap(results.to_a.last[:sort]).join(',')) : nil,
+              "page[cursor]" => page[:cursor] ? Base64.strict_encode64(Array.wrap(results.to_a.last[:sort]).join(',')) : nil,
               "page[number]" => page[:cursor].nil? && page[:number].present? ? page[:number] + 1 : nil,
               "page[size]" => page[:size] }.compact.to_query
             }.compact

--- a/app/controllers/dois_controller.rb
+++ b/app/controllers/dois_controller.rb
@@ -190,6 +190,7 @@ class DoisController < ApplicationController
               query: params[:query],
               "provider-id" => params[:provider_id],
               "client-id" => params[:client_id],
+              # The cursor link should be based on the ES sort, but we want to encode it into a single string
               "page[cursor]" => show_cursor_link == true ? Base64.encode64(Array.wrap(results.to_a.last[:sort]).join(',')) : nil,
               "page[number]" => show_cursor_link == false && page[:number].present? ? page[:number] + 1 : nil,
               "page[size]" => page[:size] }.compact.to_query

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -102,7 +102,7 @@ class EventsController < ApplicationController
     end
 
     total = response.results.total
-    total_for_pages = page[:cursor].present? ? total.to_f : [total.to_f, 10000].min
+    total_for_pages = page[:cursor].nil? ? total.to_f : [total.to_f, 10000].min
     total_pages = page[:size] > 0 ? (total_for_pages / page[:size]).ceil : 0
 
     sources = total.positive? ? facet_by_source(response.response.aggregations.sources.buckets) : nil
@@ -121,7 +121,7 @@ class EventsController < ApplicationController
     options[:meta] = {
       total: total,
       "totalPages" => total_pages,
-      page: page[:cursor].blank? && page[:number].present? ? page[:number] : nil,
+      page: page[:cursor].nil? && page[:number].present? ? page[:number] : nil,
       sources: sources,
       prefixes: prefixes,
       "citationTypes" => citation_types,
@@ -150,8 +150,8 @@ class EventsController < ApplicationController
         "registrant-id" => params[:registrant_id],
         "publication-year" => params[:publication_year],
         "year-month" => params[:year_month],
-        "page[cursor]" => page[:cursor].present? ? Array.wrap(results.to_a.last[:sort]).first : nil,
-        "page[number]" => page[:cursor].blank? && page[:number].present? ? page[:number] + 1 : nil,
+        "page[cursor]" => page[:cursor] ? Base64.strict_encode64(Array.wrap(results.to_a.last[:sort]).join(',')) : nil,
+        "page[number]" => page[:cursor].nil? && page[:number].present? ? page[:number] + 1 : nil,
         "page[size]" => page[:size] }.compact.to_query
       }.compact
     options[:include] = @include

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -104,12 +104,12 @@ module Indexable
       # Default sort should be whatever is passed in
       sort = options[:sort]
       # Cursor should always be an array regardless
-      cursorValues = Array.wrap(options.dig(:page, :cursor))
+      cursor_values = Array.wrap(options.dig(:page, :cursor))
 
       # Cursor nav use the search after, this should always be an array of values that match the sort.
       if options.dig(:page, :cursor).present?
         from = 0
-        search_after = cursorValues
+        search_after = cursor_values
       else
         from = ((options.dig(:page, :number) || 1) - 1) * (options.dig(:page, :size) || 25)
         search_after = nil
@@ -117,15 +117,15 @@ module Indexable
 
       # Calculate cursor sort based upon the type of model
       # Cursor sorts override any option sort
-      if self.name == "Doi" && cursorValues
+      if self.name == "Doi" && cursor_values
         sort = [{ created: "asc", doi: "asc"}]
-      elsif self.name == "Event" && cursorValues
+      elsif self.name == "Event" && cursor_values
         sort = [{ created_at: "asc", uuid: "asc"}]
-      elsif self.name == "Activity" && cursorValues
+      elsif self.name == "Activity" && cursor_values
         sort = [{ created: { order: 'asc' }}]
-      elsif self.name == "Researcher" && cursorValues
+      elsif self.name == "Researcher" && cursor_values
         sort = [{ created_at: "asc", uid: "asc"}]
-      elsif cursorValues
+      elsif cursor_values
         sort = [{ created: { order: 'asc' }}]
       else
         sort = options[:sort]

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -103,11 +103,13 @@ module Indexable
 
       # Default sort should be whatever is passed in
       sort = options[:sort]
+      # Cursor should always be an array regardless
+      cursorValues = Array.wrap(options.dig(:page, :cursor))
 
       # Cursor nav use the search after, this should always be an array of values that match the sort.
       if options.dig(:page, :cursor).present?
         from = 0
-        search_after = Array.wrap(options.dig(:page, :cursor))
+        search_after = cursorValues
       else
         from = ((options.dig(:page, :number) || 1) - 1) * (options.dig(:page, :size) || 25)
         search_after = nil
@@ -115,15 +117,15 @@ module Indexable
 
       # Calculate cursor sort based upon the type of model
       # Cursor sorts override any option sort
-      if self.name == "Doi" && !options.dig(:page, :cursor).nil?
+      if self.name == "Doi" && cursorValues
         sort = [{ created: "asc", doi: "asc"}]
-      elsif self.name == "Event" && !options.dig(:page, :cursor).nil?
+      elsif self.name == "Event" && cursorValues
         sort = [{ created_at: "asc", uuid: "asc"}]
-      elsif self.name == "Activity" && !options.dig(:page, :cursor).nil?
+      elsif self.name == "Activity" && cursorValues
         sort = [{ created: { order: 'asc' }}]
-      elsif self.name == "Researcher" && !options.dig(:page, :cursor).nil?
+      elsif self.name == "Researcher" && cursorValues
         sort = [{ created_at: "asc", uid: "asc"}]
-      elsif !options.dig(:page, :cursor).nil?
+      elsif cursorValues
         sort = [{ created: { order: 'asc' }}]
       else
         sort = options[:sort]

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -118,11 +118,11 @@ module Indexable
       if self.name == "Doi" && !options.dig(:page, :cursor).nil?
         sort = [{ created: "asc", doi: "asc"}]
       elsif self.name == "Event" && !options.dig(:page, :cursor).nil?
-        sort = [{ _id: { order: 'asc' }}]
+        sort = [{ created_at: "asc", uuid: "asc"}]
       elsif self.name == "Activity" && !options.dig(:page, :cursor).nil?
         sort = [{ created: { order: 'asc' }}]
       elsif self.name == "Researcher" && !options.dig(:page, :cursor).nil?
-        sort = [{ created_at: { order: 'asc' }}]
+        sort = [{ created_at: "asc", uid: "asc"}]
       elsif !options.dig(:page, :cursor).nil?
         sort = [{ created: { order: 'asc' }}]
       else

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -101,30 +101,31 @@ module Indexable
       options[:page][:number] ||= 1
       options[:page][:size] ||= 25
 
-      # enable cursor-based pagination for DOIs
-      if self.name == "Doi" && options.dig(:page, :cursor).present?
+      # Default sort should be whatever is passed in
+      sort = options[:sort]
+
+      # Cursor nav use the search after, this should always be an array of values that match the sort.
+      if options.dig(:page, :cursor).present?
         from = 0
         search_after = Array.wrap(options.dig(:page, :cursor))
-        sort = [{ created: "asc", doi: "asc"}]
-      elsif self.name == "Event" && options.dig(:page, :cursor).present?
-        from = 0
-        search_after = [options.dig(:page, :cursor)]
-        sort = [{ _id: { order: 'asc' }}]
-      elsif self.name == "Activity" && options.dig(:page, :cursor).present?
-        from = 0
-        search_after = [options.dig(:page, :cursor)]
-        sort = [{ created: { order: 'asc' }}]
-      elsif self.name == "Researcher" && options.dig(:page, :cursor).present?
-        from = 0
-        search_after = [options.dig(:page, :cursor)]
-        sort = [{ created_at: { order: 'asc' }}]
-      elsif options.dig(:page, :cursor).present?
-        from = 0
-        search_after = [options.dig(:page, :cursor)]
-        sort = [{ created: { order: 'asc' }}]
       else
         from = ((options.dig(:page, :number) || 1) - 1) * (options.dig(:page, :size) || 25)
         search_after = nil
+      end
+
+      # Calculate cursor sort based upon the type of model
+      # Cursor sorts override any option sort
+      if self.name == "Doi" && !options.dig(:page, :cursor).nil?
+        sort = [{ created: "asc", doi: "asc"}]
+      elsif self.name == "Event" && !options.dig(:page, :cursor).nil?
+        sort = [{ _id: { order: 'asc' }}]
+      elsif self.name == "Activity" && !options.dig(:page, :cursor).nil?
+        sort = [{ created: { order: 'asc' }}]
+      elsif self.name == "Researcher" && !options.dig(:page, :cursor).nil?
+        sort = [{ created_at: { order: 'asc' }}]
+      elsif !options.dig(:page, :cursor).nil?
+        sort = [{ created: { order: 'asc' }}]
+      else
         sort = options[:sort]
       end
 

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -104,8 +104,8 @@ module Indexable
       # enable cursor-based pagination for DOIs
       if self.name == "Doi" && options.dig(:page, :cursor).present?
         from = 0
-        search_after = [options.dig(:page, :cursor)]
-        sort = [{ _id: { order: 'asc' }}]
+        search_after = Array.wrap(options.dig(:page, :cursor))
+        sort = [{ created: "asc", doi: "asc"}]
       elsif self.name == "Event" && options.dig(:page, :cursor).present?
         from = 0
         search_after = [options.dig(:page, :cursor)]
@@ -205,7 +205,7 @@ module Indexable
         must << { terms: { relation_type_id: options[:relation_type_id].split(",") }} if options[:relation_type_id].present?
         must << { terms: { registrant_id: options[:registrant_id].split(",") }} if options[:registrant_id].present?
         must << { terms: { registrant_id: options[:provider_id].split(",") }} if options[:provider_id].present?
-        must << { terms: { issn: options[:issn].split(",") }} if options[:issn].present?  
+        must << { terms: { issn: options[:issn].split(",") }} if options[:issn].present?
       end
 
       # ES query can be optionally defined in different ways
@@ -290,7 +290,7 @@ module Indexable
 
     def update_aliases(old_index: nil, new_index: nil)
       return nil unless old_index.present? && new_index.present?
-      
+
       client     = self.gateway.client
       index_name = self.index_name
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -207,7 +207,7 @@ class Event < ActiveRecord::Base
   # return results for one or more ids
   def self.find_by_id(ids, options={})
     ids = ids.split(",") if ids.is_a?(String)
-    
+
     options[:page] ||= {}
     options[:page][:number] ||= 1
     options[:page][:size] ||= 1000
@@ -283,9 +283,9 @@ class Event < ActiveRecord::Base
     logger = Logger.new(STDOUT)
 
     size = (options[:size] || 1000).to_i
-    cursor = (options[:cursor] || 0).to_i
+    cursor = [(options[:cursor] || [])]
 
-    response = Event.query(nil, source_id: "crossref", page: { size: 1, cursor: cursor })
+    response = Event.query(nil, source_id: "crossref", page: { size: 1, cursor: [] })
     logger.info "[Update] #{response.results.total} events for source crossref."
 
     # walk through results using cursor
@@ -294,8 +294,8 @@ class Event < ActiveRecord::Base
         response = Event.query(nil, source_id: "crossref", page: { size: size, cursor: cursor })
         break unless response.results.results.length > 0
 
-        logger.info "[Update] Updating #{response.results.results.length} crossref events starting with _id #{cursor + 1}."
-        cursor = response.results.to_a.last[:sort].first.to_i
+        logger.info "[Update] Updating #{response.results.results.length} crossref events starting with _id #{response.results.to_a.first[:_id]}."
+        cursor = response.results.to_a.last[:sort]
 
         dois = response.results.results.map(&:subj_id).uniq
         CrossrefDoiJob.perform_later(dois)
@@ -341,7 +341,7 @@ class Event < ActiveRecord::Base
     logger = Logger.new(STDOUT)
 
     size = (options[:size] || 1000).to_i
-    cursor = (options[:cursor] || 0).to_i
+    cursor = (options[:cursor] || [])
     ra = options[:ra] || "crossref"
     source_id = "datacite-#{ra}"
 
@@ -354,11 +354,11 @@ class Event < ActiveRecord::Base
         response = Event.query(nil, source_id: source_id, page: { size: size, cursor: cursor })
         break unless response.results.results.length > 0
 
-        logger.info "[Update] Updating #{response.results.results.length} #{source_id} events starting with _id #{cursor + 1}."
-        cursor = response.results.to_a.last[:sort].first.to_i
+        logger.info "[Update] Updating #{response.results.results.length} #{source_id} events starting with _id #{response.results.to_a.first[:_id]}."
+        cursor = response.results.to_a.last[:sort]
 
         dois = response.results.results.map(&:obj_id).uniq
-        
+
         # use same jobs as for crossref dois
         CrossrefDoiJob.perform_later(dois, options)
       end
@@ -371,7 +371,7 @@ class Event < ActiveRecord::Base
     logger = Logger.new(STDOUT)
 
     size = (options[:size] || 1000).to_i
-    cursor = (options[:cursor] || 0).to_i
+    cursor = (options[:cursor] || []).to_i
 
     response = Event.query(nil, source_id: "datacite-orcid-auto-update", page: { size: 1, cursor: cursor })
     logger.info "[Update] #{response.results.total} events for source datacite-orcid-auto-update."
@@ -382,7 +382,7 @@ class Event < ActiveRecord::Base
         response = Event.query(nil, source_id: "datacite-orcid-auto-update", page: { size: size, cursor: cursor })
         break unless response.results.results.length > 0
 
-        logger.info "[Update] Updating #{response.results.results.length} datacite-orcid-auto-update events starting with _id #{cursor + 1}."
+        logger.info "[Update] Updating #{response.results.results.length} datacite-orcid-auto-update events starting with _id #{response.results.to_a.first[:_id]}."
         cursor = response.results.to_a.last[:sort].first.to_i
 
         ids = response.results.results.map(&:obj_id).uniq

--- a/spec/concerns/indexable_spec.rb
+++ b/spec/concerns/indexable_spec.rb
@@ -70,6 +70,7 @@ describe "Indexable class methods", elasticsearch: true do
 
   context "doi" do
     let!(:doi) { create(:doi, titles: { title: "Soil investigations" }, publisher: "Pangaea", descriptions: { description: "this is a description" }, aasm_state: "findable") }
+    let!(:dois) { create_list(:doi, 3, aasm_state: "findable") }
 
     before do
       Doi.import
@@ -104,6 +105,18 @@ describe "Indexable class methods", elasticsearch: true do
     it 'query by description not found' do
       results = Doi.query("climate").results
       expect(results.total).to eq(0)
+    end
+
+    it 'query with cursor navigation' do
+      results = Doi.query(nil, page: { size: 2, cursor: [] }).results
+      expect(results.total).to eq(4)
+
+      # Initial length should match the size
+      expect(results.to_a.length).to eq(2)
+
+      # Move onto next based on search_after
+      results = Doi.query(nil, page: { size: 1, cursor: results.to_a.last[:sort] }).results
+      expect(results.to_a.length).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Related to #307

This means sort orders won't work when cursor specified.

We keep intact existing API that "cursor=1" initiates a cursor query, even though it wont be used in any search results.