### PR TITLE
fix registrant_id indexing function

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -522,7 +522,7 @@ class Event < ActiveRecord::Base
   end
 
   def registrant_id
-    [subj["registrantId"], obj["registrantId"], subj["provider_id"], obj["provider_id"]].compact
+    [subj["registrant_id"], obj["registrant_id"], subj["provider_id"], obj["provider_id"]].compact
   end
 
   def subtype


### PR DESCRIPTION

Registrant aggregation is not showing full results:

![image](https://user-images.githubusercontent.com/1092861/62457854-edcce780-b77b-11e9-8b0e-910a46cdc765.png)


`ActiveModelSerializers::Deserialization.jsonapi_parse!` convert camelCase inputs into kebab_case and that's how they are saved into the database.

https://github.com/datacite/lupo/blob/2d51179c2ae0cdf0df16071f43dc5baed6e651ee/app/controllers/events_controller.rb#L231

Registrants are not being indexed because the function is looking for camelCase registrantId when in the database is kebab_Case registrant_id