### PR TITLE
obtain unique doi count

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -132,6 +132,8 @@ class EventsController < ApplicationController
     downloads_histogram = total.positive? && aggregations.include?("metrics_aggregations") ? facet_counts_by_year_month(response.response.aggregations.downloads_histogram) : nil
     views = total.positive? && aggregations.include?("metrics_aggregations") ? facet_by_source(response.response.aggregations.views.dois.buckets) : nil
     downloads = total.positive? && aggregations.include?("metrics_aggregations") ? facet_by_source(response.response.aggregations.downloads.dois.buckets) : nil
+    unique_obj_count = total.positive? && aggregations.include?("advanced_aggregations") ? response.response.aggregations.unique_obj_count.value : nil
+    unique_subj_count = total.positive? && aggregations.include?("advanced_aggregations") ? response.response.aggregations.unique_subj_count.value : nil
  
     results = response.results
 
@@ -151,6 +153,10 @@ class EventsController < ApplicationController
       "doisCitations": dois_citations,
       "citationsHistogram": citations_histogram,
       "uniqueCitations": citations,
+      "uniqueNodes": {
+        "objCount": unique_obj_count,
+        "subjCount": unique_subj_count
+      },
       "viewsHistogram": views_histogram,
       "views": views,
       "downloadsHistogram": downloads_histogram,

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -276,6 +276,13 @@ class Event < ActiveRecord::Base
   }
   end
 
+  def self.advanced_aggregations
+    {
+      unique_obj_count: { cardinality: { field: 'obj_id' }},
+      unique_subj_count: { cardinality: { field: 'subj_id' }}
+    }
+  end
+
   # return results for one or more ids
   def self.find_by_id(ids, options={})
     ids = ids.split(",") if ids.is_a?(String)


### PR DESCRIPTION
investigate the percentage of of missing Crossref DOI metadata in crossref.citations needed for: https://github.com/datacite/datacite/issues/785

with these two counters we can investigate how many *unique* Crossref DOI  we have in Eventdata, in order to calculate the percentage of metadat missin in crossref.citations