### PR TITLE
Remove support for single landingPage attribute with params.

### DIFF
--- a/app/controllers/dois_controller.rb
+++ b/app/controllers/dois_controller.rb
@@ -502,7 +502,6 @@ class DoisController < ApplicationController
       { dates: [:date, :dateType, :dateInformation] },
       :subjects,
       { subjects: [:subject, :subjectScheme, :schemeUri, :valueUri, :lang] },
-      :landingPage,
       {
         landingPage: [
           :checked,

--- a/spec/requests/dois_spec.rb
+++ b/spec/requests/dois_spec.rb
@@ -2379,6 +2379,13 @@ describe "dois", type: :request do
         expect(json.dig('data', 'attributes', 'landingPage')).to eq(landing_page)
         expect(json.dig('data', 'attributes', 'state')).to eq("findable")
       end
+
+      it 'fails to create a doi with bad data' do
+        valid_attributes['data']['attributes']['landingPage'] = "http://example.com"
+        post '/dois', valid_attributes.to_json, { 'HTTP_ACCEPT'=>'application/vnd.api+json', 'CONTENT_TYPE'=>'application/vnd.api+json', 'HTTP_AUTHORIZATION' => 'Bearer ' + bearer }
+
+        expect(last_response.status).to eq(422)
+      end
     end
 
     context 'update with landing page info as admin' do


### PR DESCRIPTION
Ref #325

I believe this is the correct way to remove singular arguments from safe_params but please say if not, I couldn't find the exact documentation for this.

In general this should all that's be needed because for the most part nobody should be updating this but us, but in event someone tries to it should deny them.