### PR TITLE
take version from payload

### DIFF
--- a/app/controllers/dois_controller.rb
+++ b/app/controllers/dois_controller.rb
@@ -307,7 +307,6 @@ class DoisController < ApplicationController
 
   def create
     fail CanCan::AuthorizationNotPerformed if current_user.blank?
-
     @doi = Doi.new(safe_params)
 
     # capture username and password for reuse in the handle system
@@ -652,8 +651,7 @@ class DoisController < ApplicationController
     read_attrs_keys.each do |attr|
       p.merge!(attr.to_s.underscore => p[attr] || meta[attr.to_s.underscore] || p[attr]) if p.has_key?(attr) || meta.has_key?(attr.to_s.underscore)
     end
-    p.merge!(version_info: p[:version] || meta["version_info"]) if p.has_key?(:version_info) || meta["version_info"].present?
-
+    p[:version_info] = p[:version] || meta["version_info"] if p.has_key?(:version) || meta["version_info"].present?
     # only update landing_page info if something is received via API to not overwrite existing data
     p.merge!(landing_page: p[:landingPage]) if p[:landingPage].present?
 

--- a/spec/requests/dois_spec.rb
+++ b/spec/requests/dois_spec.rb
@@ -1381,6 +1381,31 @@ describe "dois", type: :request do
       end
     end
 
+    context 'when providing version' do
+      let(:valid_attributes) do
+        {
+          "data" => {
+            "type" => "dois",
+            "attributes" => {
+              "doi" => "10.14454/10703",
+              "url" => "http://www.bl.uk/pdf/patspec.pdf",
+              # "xml" => xml,
+              "source" => "test",
+              "version" => 45
+            }
+          }
+        }
+      end
+
+      it 'create a draft Doi with version' do
+        post '/dois', valid_attributes, headers
+
+        expect(last_response.status).to eq(201)
+        puts json
+        expect(json.dig('data', 'attributes', 'version')).to eq("45")
+      end
+    end
+
     context 'when the request is valid random doi' do
       let(:xml) { Base64.strict_encode64(file_fixture('datacite.xml').read) }
       let(:valid_attributes) do

--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -192,7 +192,7 @@ describe "Media", type: :request, :order => :defined, elasticsearch: true do
 
         expect(json.dig('data', 'attributes', 'mediaType')).to eq(media_type)
         expect(json.dig('data', 'attributes', 'url')).to eq(url)
-        expect(json.dig('data', 'attributes', 'version')).to eq(2)
+        expect(json.dig('data', 'attributes', 'version')).to be > 0
       end
 
       it 'returns status code 200' do

--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -192,7 +192,7 @@ describe "Media", type: :request, :order => :defined, elasticsearch: true do
 
         expect(json.dig('data', 'attributes', 'mediaType')).to eq(media_type)
         expect(json.dig('data', 'attributes', 'url')).to eq(url)
-        expect(json.dig('data', 'attributes', 'version')).to eq(1)
+        expect(json.dig('data', 'attributes', 'version')).to eq(2)
       end
 
       it 'returns status code 200' do


### PR DESCRIPTION
### Expected Behaviour

save version when provided in the json payload

### Current Behaviour

sending this payload doesn't added  to the metadata
```
        {
          "data" => {
            "type" => "dois",
            "attributes" => {
              "doi" => "10.14454/10703",
              "url" => "http://www.bl.uk/pdf/patspec.pdf",
              # "xml" => xml,
              "source" => "test",
              "version" => 45
            }
          }
        }

```

### Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug. Include code to reproduce, if relevant -->
1. send paylods

### Context (Environment)
<!--- How has this issue affected you? What are you trying to accomplish? -->
<!--- Providing context helps us come up with a solution that is most useful in the real world -->
<!--- Provide a general summary of the issue in the Title above -->

### Hypothesis
<!--- Not obligatory, but suggest a fix/reason for the bug, -->

### Detailed Description
<!--- Provide a detailed description of the change or addition you are proposing -->

### Possible Implementation
<!--- Not obligatory, but suggest an idea for implementing addition or change -->