### PR TITLE
pre-index linking data

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require: rubocop-performance
+# require: rubocop-performance
 inherit_from: .rubocop_todo.yml
 
 # from https://github.com/rails/rails/blob/master/.rubocop.yml
@@ -91,7 +91,7 @@ Style/HashSyntax:
 # extra level of indentation.
 Layout/IndentationConsistency:
   Enabled: true
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
 
 # Two spaces, no tabs (for indentation).
 Layout/IndentationWidth:
@@ -184,7 +184,7 @@ Layout/TrailingWhitespace:
   Enabled: true
 
 # Use quotes for string literals when they are enough.
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
 
 Lint/AmbiguousOperator:

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -225,6 +225,7 @@ module Indexable
         must << { term: { subj_id: URI.decode(options[:subj_id]) }} if options[:subj_id].present?
         must << { term: { obj_id: URI.decode(options[:obj_id]) }} if options[:obj_id].present?
         must << { term: { citation_type: options[:citation_type] }} if options[:citation_type].present?
+        must << { term: { link_types: options[:link_types] }} if options[:link_types].present?
         must << { term: { year_month: options[:year_month] }} if options[:year_month].present?
         must << { range: { "subj.datePublished" => { gte: "#{options[:publication_year].split("-").min}||/y", lte: "#{options[:publication_year].split("-").max}||/y", format: "yyyy" }}} if options[:publication_year].present?
         must << { range: { occurred_at: { gte: "#{options[:occurred_at].split("-").min}||/y", lte: "#{options[:occurred_at].split("-").max}||/y", format: "yyyy" }}} if options[:occurred_at].present?

--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -20,9 +20,7 @@ class EventsQuery
 
   def doi_citations(doi)
     return nil unless doi.present?
-    pid = Event.new.normalize_doi(doi)
-    query = "(subj_id:\"#{pid}\" AND (relation_type_id:#{PASSIVE_RELATION_TYPES.join(' OR relation_type_id:')})) OR (obj_id:\"#{pid}\" AND (relation_type_id:#{ACTIVE_RELATION_TYPES.join(' OR relation_type_id:')}))"
-    results = Event.query(query, doi: doi, aggregations: "citation_count_aggregation", page: { size: 1, cursor: [] }).response.aggregations.citations.buckets
+    results = Event.query(nil, link_types:"#{doi}-citation", aggregations: "citation_count_aggregation", page: { size: 1, cursor: [] }).response.aggregations.citations.buckets
     results.any? ? results.first.total.value : 0
   end
 
@@ -35,17 +33,17 @@ class EventsQuery
 
   def citations_histogram(doi)
     return {} unless doi.present?
-    pid = Event.new.normalize_doi(doi.downcase.split(",").first)
-    query = "(subj_id:\"#{pid}\" AND (relation_type_id:#{PASSIVE_RELATION_TYPES.join(' OR relation_type_id:')})) OR (obj_id:\"#{pid}\" AND (relation_type_id:#{ACTIVE_RELATION_TYPES.join(' OR relation_type_id:')}))"
-    results = Event.query(query, doi: doi, aggregations: "yearly_histogram_aggregation", page: { size: 1, cursor: [] }).response.aggregations
+    # pid = Event.new.normalize_doi(doi.downcase.split(",").first)
+    # query = "(subj_id:\"#{pid}\" AND (relation_type_id:#{PASSIVE_RELATION_TYPES.join(' OR relation_type_id:')})) OR (obj_id:\"#{pid}\" AND (relation_type_id:#{ACTIVE_RELATION_TYPES.join(' OR relation_type_id:')}))"
+    results = Event.query(nil, link_types:"#{doi}-citation", aggregations: "yearly_histogram_aggregation", page: { size: 1, cursor: [] }).response.aggregations
     facet_citations_by_year(results)
   end
 
 
   def doi_views(doi)
     return nil unless doi.present?
-    query = "(relation_type_id:unique-dataset-investigations-regular AND source_id:datacite-usage)"
-    results = Event.query(query, doi: doi, aggregations: "usage_count_aggregation", page: { size: 1, cursor: [] }).response.aggregations.usage.buckets
+    # query = "(relation_type_id:unique-dataset-investigations-regular AND source_id:datacite-usage)"
+    results = Event.query(nil, link_types:"#{doi}-view", aggregations: "usage_count_aggregation", page: { size: 1, cursor: [] }).response.aggregations.usage.buckets
     results.any? ? results.first.dig("total_by_type", "value") : 0
   end
 
@@ -59,15 +57,15 @@ class EventsQuery
   def views_histogram(doi)
     return {} unless doi.present?
     doi = doi.downcase.split(",").first
-    query = "(relation_type_id:unique-dataset-investigations-regular AND source_id:datacite-usage)"
-    results = Event.query(query, doi: doi, aggregations: "monthly_histogram_aggregation", page: { size: 1, cursor: [] }).response.aggregations
+    # query = "(relation_type_id:unique-dataset-investigations-regular AND source_id:datacite-usage)"
+    results = Event.query(nil, link_types:"#{doi}-view", aggregations: "monthly_histogram_aggregation", page: { size: 1, cursor: [] }).response.aggregations
     facet_counts_by_year_month(results)
   end
 
   def doi_downloads(doi)
     return nil unless doi.present?
-    query = "(relation_type_id:unique-dataset-requests-regular AND source_id:datacite-usage)"
-    results = Event.query(query, doi: doi, aggregations: "usage_count_aggregation", page: { size: 1, cursor: [] }).response.aggregations.usage.buckets
+    # query = "(relation_type_id:unique-dataset-requests-regular AND source_id:datacite-usage)"
+    results = Event.query(nil, link_types:"#{doi}-download", aggregations: "usage_count_aggregation", page: { size: 1, cursor: [] }).response.aggregations.usage.buckets
     results.any? ? results.first.dig("total_by_type", "value") : 0
   end
 
@@ -81,8 +79,8 @@ class EventsQuery
   def downloads_histogram(doi)
     return {} unless doi.present?
     doi = doi.downcase.split(",").first
-    query = "(relation_type_id:unique-dataset-requests-regular AND source_id:datacite-usage)"
-    results = Event.query(query, doi: doi, aggregations: "monthly_histogram_aggregation", page: { size: 1, cursor: [] }).response.aggregations
+    # query = "(relation_type_id:unique-dataset-requests-regular AND source_id:datacite-usage)"
+    results = Event.query(nil, link_types:"#{doi}-download", aggregations: "monthly_histogram_aggregation", page: { size: 1, cursor: [] }).response.aggregations
     facet_counts_by_year_month(results)
   end
 

--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -17,10 +17,10 @@ class EventsQuery
 
   def initialize
   end
-
+ 
   def doi_citations(doi)
     return nil unless doi.present?
-    results = Event.query(nil, link_types:"#{doi}-citation", aggregations: "citation_count_aggregation", page: { size: 1, cursor: [] }).response.aggregations.citations.buckets
+    results = Event.query(nil, link_types: "#{doi}-citation", aggregations: "citation_count_aggregation", page: { size: 1, cursor: [] }).response.aggregations.citations.buckets
     results.any? ? results.first.total.value : 0
   end
 
@@ -33,17 +33,14 @@ class EventsQuery
 
   def citations_histogram(doi)
     return {} unless doi.present?
-    # pid = Event.new.normalize_doi(doi.downcase.split(",").first)
-    # query = "(subj_id:\"#{pid}\" AND (relation_type_id:#{PASSIVE_RELATION_TYPES.join(' OR relation_type_id:')})) OR (obj_id:\"#{pid}\" AND (relation_type_id:#{ACTIVE_RELATION_TYPES.join(' OR relation_type_id:')}))"
-    results = Event.query(nil, link_types:"#{doi}-citation", aggregations: "yearly_histogram_aggregation", page: { size: 1, cursor: [] }).response.aggregations
+    results = Event.query(nil, link_types: "#{doi}-citation", aggregations: "yearly_histogram_aggregation", page: { size: 1, cursor: [] }).response.aggregations
     facet_citations_by_year(results)
   end
 
 
   def doi_views(doi)
     return nil unless doi.present?
-    # query = "(relation_type_id:unique-dataset-investigations-regular AND source_id:datacite-usage)"
-    results = Event.query(nil, link_types:"#{doi}-view", aggregations: "usage_count_aggregation", page: { size: 1, cursor: [] }).response.aggregations.usage.buckets
+    results = Event.query(nil, link_types: "#{doi}-view", aggregations: "usage_count_aggregation", page: { size: 1, cursor: [] }).response.aggregations.usage.buckets
     results.any? ? results.first.dig("total_by_type", "value") : 0
   end
 
@@ -57,15 +54,13 @@ class EventsQuery
   def views_histogram(doi)
     return {} unless doi.present?
     doi = doi.downcase.split(",").first
-    # query = "(relation_type_id:unique-dataset-investigations-regular AND source_id:datacite-usage)"
-    results = Event.query(nil, link_types:"#{doi}-view", aggregations: "monthly_histogram_aggregation", page: { size: 1, cursor: [] }).response.aggregations
+    results = Event.query(nil, link_types: "#{doi}-view", aggregations: "monthly_histogram_aggregation", page: { size: 1, cursor: [] }).response.aggregations
     facet_counts_by_year_month(results)
   end
 
   def doi_downloads(doi)
     return nil unless doi.present?
-    # query = "(relation_type_id:unique-dataset-requests-regular AND source_id:datacite-usage)"
-    results = Event.query(nil, link_types:"#{doi}-download", aggregations: "usage_count_aggregation", page: { size: 1, cursor: [] }).response.aggregations.usage.buckets
+    results = Event.query(nil, link_types: "#{doi}-download", aggregations: "usage_count_aggregation", page: { size: 1, cursor: [] }).response.aggregations.usage.buckets
     results.any? ? results.first.dig("total_by_type", "value") : 0
   end
 
@@ -79,8 +74,7 @@ class EventsQuery
   def downloads_histogram(doi)
     return {} unless doi.present?
     doi = doi.downcase.split(",").first
-    # query = "(relation_type_id:unique-dataset-requests-regular AND source_id:datacite-usage)"
-    results = Event.query(nil, link_types:"#{doi}-download", aggregations: "monthly_histogram_aggregation", page: { size: 1, cursor: [] }).response.aggregations
+    results = Event.query(nil, link_types: "#{doi}-download", aggregations: "monthly_histogram_aggregation", page: { size: 1, cursor: [] }).response.aggregations
     facet_counts_by_year_month(results)
   end
 
@@ -90,18 +84,18 @@ class EventsQuery
       pid = Event.new.normalize_doi(item)
       requests = EventsQuery.new.doi_downloads(item)
       investigations = EventsQuery.new.doi_views(item)
-      { id: pid, 
+      { id: pid,
         title: pid,
-      relationTypes: [
-        { id: "unique-dataset-requests-regular",
-        title: "unique-dataset-requests-regular",
-          sum: requests
-        },
-        { id: "unique-dataset-investigations-regular",
-          title: "unique-dataset-investigations-regular",
-          sum: investigations
-        }
-      ]
+        relationTypes: [
+            { id: "unique-dataset-requests-regular",
+              title: "unique-dataset-requests-regular",
+              sum: requests
+            },
+            { id: "unique-dataset-investigations-regular",
+              title: "unique-dataset-investigations-regular",
+              sum: investigations
+            }
+        ]
       }
     end
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -20,6 +20,10 @@ describe Event, :type => :model, vcr: true do
     it "has citation_id" do
       expect(subject.citation_id).to eq("https://doi.org/10.5061/dryad.47sd5/1-https://doi.org/10.5061/dryad.47sd5e/1")
     end
+
+    it "has link_types" do
+      expect(subject.link_types).to eq(["10.5061/dryad.47sd5/1-citation", "10.5061/dryad.47sd5e/2-reference"])
+    end
   
     it "has citation_year" do
       expect(subject.citation_year).to eq(2015)


### PR DESCRIPTION
addresses https://github.com/datacite/spitz/issues/6

According to our criteria, Every Event can be at most two `types of links` at the same time:

- An event of the type `citation-link` will always be also  `reference-link` at the same time. A `citation-link` for the subjectt of the event, it's a  `reference-link` for the object and vice-versa.
- An event of the type  `relation-link` can only be a  `reference-link` type only.
- An event of the type  `view-link` can only be a  `view-link` type only.
- An event of the type  `download-link` can only be a  `download-link` type only.

link_types for 10.14454/9ofdqasd3
`10.14454/9ofdqasd3-citation`
`10.14454/9ofdqasd3-reference`
`10.14454/9ofdqasd3-relation`
`10.14454/9ofdqasd3-view`
`10.14454/9ofdqasd3-download`






