### PR TITLE
configuration for our version of rubocup

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,4 @@
+ruby:
+  config_file: .rubocop.yml
+rubocop:
+  version: 0.77.0


### PR DESCRIPTION

## Description

Hound is very noisy in the PRs. There many reasons but two obvious ones is that we do not run the same rubocup version as hound does by default and also it does not consider our repo configuration.

http://help.houndci.com/en/articles/2137566-rubocop

thic pr aim to change that

## List of General Components affected

## Status
- [x] Ready for Review

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Non Functional Requirement
- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] All new and existing tests passed.
- [ ] Documentation
