### PR TITLE
adding filtered aggregations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
 - 2.4.4
 sudo: required
-dist: trusty
+dist: xenial
 
 services:
   - mysql
@@ -12,13 +12,6 @@ services:
 addons:
   code_climate:
     repo_token: $CODECLIMATE_REPO_TOKEN
-  apt:
-    packages:
-      - oracle-java9-set-default
-      - mysql-server
-      - mysql-client
-    sources:
-      - mysql-5.7-trusty
 
 before_install:
   - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.3.2.deb

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -105,6 +105,7 @@ class EventsController < ApplicationController
                              occurred_at: params[:occurred_at],
                              year_month: params[:year_month],
                              unique: params[:unique],
+                             aggregations: params[:aggregations],
                              page: page,
                              sort: sort)
     end
@@ -113,16 +114,18 @@ class EventsController < ApplicationController
     total_for_pages = page[:cursor].nil? ? total.to_f : [total.to_f, 10000].min
     total_pages = page[:size] > 0 ? (total_for_pages / page[:size]).ceil : 0
 
-    sources = total.positive? ? facet_by_source(response.response.aggregations.sources.buckets) : nil
-    prefixes = total.positive? ? facet_by_source(response.response.aggregations.prefixes.buckets) : nil
-    citation_types = total.positive? ? facet_by_citation_type(response.response.aggregations.citation_types.buckets) : nil
-    relation_types = total.positive? ? facet_by_relation_type(response.response.aggregations.relation_types.buckets) : nil
-    registrants = total.positive? && params[:extra] ? facet_by_registrants(response.response.aggregations.registrants.buckets) : nil
-    pairings = total.positive? && params[:extra] ? facet_by_pairings(response.response.aggregations.pairings.buckets) : nil
-    dois = total.positive? && params[:extra] ? facet_by_dois(response.response.aggregations.dois.buckets) : nil
-    dois_usage = total.positive? && params[:extra] ? facet_by_dois(response.response.aggregations.dois_usage.dois.buckets) : nil
-    dois_citations = total.positive? && params[:extra] ? facet_citations_by_year(response.response.aggregations.dois_citations) : nil
-    # unique_citations = total.positive? && params[:extra] ? facet_citations_by_dois(response.response.aggregations.unique_citations.dois.buckets) : nil
+    aggregations = params.fetch(:aggregations,"").nil? ? "" : params.fetch(:aggregations,"")
+
+    sources = total.positive? && aggregations.blank? || aggregations.include?("query_aggregations") ? facet_by_source(response.response.aggregations.sources.buckets) : nil
+    prefixes = total.positive? && aggregations.blank?  || aggregations.include?("query_aggregations") ? facet_by_source(response.response.aggregations.prefixes.buckets) : nil
+    citation_types = total.positive? && aggregations.blank?  || aggregations.include?("query_aggregations") ? facet_by_citation_type(response.response.aggregations.citation_types.buckets) : nil
+    relation_types = total.positive? && aggregations.blank? || aggregations.include?("query_aggregations")  ? facet_by_relation_type(response.response.aggregations.relation_types.buckets) : nil
+    registrants = total.positive? && aggregations.include?("advanced_aggregations")  ? facet_by_registrants(response.response.aggregations.registrants.buckets) : nil
+    pairings = total.positive? && aggregations.include?("advanced_aggregations") ? facet_by_pairings(response.response.aggregations.pairings.buckets) : nil
+    dois = total.positive? && aggregations.include?("metrics_aggregations") ? facet_by_dois(response.response.aggregations.dois.buckets) : nil
+    dois_usage = total.positive? && aggregations.include?("metrics_aggregations") ? facet_by_dois(response.response.aggregations.dois_usage.dois.buckets) : nil
+    dois_citations = total.positive? && aggregations.include?("metrics_aggregations") ? facet_citations_by_year(response.response.aggregations.dois_citations) : nil
+    # unique_citations = total.positive? && aggregations.include?("metrics_aggregations") ? facet_citations_by_dois(response.response.aggregations.unique_citations.dois.buckets) : nil
  
     results = response.results
 

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -99,7 +99,7 @@ module Indexable
       return send(:query_aggregations) if aggregations.blank?
       aggs = {}
       aggregations.split(",").each do |agg|
-        agg = :query_aggregations if agg.blank?
+        agg = :query_aggregations if agg.blank? || !respond_to?(agg)
         aggs.merge! send(agg)
       end
       aggs

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -95,8 +95,19 @@ module Indexable
       })
     end
 
+    def get_aggregations_hash(aggregations="")
+      return send(:query_aggregations) if aggregations.blank?
+      aggs = {}
+      aggregations.split(",").each do |agg|
+        agg = :query_aggregations if agg.blank?
+        aggs.merge! send(agg)
+      end
+      aggs
+    end
+  
+
     def query(query, options={})
-      aggregations = options[:totals_agg] == true ? totals_aggregations : query_aggregations
+      aggregations = options[:totals_agg] == true ? totals_aggregations : get_aggregations_hash(options[:aggregations])
       options[:page] ||= {}
       options[:page][:number] ||= 1
       options[:page][:size] ||= 25

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -180,6 +180,23 @@ class Event < ActiveRecord::Base
       }
     }
 
+    {
+      sources: { terms: { field: 'source_id', size: 50, min_doc_count: 1 } },
+      prefixes: { terms: { field: 'prefix', size: 50, min_doc_count: 1 } },
+      citation_types: { terms: { field: 'citation_type', size: 50, min_doc_count: 1 }, aggs: { year_months: { date_histogram: { field: 'occurred_at', interval: 'month', min_doc_count: 1 }, aggs: { "total_by_year_month" => { sum: { field: 'total' }}}}} },
+      relation_types: { terms: { field: 'relation_type_id', size: 50, min_doc_count: 1 }, aggs: { year_months: { date_histogram: { field: 'occurred_at', interval: 'month', min_doc_count: 1 }, aggs: { "total_by_year_month" => { sum: { field: 'total' }}}},"sum_distribution"=>sum_distribution} },
+      dois: { terms: { field: 'obj_id', size: 50, min_doc_count: 1 }, aggs: { relation_types: { terms: { field: 'relation_type_id',size: 50, min_doc_count: 1 }, aggs: { "total_by_type" => { sum: { field: 'total' }}}}} }
+    }
+  end
+
+  def self.advanced_aggregations 
+    {
+      registrants: { terms: { field: 'registrant_id', size: 50, min_doc_count: 1 }, aggs: { year: { date_histogram: { field: 'occurred_at', interval: 'year', min_doc_count: 1 }, aggs: { "total_by_year" => { sum: { field: 'total' }}}}} },
+      pairings: { terms: { field: 'registrant_id', size: 50, min_doc_count: 1 }, aggs: { recipient: { terms: { field: 'registrant_id', size: 50, min_doc_count: 1 }, aggs: { "total" => { sum: { field: 'total' }}}}} }
+    }
+  end
+
+  def self.metrics_aggregations 
     sum_year_distribution = {
       sum_bucket: {
         buckets_path: "years>total_by_year"
@@ -187,12 +204,6 @@ class Event < ActiveRecord::Base
     }
 
     {
-      sources: { terms: { field: 'source_id', size: 50, min_doc_count: 1 } },
-      prefixes: { terms: { field: 'prefix', size: 50, min_doc_count: 1 } },
-      registrants: { terms: { field: 'registrant_id', size: 50, min_doc_count: 1 }, aggs: { year: { date_histogram: { field: 'occurred_at', interval: 'year', min_doc_count: 1 }, aggs: { "total_by_year" => { sum: { field: 'total' }}}}} },
-      pairings: { terms: { field: 'registrant_id', size: 50, min_doc_count: 1 }, aggs: { recipient: { terms: { field: 'registrant_id', size: 50, min_doc_count: 1 }, aggs: { "total" => { sum: { field: 'total' }}}}} },
-      citation_types: { terms: { field: 'citation_type', size: 50, min_doc_count: 1 }, aggs: { year_months: { date_histogram: { field: 'occurred_at', interval: 'month', min_doc_count: 1 }, aggs: { "total_by_year_month" => { sum: { field: 'total' }}}}} },
-      relation_types: { terms: { field: 'relation_type_id', size: 50, min_doc_count: 1 }, aggs: { year_months: { date_histogram: { field: 'occurred_at', interval: 'month', min_doc_count: 1 }, aggs: { "total_by_year_month" => { sum: { field: 'total' }}}},"sum_distribution"=>sum_distribution} },
       dois: { terms: { field: 'obj_id', size: 50, min_doc_count: 1 }, aggs: { relation_types: { terms: { field: 'relation_type_id',size: 50, min_doc_count: 1 }, aggs: { "total_by_type" => { sum: { field: 'total' }}}}} },
       dois_usage: {
         filter: { script: { script: "doc['source_id'].value == 'datacite-usage' && doc['occurred_at'].value.getMillis() >= doc['obj.datePublished'].value.getMillis() && doc['occurred_at'].value.getMillis() < new Date().getTime()" }},
@@ -206,19 +217,20 @@ class Event < ActiveRecord::Base
           }
         },
         aggs: { years: { date_histogram: { field: 'occurred_at', interval: 'year', min_doc_count: 1 }, aggs: { "total_by_year" => { sum: { field: 'total' }}}},"sum_distribution"=>sum_year_distribution}
-      # },
-      # unique_citations: {
-      #   filter: {
-      #     script: {
-      #       script: "#{INCLUDED_RELATION_TYPES}.contains(doc['relation_type_id'].value)"
-      #     }
-      #   },
-      #   aggs: { dois: {
-      #      terms: { field: 'obj_id', size: 50, min_doc_count: 1 }, aggs: { unique_citations: { cardinality: { field: 'citation_id' }}}
-      #   }}
+      },
+      unique_citations: {
+        filter: {
+          script: {
+            script: "#{INCLUDED_RELATION_TYPES}.contains(doc['relation_type_id'].value)"
+          }
+        },
+        aggs: { dois: {
+           terms: { field: 'obj_id', size: 50, min_doc_count: 1 }, aggs: { unique_citations: { cardinality: { field: 'citation_id' }}}
+        } }
       }
     }
   end
+
 
   # return results for one or more ids
   def self.find_by_id(ids, options={})

--- a/spec/concerns/indexable_spec.rb
+++ b/spec/concerns/indexable_spec.rb
@@ -100,6 +100,10 @@ describe "Indexable class methods", elasticsearch: true do
     it 'query by description' do
       results = Doi.query("description").results
       expect(results.total).to eq(1)
+      expect(results.response.aggregations.states).not_to be_nil
+      expect(results.response.aggregations.prefixes).not_to be_nil
+      expect(results.response.aggregations.created).not_to be_nil
+      expect(results.response.aggregations.schema_versions).not_to be_nil
     end
 
     it 'query by description not found' do
@@ -118,5 +122,62 @@ describe "Indexable class methods", elasticsearch: true do
       results = Doi.query(nil, page: { size: 1, cursor: results.to_a.last[:sort] }).results
       expect(results.to_a.length).to eq(1)
     end
+
+    context "aggregations" do
+      it 'returns query_aggregation when filters aggregation with empty' do
+        aggregations = Doi.get_aggregations_hash("")
+        expect(aggregations[:resource_types]).not_to be_nil
+        expect(aggregations[:states]).not_to be_nil
+        expect(aggregations[:created]).not_to be_nil
+        expect(aggregations[:schema_versions]).not_to be_nil
+      end
+  
+      it 'returns multiple aggregations when filters aggregations with multiple' do
+        aggregations = Doi.get_aggregations_hash("query_aggregations,metrics_aggregations")
+        expect(aggregations[:resource_types]).not_to be_nil
+        expect(aggregations[:states]).not_to be_nil
+        expect(aggregations[:created]).not_to be_nil
+        expect(aggregations[:schema_versions]).not_to be_nil
+      end
+    end
   end
+
+  context "when event" do
+    let!(:event) { create(:event) }
+    let!(:events) { create_list(:event, 3) }
+
+    before do
+      Event.import
+      sleep 1
+    end
+
+    context "aggregations" do
+      it 'returns query_aggregation when filters aggregation with empty' do
+        aggregations = Event.get_aggregations_hash("")
+        expect(aggregations[:sources]).not_to be_nil
+        expect(aggregations[:prefixes]).not_to be_nil
+        expect(aggregations[:citation_types]).not_to be_nil
+        expect(aggregations[:relation_types]).not_to be_nil
+        expect(aggregations[:registrants]).to be_nil
+        expect(aggregations[:pairings]).to be_nil
+        expect(aggregations[:dois_usage]).to be_nil
+
+      end
+  
+      it 'returns multiple aggregations when filters aggregations with multiple' do
+        aggregations = Event.get_aggregations_hash("query_aggregations,metrics_aggregations")
+        expect(aggregations[:sources]).not_to be_nil
+        expect(aggregations[:prefixes]).not_to be_nil
+        expect(aggregations[:citation_types]).not_to be_nil
+        expect(aggregations[:relation_types]).not_to be_nil
+        expect(aggregations[:registrants]).to be_nil
+        expect(aggregations[:pairings]).to be_nil
+        expect(aggregations[:dois]).not_to be_nil
+        expect(aggregations[:dois_usage]).not_to be_nil
+      end
+    end
+  end
+
 end
+
+


### PR DESCRIPTION
We are adding more and more aggregations to our endpoints. They have an impact in performance. We can make use of aggregation selector for specific use cases. For example, when we need them in Fabrica or in Search for citations

for example:

`/events` will give you all the normal aggregation we have

`/events?aggregations=metrics_aggregations` will give you the metrics aggregation but exclude the normal ones

`/events?aggregations=metrics_aggregations,query_aggregations` will give you both the metrics aggregations and the normal aggregations





