### PR TITLE
separate api endpoint for stats

### DIFF
--- a/app/controllers/concerns/countable.rb
+++ b/app/controllers/concerns/countable.rb
@@ -14,7 +14,7 @@ module Countable
       else
         response = Doi.query(nil, page: { number: 1, size: 0 })
       end
-
+      
       response.results.total.positive? ? facet_by_year(response.response.aggregations.created.buckets) : []
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,11 +53,16 @@ Rails.application.routes.draw do
   get 'dois/random', :to => 'dois#random'
   get 'dois/:id/get-url', :to => 'dois#get_url', constraints: { :id => /.+/ }
   get 'dois/get-dois', :to => 'dois#get_dois'
+
   get 'providers/image/:id', :to => 'providers#image', constraints: { :id => /.+/ }
+
   get 'providers/totals', :to => 'providers#totals'
   get 'clients/totals', :to => 'clients#totals'
   get 'repositories/totals', :to => 'repositories#totals'
   get 'prefixes/totals', :to => 'prefixes#totals'
+  get '/providers/:id/stats', :to => 'providers#stats'
+  get '/clients/:id/stats', :to => 'clients#stats', constraints: { :id => /.+/ }
+  get '/repositories/:id/stats', :to => 'repositories#stats', constraints: { :id => /.+/ }
 
   # Reporting
   get 'export/organizations', :to => 'export#organizations',  defaults: { format: :csv }

--- a/spec/requests/clients_spec.rb
+++ b/spec/requests/clients_spec.rb
@@ -93,6 +93,26 @@ describe 'Clients', type: :request, elasticsearch: true do
     end
   end
 
+  describe 'GET /clients/totals' do
+    let(:client)  { create(:client) }
+    let!(:dois) { create_list(:doi, 3, client: client, aasm_state: "findable") }
+
+    before do
+      Client.import
+      Doi.import
+      sleep 3
+    end
+
+    it "returns clients" do
+      get "/clients/totals", nil, headers
+
+      expect(last_response.status).to eq(200)
+      expect(json.first.dig('count')).to eq(3)
+      expect(json.first.dig('states')).to eq([{"count"=>3, "id"=>"findable", "title"=>"Findable"}])
+      expect(json.first.dig('temporal')).not_to be_nil
+    end
+  end
+
   describe 'POST /clients' do
     context 'when the request is valid' do    
       it 'creates a client' do

--- a/spec/requests/dois_spec.rb
+++ b/spec/requests/dois_spec.rb
@@ -177,13 +177,13 @@ describe "dois", type: :request do
       expect(json.dig('meta', 'views')).to eq([{"count"=>75, "id"=>"2011", "title"=>"2011"}])
     end
 
-    it "repository shows summary count" do
-      get "/repositories/#{client.uid}", nil, headers
+    # it "repository shows summary count" do
+    #   get "/repositories/stats/#{client.uid}", nil, headers
 
-      expect(last_response.status).to eq(200)
-      expect(json.dig('data', 'attributes', 'name')).to eq(client.name)
-      expect(json.dig('meta', 'views')).to eq([{"count"=>75, "id"=>"2011", "title"=>"2011"}])
-    end
+    #   expect(last_response.status).to eq(200)
+    #   expect(json).to eq(client.name)
+    #   expect(json.dig('meta', 'views')).to eq([{"count"=>75, "id"=>"2011", "title"=>"2011"}])
+    # end
   end
 
   describe "downloads", elasticsearch: true, vcr: true do
@@ -214,13 +214,12 @@ describe "dois", type: :request do
       expect(json.dig('meta', 'downloads')).to eq([{"count"=>30, "id"=>"2011", "title"=>"2011"}])
     end
 
-    it "repository shows summary count" do
-      get "/repositories/#{client.uid}", nil, headers
+    # it "repository shows summary count" do
+    #   get "/repositories/stats/#{client.uid}", nil, headers
 
-      expect(last_response.status).to eq(200)
-      expect(json.dig('data', 'attributes', 'name')).to eq(client.name)
-      expect(json.dig('meta', 'downloads')).to eq([{"count"=>30, "id"=>"2011", "title"=>"2011"}])
-    end
+    #   expect(last_response.status).to eq(200)
+    #   expect(json.dig('meta', 'downloads')).to eq([{"count"=>30, "id"=>"2011", "title"=>"2011"}])
+    # end
   end
 
   describe "references", elasticsearch: true, vcr: true do
@@ -280,13 +279,12 @@ describe "dois", type: :request do
       expect(json.dig('meta', 'citations')).to eq([{"count"=>1, "id"=>"2011", "title"=>"2011"}])
     end
 
-    it "repository shows summary count" do
-      get "/repositories/#{client.uid}", nil, headers
+    # it "repository shows summary count" do
+    #   get "/repositories/stats/#{client.uid}", nil, headers
 
-      expect(last_response.status).to eq(200)
-      expect(json.dig('data', 'attributes', 'name')).to eq(client.name)
-      expect(json.dig('meta', 'citations')).to eq([{"count"=>1, "id"=>"2011", "title"=>"2011"}])
-    end
+    #   expect(last_response.status).to eq(200)
+    #   expect(json.dig('meta', 'citations')).to eq([{"count"=>1, "id"=>"2011", "title"=>"2011"}])
+    # end
   end
 
   describe "parts", elasticsearch: true, vcr: true do

--- a/spec/requests/repositories_spec.rb
+++ b/spec/requests/repositories_spec.rb
@@ -98,6 +98,47 @@ describe 'Repositories', type: :request, elasticsearch: true do
     end
   end
 
+  describe 'GET /repositories/totals' do
+    let(:client) { create(:client) }
+    let!(:dois) { create_list(:doi, 3, client: client, aasm_state: "findable") }
+
+    before do
+      Client.import
+      Doi.import
+      sleep 1
+    end
+
+    it "returns repositories" do
+      get "/repositories/totals", nil, headers
+
+      expect(last_response.status).to eq(200)
+      expect(json.first.dig('count')).to eq(3)
+      expect(json.first.dig('states')).to eq([{"count"=>3, "id"=>"findable", "title"=>"Findable"}])
+      expect(json.first.dig('temporal')).not_to be_nil
+    end
+  end
+
+  describe 'GET /repositories/:id/stats' do
+    let(:provider)  { create(:provider) }
+    let(:client)  { create(:client) }
+    let!(:dois) { create_list(:doi, 3, client: client, aasm_state: "findable") }
+
+    before do
+      Provider.import
+      Client.import
+      Doi.import
+      sleep 2
+    end
+
+    it "returns repository" do
+      get "/repositories/#{client.uid}/stats"
+
+      expect(last_response.status).to eq(200)
+      expect(json["resourceTypes"]).to eq([{"count"=>3, "id"=>"dataset", "title"=>"Dataset"}])
+      expect(json["dois"]).to eq([{"count"=>3, "id"=>"2020", "title"=>"2020"}])
+    end
+  end
+
   describe 'POST /repositories' do
     context 'when the request is valid' do    
       it 'creates a repository' do


### PR DESCRIPTION
Provide stats for providers and repositories in a separate API endpoint, as they add too much overhead.