### PR TITLE
Bug incorrect ES mapping

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -120,7 +120,6 @@ class EventsController < ApplicationController
     registrants = total.positive? && aggregations.blank? || aggregations.include?("query_aggregations")  ? facet_by_registrants(response.response.aggregations.registrants.buckets) : nil
     pairings = total.positive? && aggregations.blank? || aggregations.include?("query_aggregations") ? facet_by_pairings(response.response.aggregations.pairings.buckets) : nil
     dois = total.positive? && aggregations.blank? || aggregations.include?("query_aggregations") ? facet_by_dois(response.response.aggregations.dois.buckets) : nil
-    dois_usage = total.positive? && aggregations.blank? || aggregations.include?("query_aggregations") ? facet_by_dois(response.response.aggregations.dois_usage.dois.buckets) : nil
     dois_citations = total.positive? && aggregations.blank? || aggregations.include?("query_aggregations") ? facet_citations_by_year_v1(response.response.aggregations.dois_citations) : nil
     citations_histogram = total.positive? && params[:doi].present? && aggregations.include?("citations_aggregations") ? facet_citations_by_year(response.response.aggregations.citations_histogram) : nil
     citations = total.positive? && params[:doi].present? &&  aggregations.include?("citations_aggregations") ? facet_citations_by_dois(response.response.aggregations.citations.dois.buckets) : nil
@@ -147,7 +146,6 @@ class EventsController < ApplicationController
       pairings: pairings,
       registrants: registrants,
       "doisRelationTypes": dois,
-      "doisUsageTypes": dois_usage,
       "doisCitations": dois_citations,
       "citationsHistogram": citations_histogram,
       "uniqueCitations": citations,

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Event < ActiveRecord::Base
   # include helper module for query caching
   include Cacheable
@@ -23,8 +25,8 @@ class Event < ActiveRecord::Base
   # include state machine
   include AASM
 
-  aasm :whiny_transitions => false do
-    state :waiting, :initial => true
+  aasm whiny_transitions: false do
+    state :waiting, initial: true
     state :working, :failed, :done
 
     # Reset after failure
@@ -67,7 +69,7 @@ class Event < ActiveRecord::Base
   ]
 
   ACTIVE_RELATION_TYPES = [
-    "cites", 
+    "cites",
     "is-supplement-to",
     "references"
   ]
@@ -117,18 +119,18 @@ class Event < ActiveRecord::Base
       type: { type: :keyword },
       id: { type: :keyword },
       uid: { type: :keyword },
-      proxyIdentifiers: { type: :keyword },
-      datePublished: { type: :date, format: "date_optional_time||yyyy-MM-dd||yyyy-MM||yyyy", ignore_malformed: true },
-      registrantId: { type: :keyword },
+      proxy_identifiers: { type: :keyword },
+      date_published: { type: :date, format: "date_optional_time||yyyy-MM-dd||yyyy-MM||yyyy", ignore_malformed: true },
+      registrant_id: { type: :keyword },
       cache_key: { type: :keyword }
     }
     indexes :obj,               type: :object, properties: {
       type: { type: :keyword },
       id: { type: :keyword },
       uid: { type: :keyword },
-      proxyIdentifiers: { type: :keyword },
-      datePublished: { type: :date, format: "date_optional_time||yyyy-MM-dd||yyyy-MM||yyyy", ignore_malformed: true },
-      registrantId: { type: :keyword },
+      proxy_identifiers: { type: :keyword },
+      date_published: { type: :date, format: "date_optional_time||yyyy-MM-dd||yyyy-MM||yyyy", ignore_malformed: true },
+      registrant_id: { type: :keyword },
       cache_key: { type: :keyword }
     }
     indexes :source_id,        type: :keyword
@@ -139,7 +141,7 @@ class Event < ActiveRecord::Base
     indexes :access_method,    type: :keyword
     indexes :metric_type,      type: :keyword
     indexes :total,            type: :integer
-    indexes :license,          type: :text, fields: { keyword: { type: "keyword" }}
+    indexes :license,          type: :text, fields: { keyword: { type: "keyword" } }
     indexes :error_messages,   type: :object
     indexes :callback,         type: :text
     indexes :aasm_state,       type: :keyword
@@ -154,7 +156,7 @@ class Event < ActiveRecord::Base
     indexes :cache_key,        type: :keyword
   end
 
-  def as_indexed_json(options={})
+  def as_indexed_json(options = {})
     {
       "uuid" => uuid,
       "subj_id" => subj_id,
@@ -195,10 +197,10 @@ class Event < ActiveRecord::Base
   end
 
   def self.query_fields
-    ['subj_id^10', 'obj_id^10', 'subj.name^5', 'subj.author^5', 'subj.periodical^5', 'subj.publisher^5', 'obj.name^5', 'obj.author^5', 'obj.periodical^5', 'obj.publisher^5', '_all']
+    ["subj_id^10", "obj_id^10", "subj.name^5", "subj.author^5", "subj.periodical^5", "subj.publisher^5", "obj.name^5", "obj.author^5", "obj.periodical^5", "obj.publisher^5", "_all"]
   end
 
-  def self.query_aggregations(doi=nil) 
+  def self.query_aggregations(doi = nil)
     sum_distribution = {
       sum_bucket: {
         buckets_path: "year_months>total_by_year_month"
@@ -212,25 +214,20 @@ class Event < ActiveRecord::Base
     }
 
     {
-      sources: { terms: { field: 'source_id', size: 50, min_doc_count: 1 } },
-      prefixes: { terms: { field: 'prefix', size: 50, min_doc_count: 1 } },
-      registrants: { terms: { field: 'registrant_id', size: 50, min_doc_count: 1 }, aggs: { year: { date_histogram: { field: 'occurred_at', interval: 'year', min_doc_count: 1 }, aggs: { "total_by_year" => { sum: { field: 'total' }}}}} },
-      pairings: { terms: { field: 'registrant_id', size: 50, min_doc_count: 1 }, aggs: { recipient: { terms: { field: 'registrant_id', size: 50, min_doc_count: 1 }, aggs: { "total" => { sum: { field: 'total' }}}}} },
-      citation_types: { terms: { field: 'citation_type', size: 50, min_doc_count: 1 }, aggs: { year_months: { date_histogram: { field: 'occurred_at', interval: 'month', min_doc_count: 1 }, aggs: { "total_by_year_month" => { sum: { field: 'total' }}}}} },
-      relation_types: { terms: { field: 'relation_type_id', size: 50, min_doc_count: 1 }, aggs: { year_months: { date_histogram: { field: 'occurred_at', interval: 'month', min_doc_count: 1 }, aggs: { "total_by_year_month" => { sum: { field: 'total' }}}},"sum_distribution"=>sum_distribution} },
-      dois: { terms: { field: 'obj_id', size: 50, min_doc_count: 1 }, aggs: { relation_types: { terms: { field: 'relation_type_id',size: 50, min_doc_count: 1 }, aggs: { "total_by_type" => { sum: { field: 'total' }}}}} },
-      dois_usage: {
-        filter: { script: { script: "doc['source_id'].value == 'datacite-usage' && doc['occurred_at'].size() > 0 && doc['obj.datePublished'].size() > 0 && doc['occurred_at'].value.getMillis() >= doc['obj.datePublished'].value.getMillis() && doc['occurred_at'].value.getMillis() < new Date().getTime()" }},
-        aggs: {
-          dois: { terms: { field: 'obj_id', size: 50, min_doc_count: 1 }, aggs: { relation_types: { terms: { field: 'relation_type_id',size: 50, min_doc_count: 1 }, aggs: { "total_by_type" => { sum: { field: 'total' }}}}} } }
-      },
+      sources: { terms: { field: "source_id", size: 50, min_doc_count: 1 } },
+      prefixes: { terms: { field: "prefix", size: 50, min_doc_count: 1 } },
+      registrants: { terms: { field: "registrant_id", size: 50, min_doc_count: 1 }, aggs: { year: { date_histogram: { field: "occurred_at", interval: "year", min_doc_count: 1 }, aggs: { "total_by_year" => { sum: { field: "total" } } } } } },
+      pairings: { terms: { field: "registrant_id", size: 50, min_doc_count: 1 }, aggs: { recipient: { terms: { field: "registrant_id", size: 50, min_doc_count: 1 }, aggs: { "total" => { sum: { field: "total" } } } } } },
+      citation_types: { terms: { field: "citation_type", size: 50, min_doc_count: 1 }, aggs: { year_months: { date_histogram: { field: "occurred_at", interval: "month", min_doc_count: 1 }, aggs: { "total_by_year_month" => { sum: { field: "total" } } } } } },
+      relation_types: { terms: { field: "relation_type_id", size: 50, min_doc_count: 1 }, aggs: { year_months: { date_histogram: { field: "occurred_at", interval: "month", min_doc_count: 1 }, aggs: { "total_by_year_month" => { sum: { field: "total" } } } }, "sum_distribution" => sum_distribution } },
+      dois: { terms: { field: "obj_id", size: 50, min_doc_count: 1 }, aggs: { relation_types: { terms: { field: "relation_type_id", size: 50, min_doc_count: 1 }, aggs: { "total_by_type" => { sum: { field: "total" } } } } } },
       dois_citations: {
         filter: {
           script: {
             script: "#{INCLUDED_RELATION_TYPES}.contains(doc['relation_type_id'].value)"
           }
         },
-        aggs: { years: { date_histogram: { field: 'occurred_at', interval: 'year', min_doc_count: 1 }, aggs: { "total_by_year" => { sum: { field: 'total' }}}},"sum_distribution"=>sum_year_distribution}
+        aggs: { years: { date_histogram: { field: "occurred_at", interval: "year", min_doc_count: 1 }, aggs: { "total_by_year" => { sum: { field: "total" } } } }, "sum_distribution" => sum_year_distribution }
       }
     }
   end
@@ -241,39 +238,39 @@ class Event < ActiveRecord::Base
         buckets_path: "year_months>total_by_year_month"
       }
     }
- 
-    views_filter = { script: { script: "doc['relation_type_id'].value == 'unique-dataset-investigations-regular' && doc['source_id'].value == 'datacite-usage' && doc['occurred_at'].size() > 0 && doc['obj.datePublished'].size() > 0 && doc['occurred_at'].value.getMillis() >= doc['obj.datePublished'].value.getMillis() && doc['occurred_at'].value.getMillis() < new Date().getTime()" } }
-    downloads_filter = { script: { script: "doc['relation_type_id'].value == 'unique-dataset-requests-regular' && doc['source_id'].value == 'datacite-usage' && doc['occurred_at'].size() > 0 && doc['obj.datePublished'].size() > 0 && doc['occurred_at'].value.getMillis() >= doc['obj.datePublished'].value.getMillis() && doc['occurred_at'].value.getMillis() < new Date().getTime()" } }
+
+    views_filter = { script: { script: "(doc['relation_type_id'].value == 'unique-dataset-investigations-regular'  && doc['obj.date_published'].size() > 0 && doc['source_id'].value == 'datacite-usage' && doc['occurred_at'].value.toInstant().toEpochMilli() >= doc['obj.date_published'].value.toInstant().toEpochMilli() && doc['occurred_at'].value.toInstant().toEpochMilli() < new Date().getTime())" } }
+    downloads_filter = { script: { script: "doc['relation_type_id'].value == 'unique-dataset-requests-regular' && doc['obj.date_published'].size() > 0  && doc['source_id'].value == 'datacite-usage'  && doc['occurred_at'].value.toInstant().toEpochMilli() >= doc['obj.date_published'].value.toInstant().toEpochMilli() && doc['occurred_at'].value.toInstant().toEpochMilli() < new Date().getTime()" } }
 
    {
       views: {
         filter: views_filter,
         aggs: { dois: {
-          terms: { field: 'obj_id', size: 50, min_doc_count: 1 } , aggs: { "total_by_type" => { sum: { field: 'total' }}}
-        }}
+          terms: { field: "obj_id", size: 50, min_doc_count: 1 } , aggs: { "total_by_type" => { sum: { field: "total" } } }
+        } }
       },
       views_histogram: {
         filter: views_filter,
         aggs: {
-          year_months: { date_histogram: { field: 'occurred_at', interval: 'month', min_doc_count: 1 }, aggs: { "total_by_year_month" => { sum: { field: 'total' } } } }, "sum_distribution" => sum_distribution
+          year_months: { date_histogram: { field: "occurred_at", interval: "month", min_doc_count: 1 }, aggs: { "total_by_year_month" => { sum: { field: "total" } } } }, "sum_distribution" => sum_distribution
         }
       },
       downloads: {
         filter: downloads_filter,
         aggs: { dois: {
-          terms: { field: 'obj_id', size: 50, min_doc_count: 1} , aggs: { "total_by_type" => { sum: { field: 'total' }}}
-        }}
+          terms: { field: "obj_id", size: 50, min_doc_count: 1 } , aggs: { "total_by_type" => { sum: { field: "total" } } }
+        } }
       },
       downloads_histogram: {
         filter: downloads_filter,
         aggs: {
-          year_months: { date_histogram: { field: 'occurred_at', interval: 'month', min_doc_count: 1 }, aggs: { "total_by_year_month" => { sum: { field: 'total' } } } }, "sum_distribution" => sum_distribution
+          year_months: { date_histogram: { field: "occurred_at", interval: "month", min_doc_count: 1 }, aggs: { "total_by_year_month" => { sum: { field: "total" } } } }, "sum_distribution" => sum_distribution
         }
       }
     }
   end
 
-  def self.citations_aggregations(doi)  
+  def self.citations_aggregations(doi)
     doi = Event.new.normalize_doi(doi) if doi.present?
 
     sum_year_distribution = {
@@ -288,45 +285,45 @@ class Event < ActiveRecord::Base
     {
       citations_histogram: {
         filter: citations_filter,
-        aggs: { years: { histogram: { field: 'citation_year', interval: 1 , min_doc_count: 1 }, aggs: { "total_by_year" => { sum: { field: 'total' }}}}, "sum_distribution" => sum_year_distribution }
+        aggs: { years: { histogram: { field: "citation_year", interval: 1 , min_doc_count: 1 }, aggs: { "total_by_year" => { sum: { field: "total" } } } }, "sum_distribution" => sum_year_distribution }
       },
       citations: {
         filter: citations_filter,
         aggs: { dois: {
-          terms: { field: 'doi', size: 100, min_doc_count: 1 }, aggs: { total: { cardinality: { field: 'citation_id' }}}
-        }}
+          terms: { field: "doi", size: 100, min_doc_count: 1 }, aggs: { total: { cardinality: { field: "citation_id" } } }
+        } }
       },
       references: {
         filter: references_filter,
         aggs: { dois: {
-          terms: { field: 'doi', size: 100, min_doc_count: 1 }, aggs: { total: { cardinality: { field: 'citation_id' }}}
-        }}
+          terms: { field: "doi", size: 100, min_doc_count: 1 }, aggs: { total: { cardinality: { field: "citation_id" } } }
+        } }
       },
       relations: {
         filter: { script: { script: "#{RELATIONS_RELATION_TYPES}.contains(doc['relation_type_id'].value)" }
         },
         aggs: { dois: {
-          terms: { field: 'doi', size: 100, min_doc_count: 1 }, aggs: { total: { cardinality: { field: 'citation_id' }}}
-        }}
+          terms: { field: "doi", size: 100, min_doc_count: 1 }, aggs: { total: { cardinality: { field: "citation_id" } } }
+        } }
       }
-    } 
+    }
   end
 
-  def self.advanced_aggregations(doi=nil)
+  def self.advanced_aggregations(doi = nil)
     {
-      unique_obj_count: { cardinality: { field: 'obj_id' }},
-      unique_subj_count: { cardinality: { field: 'subj_id' }}
+      unique_obj_count: { cardinality: { field: "obj_id" } },
+      unique_subj_count: { cardinality: { field: "subj_id" } }
     }
   end
 
   # return results for one or more ids
-  def self.find_by_id(ids, options={})
+  def self.find_by_id(ids, options = {})
     ids = ids.split(",") if ids.is_a?(String)
 
     options[:page] ||= {}
     options[:page][:number] ||= 1
     options[:page][:size] ||= 1000
-    options[:sort] ||= { created_at: { order: "asc" }}
+    options[:sort] ||= { created_at: { order: "asc" } }
 
     __elasticsearch__.search({
       from: (options.dig(:page, :number) - 1) * options.dig(:page, :size),
@@ -341,7 +338,7 @@ class Event < ActiveRecord::Base
     })
   end
 
-  def self.import_by_ids(options={})
+  def self.import_by_ids(options = {})
     from_id = (options[:from_id] || Event.minimum(:id)).to_i
     until_id = (options[:until_id] || Event.maximum(:id)).to_i
 
@@ -352,7 +349,7 @@ class Event < ActiveRecord::Base
     end
   end
 
-  def self.import_by_id(options={})
+  def self.import_by_id(options = {})
     return nil unless options[:id].present?
 
     id = options[:id].to_i
@@ -369,8 +366,8 @@ class Event < ActiveRecord::Base
         body:    events.map { |event| { index: { _id: event.id, data: event.as_indexed_json } } }
 
       # log errors
-      errors += response['items'].map { |k, v| k.values.first['error'] }.compact.length
-      response['items'].select { |k, v| k.values.first['error'].present? }.each do |err|
+      errors += response["items"].map { |k, v| k.values.first["error"] }.compact.length
+      response["items"].select { |k, v| k.values.first["error"].present? }.each do |err|
         logger.error "[Elasticsearch] " + err.inspect
       end
 
@@ -395,7 +392,7 @@ class Event < ActiveRecord::Base
     logger.info "[Elasticsearch] Imported #{count} events with IDs #{id} - #{(id + 499)}."
   end
 
-  def self.update_crossref(options={})
+  def self.update_crossref(options = {})
     logger = Logger.new(STDOUT)
 
     size = (options[:size] || 1000).to_i
@@ -421,39 +418,39 @@ class Event < ActiveRecord::Base
     response.results.total
   end
 
-  def self.update_datacite_crossref(options={})
+  def self.update_datacite_crossref(options = {})
     update_datacite_ra(options.merge(ra: "crossref"))
   end
 
-  def self.update_datacite_medra(options={})
+  def self.update_datacite_medra(options = {})
     update_datacite_ra(options.merge(ra: "medra"))
   end
 
-  def self.update_datacite_kisti(options={})
+  def self.update_datacite_kisti(options = {})
     update_datacite_ra(options.merge(ra: "kisti"))
   end
 
-  def self.update_datacite_jalc(options={})
+  def self.update_datacite_jalc(options = {})
     update_datacite_ra(options.merge(ra: "jalc"))
   end
 
-  def self.update_datacite_op(options={})
+  def self.update_datacite_op(options = {})
     update_datacite_ra(options.merge(ra: "op"))
   end
 
-  def self.update_datacite_medra(options={})
+  def self.update_datacite_medra(options = {})
     update_datacite_ra(options.merge(ra: "medra"))
   end
 
-  def self.update_datacite_medra(options={})
+  def self.update_datacite_medra(options = {})
     update_datacite_ra(options.merge(ra: "medra"))
   end
 
-  def self.update_datacite_medra(options={})
+  def self.update_datacite_medra(options = {})
     update_datacite_ra(options.merge(ra: "medra"))
   end
 
-  def self.update_datacite_ra(options={})
+  def self.update_datacite_ra(options = {})
     logger = Logger.new(STDOUT)
 
     size = (options[:size] || 1000).to_i
@@ -483,7 +480,7 @@ class Event < ActiveRecord::Base
     response.results.total
   end
 
-  def self.update_registrant(options={})
+  def self.update_registrant(options = {})
     logger = Logger.new(STDOUT)
 
     size = (options[:size] || 1000).to_i
@@ -514,7 +511,7 @@ class Event < ActiveRecord::Base
     response.results.total
   end
 
-  def self.update_datacite_orcid_auto_update(options={})
+  def self.update_datacite_orcid_auto_update(options = {})
     logger = Logger.new(STDOUT)
 
     size = (options[:size] || 1000).to_i
@@ -553,8 +550,8 @@ class Event < ActiveRecord::Base
                "messageAction" => message_action,
                "sourceToken" => source_token,
                "total" => total,
-               "timestamp" => timestamp }}
-    Maremma.post(callback, data: data.to_json, token: ENV['API_KEY'])
+               "timestamp" => timestamp } }
+    Maremma.post(callback, data: data.to_json, token: ENV["API_KEY"])
   end
 
   def access_method
@@ -579,7 +576,7 @@ class Event < ActiveRecord::Base
   end
 
   def prefix
-    [doi.map { |d| d.to_s.split('/', 2).first }].compact
+    [doi.map { |d| d.to_s.split("/", 2).first }].compact
   end
 
   def orcid
@@ -612,7 +609,7 @@ class Event < ActiveRecord::Base
   def doi_from_url(url)
     if /\A(?:(http|https):\/\/(dx\.)?(doi.org|handle.test.datacite.org)\/)?(doi:)?(10\.\d{4,5}\/.+)\z/.match(url)
       uri = Addressable::URI.parse(url)
-      uri.path.gsub(/^\//, '').downcase
+      uri.path.gsub(/^\//, "").downcase
     end
   end
 
@@ -644,16 +641,16 @@ class Event < ActiveRecord::Base
   end
 
   def citation_year
-    "" unless (INCLUDED_RELATION_TYPES+RELATIONS_RELATION_TYPES).include?(relation_type_id)
-    subj_publication = subj['date_published'] || (date_published(subj_id) || year_month)
-    obj_publication =  obj['date_published']  || (date_published(obj_id) || year_month)
+    "" unless (INCLUDED_RELATION_TYPES + RELATIONS_RELATION_TYPES).include?(relation_type_id)
+    subj_publication = subj["date_published"] || (date_published(subj_id) || year_month)
+    obj_publication =  obj["date_published"]  || (date_published(obj_id) || year_month)
     [subj_publication[0..3].to_i, obj_publication[0..3].to_i].max
   end
 
   def date_published(doi)
-    ## TODO: we need to make sure all the dois from other RA are indexed 
+    ## TODO: we need to make sure all the dois from other RA are indexed
     item = Doi.where(doi: doi_from_url(doi)).first
-    item[:publication_year].to_s if item.present? 
+    item[:publication_year].to_s if item.present?
   end
 
   def set_defaults

--- a/spec/concerns/indexable_spec.rb
+++ b/spec/concerns/indexable_spec.rb
@@ -161,7 +161,7 @@ describe "Indexable class methods", elasticsearch: true do
         expect(aggregations[:relation_types]).not_to be_nil
         expect(aggregations[:registrants]).not_to be_nil
         expect(aggregations[:pairings]).not_to be_nil
-        expect(aggregations[:dois_usage]).not_to be_nil
+        # expect(aggregations[:dois_usage]).not_to be_nil
         expect(aggregations[:citations_histogram]).to be_nil
         expect(aggregations[:citations]).to be_nil
       end
@@ -175,7 +175,7 @@ describe "Indexable class methods", elasticsearch: true do
         expect(aggregations[:registrants]).not_to be_nil
         expect(aggregations[:pairings]).not_to be_nil
         expect(aggregations[:dois]).not_to be_nil
-        expect(aggregations[:dois_usage]).not_to be_nil
+        # expect(aggregations[:dois_usage]).not_to be_nil
         expect(aggregations[:citations_histogram]).to be_nil
         expect(aggregations[:citations]).to be_nil
       end

--- a/spec/factories/default.rb
+++ b/spec/factories/default.rb
@@ -1,4 +1,6 @@
-require 'faker'
+# frozen_string_literal: true
+
+require "faker"
 
 FactoryBot.define do
   factory :user do
@@ -23,12 +25,12 @@ FactoryBot.define do
     end
 
     factory :valid_user do
-      uid { '0000-0001-6528-2027' }
-      orcid_token { ENV['ACCESS_TOKEN'] }
+      uid { "0000-0001-6528-2027" }
+      orcid_token { ENV["ACCESS_TOKEN"] }
     end
 
     factory :invalid_user do
-      uid { '0000-0001-6528-2027' }
+      uid { "0000-0001-6528-2027" }
       orcid_token { nil }
     end
 
@@ -239,7 +241,7 @@ FactoryBot.define do
 
   factory :provider do
     system_email { "josiah@example.org" }
-    sequence(:symbol, 'A') { |n| "TEST#{n}" }
+    sequence(:symbol, "A") { |n| "TEST#{n}" }
     name { "My provider" }
     display_name { "My provider" }
     website { Faker::Internet.url }
@@ -301,24 +303,24 @@ FactoryBot.define do
     association :provider, factory: :provider, strategy: :create
   end
 
-  factory :activity do  
+  factory :activity do
     association :doi, factory: :doi, strategy: :create
   end
 
-  factory :event do    
+  factory :event do
     uuid { SecureRandom.uuid }
     source_id { "citeulike" }
     source_token { "citeulike_123" }
     sequence(:subj_id) { |n| "http://www.citeulike.org/user/dbogartoit/#{n}" }
     obj_id { "http://doi.org/10.1371/journal.pmed.0030186" }
-    subj {{ "@id"=>"http://www.citeulike.org/user/dbogartoit",
-            "@type"=>"CreativeWork",
-            "uid"=>"http://www.citeulike.org/user/dbogartoit",
-            "author"=>[{ "given"=>"dbogartoit" }],
-            "name"=>"CiteULike bookmarks for user dbogartoit",
-            "publisher"=>"CiteULike",
-            "date-published"=>"2006-06-13T16:14:19Z",
-            "url"=>"http://www.citeulike.org/user/dbogartoit" }}
+    subj {{ "@id" => "http://www.citeulike.org/user/dbogartoit",
+            "@type" => "CreativeWork",
+            "uid" => "http://www.citeulike.org/user/dbogartoit",
+            "author" => [{ "given" => "dbogartoit" }],
+            "name" => "CiteULike bookmarks for user dbogartoit",
+            "publisher" => "CiteULike",
+            "datePublished" => "2006-06-13T16:14:19Z",
+            "url" => "http://www.citeulike.org/user/dbogartoit" }}
     obj {}
     relation_type_id { "bookmarks" }
     updated_at { Time.zone.now }
@@ -328,9 +330,35 @@ FactoryBot.define do
       source_id { "datacite_related" }
       source_token { "datacite_related_123" }
       sequence(:subj_id) { |n| "http://doi.org/10.5061/DRYAD.47SD5e/#{n}" }
-      subj { {"datePublished"=>"2006-06-13T16:14:19Z"} }
+      subj { { "datePublished" => "2006-06-13T16:14:19Z" } }
       obj_id { "http://doi.org/10.5061/DRYAD.47SD5/1" }
       relation_type_id { "references" }
+    end
+
+    factory :event_for_datacite_usage do
+      source_id { "datacite-usage" }
+      source_token { "5348967fhdjksr3wyui325" }
+      total { rand(1..100) }
+      sequence(:subj_id) { |n| "https://api.test.datacite.org/report/#{SecureRandom.uuid}" }
+      subj { { "datePublished" => "2006-06-13T16:14:19Z" } }
+      obj { { "date_published" => "2007-06-13T16:14:19Z" } }
+      # obj {}
+      obj_id { "http://doi.org/10.5061/DRYAD.47SD5/1" }
+      relation_type_id { "unique-dataset-investigations-regular" }
+      occurred_at { "2015-06-13T16:14:19Z" }
+    end
+
+    factory :event_for_datacite_usage_empty do
+      source_id { "datacite-usage" }
+      source_token { "5348967fhdjksr3wyui325" }
+      total { rand(1..100) }
+      sequence(:subj_id) { |n| "https://api.test.datacite.org/report/#{SecureRandom.uuid}" }
+      subj { { "datePublished" => "2006-06-13T16:14:19Z" } }
+      # obj { {"datePublished"=>"2007-06-13T16:14:19Z"} }
+      obj {}
+      obj_id { "http://doi.org/10.5061/DRYAD.47SD5/1" }
+      relation_type_id { "unique-dataset-investigations-regular" }
+      occurred_at { "2015-06-13T16:14:19Z" }
     end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -10,7 +10,7 @@ describe Event, :type => :model, vcr: true do
     it { is_expected.to validate_presence_of(:source_id) }
 
     it "has subj" do
-      expect(subject.subj["date-published"]).to eq("2006-06-13T16:14:19Z")
+      expect(subject.subj["datePublished"]).to eq("2006-06-13T16:14:19Z")
     end
   end
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require "rails_helper"
-require 'pp'
- 
+require "pp"
+
 
 describe "/events", type: :request, elasticsearch: true do
   before(:each) do
@@ -9,36 +11,36 @@ describe "/events", type: :request, elasticsearch: true do
   end
 
   let(:event) { build(:event) }
-  let(:errors) { [{ "status" => "401", "title"=>"Bad credentials."}] }
+  let(:errors) { [{ "status" => "401", "title" => "Bad credentials." }] }
 
   # Successful response from creating via the API.
   let(:success) { { "id" => event.uuid,
                     "type" => "events",
-                    "attributes"=>{
+                    "attributes" => {
                       "subjId" => "http://www.citeulike.org/user/dbogartoit",
                       "objId" => "http://doi.org/10.1371/journal.pmed.0030186",
-                      "messageAction"=>"create",
-                      "sourceToken"=>"citeulike_123",
-                      "relationTypeId"=>"bookmarks",
-                      "sourceId"=>"citeulike",
-                      "total"=>1,
-                      "license"=>"https://creativecommons.org/publicdomain/zero/1.0/",
-                      "occurredAt"=>"2015-04-08T00:00:00.000Z",
-                      "subj"=> {"@id"=>"http://www.citeulike.org/user/dbogartoit",
-                                "@type"=>"CreativeWork",
-                                "author"=>[{"givenName"=>"dbogartoit"}],
-                                "name"=>"CiteULike bookmarks for user dbogartoit",
-                                "publisher"=> { "@type" => "Organization", "name" => "CiteULike" },
-                                "periodical"=> { "@type" => "Periodical",  "@id" => "https://doi.org/10.13039/100011326", "name" => "CiteULike", "issn" => "9812-847X" },
-                                "funder"=> { "@type" => "Organization", "@id" => "https://doi.org/10.13039/100011326", "name" => "CiteULike" },
+                      "messageAction" => "create",
+                      "sourceToken" => "citeulike_123",
+                      "relationTypeId" => "bookmarks",
+                      "sourceId" => "citeulike",
+                      "total" => 1,
+                      "license" => "https://creativecommons.org/publicdomain/zero/1.0/",
+                      "occurredAt" => "2015-04-08T00:00:00.000Z",
+                      "subj" => { "@id" => "http://www.citeulike.org/user/dbogartoit",
+                                "@type" => "CreativeWork",
+                                "author" => [{ "givenName" => "dbogartoit" }],
+                                "name" => "CiteULike bookmarks for user dbogartoit",
+                                "publisher" => { "@type" => "Organization", "name" => "CiteULike" },
+                                "periodical" => { "@type" => "Periodical",  "@id" => "https://doi.org/10.13039/100011326", "name" => "CiteULike", "issn" => "9812-847X" },
+                                "funder" => { "@type" => "Organization", "@id" => "https://doi.org/10.13039/100011326", "name" => "CiteULike" },
                                 "version" => "1.0",
                                 "proxyIdentifiers" => ["10.13039/100011326"],
-                                "datePublished"=>"2006-06-13T16:14:19Z",
-                                "dateModified"=>"2006-06-13T16:14:19Z",
-                                "url"=>"http://www.citeulike.org/user/dbogartoit"
+                                "datePublished" => "2006-06-13T16:14:19Z",
+                                "dateModified" => "2006-06-13T16:14:19Z",
+                                "url" => "http://www.citeulike.org/user/dbogartoit"
                       },
-                      "obj"=>{}
-                    }}}
+                      "obj" => {}
+                    } }}
 
   let(:token) { User.generate_token(role_id: "staff_admin") }
   let(:uuid) { SecureRandom.uuid }
@@ -73,7 +75,7 @@ describe "/events", type: :request, elasticsearch: true do
     end
 
     context "with very long url" do
-      let(:url) {"http://navigator.eumetsat.int/soapservices/cswstartup?service=csw&version=2.0.2&request=getrecordbyid&outputschema=http%3A%2F%2Fwww.isotc211.org%2F2005%2Fgmd&id=eo%3Aeum%3Adat%3Amult%3Arac-m11-iasia"}
+      let(:url) { "http://navigator.eumetsat.int/soapservices/cswstartup?service=csw&version=2.0.2&request=getrecordbyid&outputschema=http%3A%2F%2Fwww.isotc211.org%2F2005%2Fgmd&id=eo%3Aeum%3Adat%3Amult%3Arac-m11-iasia" }
       let(:params) do
         { "data" => { "type" => "events",
                       "attributes" => {
@@ -102,7 +104,7 @@ describe "/events", type: :request, elasticsearch: true do
         post uri, params, headers
 
         expect(last_response.status).to eq(403)
-        expect(json["errors"]).to eq([{"status"=>"403", "title"=>"You are not authorized to access this resource."}])
+        expect(json["errors"]).to eq([{ "status" => "403", "title" => "You are not authorized to access this resource." }])
         expect(json["data"]).to be_nil
       end
     end
@@ -114,7 +116,7 @@ describe "/events", type: :request, elasticsearch: true do
         post uri, params, headers
 
         expect(last_response.status).to eq(403)
-        expect(json["errors"]).to eq([{"status"=>"403", "title"=>"You are not authorized to access this resource."}])
+        expect(json["errors"]).to eq([{ "status" => "403", "title" => "You are not authorized to access this resource." }])
         expect(json["data"]).to be_blank
       end
     end
@@ -132,7 +134,7 @@ describe "/events", type: :request, elasticsearch: true do
         post uri, params, headers
 
         expect(last_response.status).to eq(422)
-        expect(json["errors"]).to eq([{"status"=>422, "title"=>"Source token can't be blank"}])
+        expect(json["errors"]).to eq([{ "status" => 422, "title" => "Source token can't be blank" }])
         expect(json["data"]).to be_nil
       end
     end
@@ -150,7 +152,7 @@ describe "/events", type: :request, elasticsearch: true do
         post uri, params, headers
 
         expect(last_response.status).to eq(422)
-        expect(json["errors"]).to eq([{"status"=>422, "title"=>"Source can't be blank"}])
+        expect(json["errors"]).to eq([{ "status" => 422, "title" => "Source can't be blank" }])
         expect(json["data"]).to be_blank
       end
     end
@@ -168,7 +170,7 @@ describe "/events", type: :request, elasticsearch: true do
         post uri, params, headers
 
         expect(last_response.status).to eq(422)
-        expect(json["errors"]).to eq([{"status"=>422, "title"=>"Subj can't be blank"}])
+        expect(json["errors"]).to eq([{ "status" => 422, "title" => "Subj can't be blank" }])
         expect(json["data"]).to be_blank
       end
     end
@@ -238,8 +240,8 @@ describe "/events", type: :request, elasticsearch: true do
         { "data" => { "type" => "events",
                       "attributes" => {
                         "subjId" => "https://doi.org/10.18713/jimis-170117-1-2",
-                        "subj" => {"@id":"https://doi.org/10.18713/jimis-170117-1-2","@type":"ScholarlyArticle","datePublished":"2017","proxyIdentifiers":[],"registrantId":"datacite.inist.umr7300"},
-                        "obj" => {"@id":"https://doi.org/10.1016/j.jastp.2013.05.001","@type":"ScholarlyArticle","datePublished":"2013-09","proxyIdentifiers":["13646826"],"registrantId":"datacite.crossref.citations"},
+                        "subj" => { "@id":"https://doi.org/10.18713/jimis-170117-1-2", "@type":"ScholarlyArticle", "datePublished":"2017", "proxyIdentifiers":[], "registrantId":"datacite.inist.umr7300" },
+                        "obj" => { "@id":"https://doi.org/10.1016/j.jastp.2013.05.001", "@type":"ScholarlyArticle", "datePublished":"2013-09", "proxyIdentifiers":["13646826"], "registrantId":"datacite.crossref.citations" },
                         "objId" => "https://doi.org/10.1016/j.jastp.2013.05.001",
                         "relationTypeId" => "references",
                         "sourceId" => "datacite-crossref",
@@ -248,7 +250,7 @@ describe "/events", type: :request, elasticsearch: true do
 
       it "has registrant aggregation" do
         post uri, params, headers
-      
+
 
         expect(last_response.status).to eq(201)
         expect(json["errors"]).to be_nil
@@ -259,21 +261,21 @@ describe "/events", type: :request, elasticsearch: true do
         sleep 1
         get uri, nil, headers
 
-        expect(json.dig("meta", "registrants",0,"count")).to eq(1)
-        expect(json.dig("meta", "registrants",0,"id")).to eq("datacite.crossref.citations")
+        expect(json.dig("meta", "registrants", 0, "count")).to eq(1)
+        expect(json.dig("meta", "registrants", 0, "id")).to eq("datacite.crossref.citations")
       end
 
       it "has citationsHistogram aggregation with correct citation year" do
         post uri, params, headers
-      
+
         expect(last_response.status).to eq(201)
         expect(json["errors"]).to be_nil
-   
+
         Event.import
         sleep 1
-        get uri+"?aggregations=citations_aggregations&doi=10.1016/j.jastp.2013.05.001", nil, headers
+        get uri + "?aggregations=citations_aggregations&doi=10.1016/j.jastp.2013.05.001", nil, headers
         puts json.dig("meta", "citationsHistogram")
-        expect(json.dig("meta", "citationsHistogram","years",0,"title")).to eq("2017")
+        expect(json.dig("meta", "citationsHistogram", "years", 0, "title")).to eq("2017")
       end
     end
   end
@@ -310,7 +312,7 @@ describe "/events", type: :request, elasticsearch: true do
         put uri, params, headers
 
         expect(last_response.status).to eq(403)
-        expect(json["errors"]).to eq([{"status"=>"403", "title"=>"You are not authorized to access this resource."}])
+        expect(json["errors"]).to eq([{ "status" => "403", "title" => "You are not authorized to access this resource." }])
         expect(json["data"]).to be_nil
       end
     end
@@ -322,7 +324,7 @@ describe "/events", type: :request, elasticsearch: true do
         put uri, params, headers
 
         expect(last_response.status).to eq(403)
-        expect(json["errors"]).to eq([{"status"=>"403", "title"=>"You are not authorized to access this resource."}])
+        expect(json["errors"]).to eq([{ "status" => "403", "title" => "You are not authorized to access this resource." }])
         expect(json["data"]).to be_blank
       end
     end
@@ -340,7 +342,7 @@ describe "/events", type: :request, elasticsearch: true do
         put uri, params, headers
 
         expect(last_response.status).to eq(422)
-        expect(json["errors"]).to eq([{"status"=>422, "title"=>"Source token can't be blank"}])
+        expect(json["errors"]).to eq([{ "status" => 422, "title" => "Source token can't be blank" }])
         expect(json["data"]).to be_nil
       end
     end
@@ -358,7 +360,7 @@ describe "/events", type: :request, elasticsearch: true do
         put uri, params, headers
 
         expect(last_response.status).to eq(422)
-        expect(json["errors"]).to eq([{"status"=>422, "title"=>"Source can't be blank"}])
+        expect(json["errors"]).to eq([{ "status" => 422, "title" => "Source can't be blank" }])
         expect(json["data"]).to be_blank
       end
     end
@@ -376,7 +378,7 @@ describe "/events", type: :request, elasticsearch: true do
         put uri, params, headers
 
         expect(last_response.status).to eq(422)
-        expect(json["errors"]).to eq([{"status"=>422, "title"=>"Subj can't be blank"}])
+        expect(json["errors"]).to eq([{ "status" => 422, "title" => "Subj can't be blank" }])
         expect(json["data"]).to be_blank
       end
     end
@@ -474,7 +476,7 @@ describe "/events", type: :request, elasticsearch: true do
         put uri, params, headers
 
         expect(last_response.status).to eq(403)
-        expect(json["errors"]).to eq([{"status"=>"403", "title"=>"You are not authorized to access this resource."}])
+        expect(json["errors"]).to eq([{ "status" => "403", "title" => "You are not authorized to access this resource." }])
         expect(json["data"]).to be_nil
       end
     end
@@ -486,7 +488,7 @@ describe "/events", type: :request, elasticsearch: true do
         put uri, params, headers
 
         expect(last_response.status).to eq(403)
-        expect(json["errors"]).to eq([{"status"=>"403", "title"=>"You are not authorized to access this resource."}])
+        expect(json["errors"]).to eq([{ "status" => "403", "title" => "You are not authorized to access this resource." }])
         expect(json["data"]).to be_blank
       end
     end
@@ -516,7 +518,7 @@ describe "/events", type: :request, elasticsearch: true do
 
       it "JSON" do
         put uri, params, headers
-        
+
         expect(last_response.status).to eq(422)
         expect(json.dig("errors", 0, "title")).to start_with("Invalid payload")
         expect(json["data"]).to be_blank
@@ -585,7 +587,7 @@ describe "/events", type: :request, elasticsearch: true do
         get uri, nil, headers
 
         expect(last_response.status).to eq(404)
-        expect(json["errors"]).to eq([{"status"=>"404", "title"=>"The resource you are looking for doesn't exist."}])
+        expect(json["errors"]).to eq([{ "status" => "404", "title" => "The resource you are looking for doesn't exist." }])
         expect(json["data"]).to be_nil
       end
     end
@@ -594,11 +596,11 @@ describe "/events", type: :request, elasticsearch: true do
   context "index" do
   #   # let!(:event) { create(:event) }
   #   # let(:uri) { "/events" }
-    
+
     context "check meta unique" do
       let!(:event) { create(:event_for_datacite_related) }
       let!(:events) { create_list(:event_for_datacite_related, 5, obj_id: event.subj_id) }
-      let(:doi) { (event.subj_id).gsub("https://doi.org/","")}
+      let(:doi) { (event.subj_id).gsub("https://doi.org/", "") }
       let(:uri) { "/events?aggregations=citations_aggregations&doi=#{doi}" }
 
       before do
@@ -619,7 +621,7 @@ describe "/events", type: :request, elasticsearch: true do
         citations = (response.dig("meta", "uniqueCitations")).select { |item| item["id"] == doi }
 
         total = response.dig("meta", "total")
-    
+
         expect(total).to eq(6)
         # puts citations.dig(:count)
         expect(citations.first["count"]).to eq(5)
@@ -633,9 +635,9 @@ describe "/events", type: :request, elasticsearch: true do
       let!(:event2) { create(:event_for_datacite_related, obj_id: event.subj_id) }
       let!(:event3) { create(:event_for_datacite_related, obj_id: event.subj_id) }
       let!(:event4) { create(:event_for_datacite_related, obj_id: event.subj_id, relation_type_id:"has-part") }
-      let(:doi) { (event.subj_id).gsub("https://doi.org/","")}
+      let(:doi) { (event.subj_id).gsub("https://doi.org/", "") }
       let(:uri) { "/events?aggregations=citations_aggregations&doi=#{doi}" }
-      
+
       before do
         Event.import
         sleep 1
@@ -658,7 +660,7 @@ describe "/events", type: :request, elasticsearch: true do
         relations = (response.dig("meta", "relations")).select { |item| item["id"] == doi }
         total = response.dig("meta", "total")
 
-        expect(json.dig("meta", "citationsHistogram","years",0,"title")).to eq("2015")    
+        expect(json.dig("meta", "citationsHistogram", "years", 0, "title")).to eq("2015")
         expect(total).to eq(5)
         expect(citations.first["count"]).to eq(2)
         expect(citations.first["id"]).to eq(doi)
@@ -669,10 +671,38 @@ describe "/events", type: :request, elasticsearch: true do
       end
     end
 
+    context "has views and downloads" do
+      let!(:event) { create_list(:event_for_datacite_usage, 5) }
+      let!(:events) { create_list(:event_for_datacite_usage_empty, 8) }
+      let(:uri) { "/events?aggregations=metrics_aggregations" }
+      let(:doi) { (event.first.obj_id) }
+
+      before do
+        Event.import
+        sleep 1
+      end
+
+      # Exclude the token header.
+      let(:headers) do
+        { "HTTP_ACCEPT" => "application/vnd.api+json; version=2" }
+      end
+
+      it "json" do
+        get uri, nil, headers
+
+        expect(last_response.status).to eq(200)
+        response = JSON.parse(last_response.body)
+
+        views = (response.dig("meta", "views")).select { |item| item["id"] == doi }
+        expect(views.first["count"]).to eq(5)
+        expect(views.first["id"]).to eq(doi)
+      end
+    end
+
     context "check meta duplicated" do
       let!(:event) { create(:event_for_datacite_related,  subj_id:"http://doi.org/10.0260/co.2004960.v2", obj_id:"http://doi.org/10.0260/co.2004960.v1") }
       let!(:copies) { create(:event_for_datacite_related,  subj_id:"http://doi.org/10.0260/co.2004960.v2", obj_id:"http://doi.org/10.0260/co.2004960.v1", relation_type_id: "cites") }
-      let(:doi) { (event.obj_id).gsub("https://doi.org/","")}
+      let(:doi) { (event.obj_id).gsub("https://doi.org/", "") }
       let(:uri) { "/events?aggregations=citations_aggregations&doi=#{doi}" }
 
       before do
@@ -961,7 +991,7 @@ describe "/events", type: :request, elasticsearch: true do
         delete uri, nil, headers
 
         expect(last_response.status).to eq(404)
-        expect(json["errors"]).to eq([{"status"=>"404", "title"=>"The resource you are looking for doesn't exist."}])
+        expect(json["errors"]).to eq([{ "status" => "404", "title" => "The resource you are looking for doesn't exist." }])
         expect(json["data"]).to be_nil
       end
     end


### PR DESCRIPTION
to address https://github.com/datacite/lupo/issues/360 and https://github.com/datacite/lupo/issues/352

Most of the indexed information includes obj.registrant_id the schema indicates that i should be obj.registrantId

ff565d8
in the database they are all beeing save as registrant_id. But levreiro is sending registrantId. So there might be a conversion.

Potential solutions to make the query

change the whole mapping and reindex all the events (it doesn't need to reimport) <- because in the database everything is saved with snacke_case

we might need to do make the change over the weekend as we will need to reindex the events. 


