### PR TITLE
Rake tasks to label events with error

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -106,6 +106,7 @@ class EventsController < ApplicationController
                               year_month: params[:year_month],
                               aggregations: params[:aggregations],
                               unique: params[:unique],
+                              state_event: params[:state],
                               scroll_id: params[:scroll_id],
                               page: page,
                               sort: sort)
@@ -156,6 +157,8 @@ class EventsController < ApplicationController
       downloads_histogram = nil
       unique_obj_count = nil
       unique_subj_count = nil
+      states = nil
+
 
       bm = Benchmark.ms {
         aggregations = params.fetch(:aggregations, "") || ""
@@ -181,6 +184,8 @@ class EventsController < ApplicationController
         # downloads = total.positive? ? EventsQuery.new.downloads(params[:doi]) : nil
         unique_obj_count = total.positive? && aggregations.include?("advanced_aggregations") ? response.response.aggregations.unique_obj_count.value : nil
         unique_subj_count = total.positive? && aggregations.include?("advanced_aggregations") ? response.response.aggregations.unique_subj_count.value : nil
+        states = total.positive? && aggregations.include?("state_aggregations") ? facet_by_source(response.response.aggregations.states.buckets) : nil
+
       }
       Rails.logger.warn method: "GET", path: "/events", message: "Aggregations /events", duration: bm
 
@@ -204,6 +209,7 @@ class EventsController < ApplicationController
         "uniqueCitations": citations,
         "references": references,
         "relations": relations,
+        "states": states,
         "uniqueNodes": {
           "objCount": unique_obj_count,
           "subjCount": unique_subj_count

--- a/app/jobs/subj_check_job.rb
+++ b/app/jobs/subj_check_job.rb
@@ -1,0 +1,12 @@
+class SubjCheckJob < ActiveJob::Base
+  queue_as :lupo_background
+
+  def perform(events, options = {})
+    events.lazy.each do |event|
+      subj_prefix = event[:subj_id][/(10\.\d{4,5})/, 1]
+      if Prefix.where(prefix: subj_prefix).exists?
+        Event.find_by(id: event[:id]).update_attribute(:state_event, "subjId_error")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
rake tasks to assess the magnitude of events that have crossref-to-crossref relationships, which were wrongly indexed. See #351 for more details.

This rake task flags all the events

we use the field `state_event` in the index.

Criteria or from events is:
subj_id in datacite-crossref,datacite-related events MUST always be a DataCite DOI

## List of General Components affected

## Status
- [ ] Ready for Review

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Non Functional Requirement
- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] All new and existing tests passed.
- [ ] Documentation
