### PR TITLE
don't use database or elasticsearch queries in facets for dois. #468

### DIFF
--- a/app/controllers/concerns/countable.rb
+++ b/app/controllers/concerns/countable.rb
@@ -114,7 +114,7 @@ module Countable
         response = Doi.query(nil, page: { number: 1, size: 0 })
       end
       
-      response.results.total.positive? ? facet_by_resource_type(response.response.aggregations.resource_types.buckets) : []
+      response.results.total.positive? ? facet_by_combined_key(response.response.aggregations.resource_types.buckets) : []
     end
   end
 end

--- a/app/controllers/concerns/facetable.rb
+++ b/app/controllers/concerns/facetable.rb
@@ -113,20 +113,6 @@ module Facetable
       end
     end
 
-    def facet_by_affiliation(arr)
-      # generate hash with id and name for each affiliation in facet
-      return [] if arr.blank?
-
-      ids = arr.map { |hsh| "\"#{hsh["key"]}\"" }.join(" ")
-      affiliations = Organization.query(ids, size: 1000)[:data] || []
-
-      arr.map do |hsh|
-        { "id" => hsh["key"],
-          "title" => affiliations.find { |a| a["id"] == hsh["key"] }.to_h["name"] || hsh["key"],
-          "count" => hsh["doc_count"] }
-      end
-    end
-
     def facet_by_provider(arr)
       # generate hash with id and name for each provider in facet
 
@@ -398,6 +384,16 @@ module Facetable
       arr.map do |hsh|
         { "id" => hsh["key"],
           "title" => clients[hsh["key"].upcase],
+          "count" => hsh["doc_count"] }
+      end
+    end
+
+    def facet_by_combined_key(arr)
+      arr.map do |hsh|
+        id, title = hsh["key"].split(":", 2)
+
+        { "id" => id,
+          "title" => title,
           "count" => hsh["doc_count"] }
       end
     end

--- a/app/controllers/dois_controller.rb
+++ b/app/controllers/dois_controller.rb
@@ -153,16 +153,16 @@ class DoisController < ApplicationController
         end
       else
         states = total.positive? ? facet_by_key(response.aggregations.states.buckets) : nil
-        resource_types = total.positive? ? facet_by_resource_type(response.aggregations.resource_types.buckets) : nil
+        resource_types = total.positive? ? facet_by_combined_key(response.aggregations.resource_types.buckets) : nil
         years = total.positive? ? facet_by_year(response.aggregations.years.buckets) : nil
         created = total.positive? ? facet_by_year(response.aggregations.created.buckets) : nil
         registered = total.positive? ? facet_by_year(response.aggregations.registered.buckets) : nil
-        providers = total.positive? ? facet_by_provider(response.aggregations.providers.buckets) : nil
-        clients = total.positive? ? facet_by_client(response.aggregations.clients.buckets) : nil
+        providers = total.positive? ? facet_by_combined_key(response.aggregations.providers.buckets) : nil
+        clients = total.positive? ? facet_by_combined_key(response.aggregations.clients.buckets) : nil
         prefixes = total.positive? ? facet_by_key(response.aggregations.prefixes.buckets) : nil
         schema_versions = total.positive? ? facet_by_schema(response.aggregations.schema_versions.buckets) : nil
 
-        affiliations = total.positive? ? facet_by_affiliation(response.aggregations.affiliations.buckets) : nil
+        affiliations = total.positive? ? facet_by_combined_key(response.aggregations.affiliations.buckets) : nil
         sources = total.positive? ? facet_by_key(response.aggregations.sources.buckets) : nil
         subjects = total.positive? ? facet_by_key(response.aggregations.subjects.buckets) : nil
         certificates = total.positive? ? facet_by_key(response.aggregations.certificates.buckets) : nil

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -55,12 +55,12 @@ class WorksController < ApplicationController
       total = response.results.total
       total_pages = page[:size].positive? ? ([total.to_f, 10000].min / page[:size]).ceil : 0
 
-      resource_types = total > 0 ? facet_by_resource_type(response.response.aggregations.resource_types.buckets) : nil
+      resource_types = total > 0 ? facet_by_combined_key(response.response.aggregations.resource_types.buckets) : nil
       registered = total > 0 ? facet_by_year(response.response.aggregations.registered.buckets) : nil
-      providers = total > 0 ? facet_by_provider(response.response.aggregations.providers.buckets) : nil
-      clients = total > 0 ? facet_by_client(response.response.aggregations.clients.buckets) : nil
+      providers = total > 0 ? facet_by_combined_key(response.response.aggregations.providers.buckets) : nil
+      clients = total > 0 ? facet_by_combined_key(response.response.aggregations.clients.buckets) : nil
 
-      affiliations = total > 0 ? facet_by_affiliation(response.response.aggregations.affiliations.buckets) : nil
+      affiliations = total > 0 ? facet_by_combined_key(response.response.aggregations.affiliations.buckets) : nil
 
       @dois = response.results
 

--- a/app/graphql/types/audiovisual_connection_type.rb
+++ b/app/graphql/types/audiovisual_connection_type.rb
@@ -34,14 +34,14 @@ class AudiovisualConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/base_connection.rb
+++ b/app/graphql/types/base_connection.rb
@@ -57,16 +57,12 @@ class BaseConnection < GraphQL::Types::Relay::BaseConnection
     end
   end
 
-  def facet_by_affiliation(arr)
-    # generate hash with id and name for each affiliation in facet
-    return [] if arr.blank?
-
-    ids = arr.map { |hsh| "\"#{hsh["key"]}\"" }.join(" ")
-    affiliations = Organization.query(ids, size: 1000)[:data] || []
-
+  def facet_by_combined_key(arr)
     arr.map do |hsh|
-      { "id" => hsh["key"],
-        "title" => affiliations.find { |a| a["id"] == hsh["key"] }.to_h["name"] || hsh["key"],
+      id, title = hsh["key"].split(":", 2)
+
+      { "id" => id,
+        "title" => title,
         "count" => hsh["doc_count"] }
     end
   end

--- a/app/graphql/types/book_chapter_connection_type.rb
+++ b/app/graphql/types/book_chapter_connection_type.rb
@@ -41,7 +41,7 @@ class BookChapterConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/book_connection_type.rb
+++ b/app/graphql/types/book_connection_type.rb
@@ -34,14 +34,14 @@ class BookConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/collection_connection_type.rb
+++ b/app/graphql/types/collection_connection_type.rb
@@ -33,14 +33,14 @@ class CollectionConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/conference_paper_connection_type.rb
+++ b/app/graphql/types/conference_paper_connection_type.rb
@@ -34,14 +34,14 @@ class ConferencePaperConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/data_paper_connection_type.rb
+++ b/app/graphql/types/data_paper_connection_type.rb
@@ -34,14 +34,14 @@ class DataPaperConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/dataset_connection_type.rb
+++ b/app/graphql/types/dataset_connection_type.rb
@@ -41,14 +41,14 @@ class DatasetConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/dissertation_connection_type.rb
+++ b/app/graphql/types/dissertation_connection_type.rb
@@ -34,14 +34,14 @@ class DissertationConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/event_connection_type.rb
+++ b/app/graphql/types/event_connection_type.rb
@@ -34,14 +34,14 @@ class EventConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/image_connection_type.rb
+++ b/app/graphql/types/image_connection_type.rb
@@ -34,14 +34,14 @@ class ImageConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/instrument_connection_type.rb
+++ b/app/graphql/types/instrument_connection_type.rb
@@ -34,14 +34,14 @@ class InstrumentConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/interactive_resource_connection_type.rb
+++ b/app/graphql/types/interactive_resource_connection_type.rb
@@ -34,14 +34,14 @@ class InteractiveResourceConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/journal_article_connection_type.rb
+++ b/app/graphql/types/journal_article_connection_type.rb
@@ -34,14 +34,14 @@ class JournalArticleConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/model_connection_type.rb
+++ b/app/graphql/types/model_connection_type.rb
@@ -34,14 +34,14 @@ class ModelConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/other_connection_type.rb
+++ b/app/graphql/types/other_connection_type.rb
@@ -34,14 +34,14 @@ class OtherConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/peer_review_connection_type.rb
+++ b/app/graphql/types/peer_review_connection_type.rb
@@ -34,14 +34,14 @@ class PeerReviewConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/physical_object_connection_type.rb
+++ b/app/graphql/types/physical_object_connection_type.rb
@@ -34,14 +34,14 @@ class PhysicalObjectConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/preprint_connection_type.rb
+++ b/app/graphql/types/preprint_connection_type.rb
@@ -34,14 +34,14 @@ class PreprintConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/publication_connection_type.rb
+++ b/app/graphql/types/publication_connection_type.rb
@@ -40,14 +40,14 @@ class PublicationConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/service_connection_type.rb
+++ b/app/graphql/types/service_connection_type.rb
@@ -34,14 +34,14 @@ class ServiceConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/software_connection_type.rb
+++ b/app/graphql/types/software_connection_type.rb
@@ -42,14 +42,14 @@ class SoftwareConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/sound_connection_type.rb
+++ b/app/graphql/types/sound_connection_type.rb
@@ -34,14 +34,14 @@ class SoundConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/work_connection_type.rb
+++ b/app/graphql/types/work_connection_type.rb
@@ -28,7 +28,7 @@ class WorkConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_resource_type(res.response.aggregations.resource_types.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.resource_types.buckets) : []
   end
 
   def registration_agencies
@@ -42,14 +42,14 @@ class WorkConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/graphql/types/workflow_connection_type.rb
+++ b/app/graphql/types/workflow_connection_type.rb
@@ -34,14 +34,14 @@ class WorkflowConnectionType < BaseConnection
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_client(res.response.aggregations.clients.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.clients.buckets) : []
   end
 
   def affiliations
     args = prepare_args(object.arguments)
 
     res = response(args)
-    res.results.total.positive? ? facet_by_affiliation(res.response.aggregations.affiliations.buckets) : []
+    res.results.total.positive? ? facet_by_combined_key(res.response.aggregations.affiliations.buckets) : []
   end
 
   def response(**args)

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -68,6 +68,11 @@ module Indexable
 
       sqs.send_message(options)
     end
+
+    def ror_from_url(url)
+      ror = Array(/\A(?:(http|https):\/\/)?(ror\.org\/)?(.+)/.match(url)).last
+      "ror.org/#{ror}" if ror.present?
+    end
   end
 
   module ClassMethods
@@ -590,7 +595,8 @@ module Indexable
     end
 
     def ror_from_url(url)
-      Array(/\A(?:(http|https):\/\/)?(ror\.org\/)?(.+)/.match(url)).last
+      ror = Array(/\A(?:(http|https):\/\/)?(ror\.org\/)?(.+)/.match(url)).last
+      "ror.org/#{ror}" if ror.present?
     end
   end
 end

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -201,6 +201,11 @@ class Doi < ActiveRecord::Base
       indexes :provider_id,                    type: :keyword
       indexes :consortium_id,                  type: :keyword
       indexes :resource_type_id,               type: :keyword
+      indexes :affiliation_id,                 type: :keyword
+      indexes :client_id_and_name,             type: :keyword
+      indexes :provider_id_and_name,           type: :keyword
+      indexes :resource_type_id_and_name,      type: :keyword
+      indexes :affiliation_id_and_name,        type: :keyword
       indexes :media_ids,                      type: :keyword
       indexes :media,                          type: :object, properties: {
         type: { type: :keyword },
@@ -457,6 +462,11 @@ class Doi < ActiveRecord::Base
       "provider_id" => provider_id,
       "consortium_id" => consortium_id,
       "resource_type_id" => resource_type_id,
+      "client_id_and_name" => client_id_and_name,
+      "provider_id_and_name" => provider_id_and_name,
+      "resource_type_id_and_name" => resource_type_id_and_name,
+      "affiliation_id" => affiliation_id,
+      "affiliation_id_and_name" => affiliation_id_and_name,
       "media_ids" => media_ids,
       "view_count" => view_count,
       "views_over_time" => views_over_time,
@@ -515,15 +525,15 @@ class Doi < ActiveRecord::Base
 
   def self.query_aggregations
     {
-      resource_types: { terms: { field: 'types.resourceTypeGeneral', size: 16, min_doc_count: 1 } },
+      resource_types: { terms: { field: 'resource_type_id_and_name', size: 16, min_doc_count: 1 } },
       states: { terms: { field: 'aasm_state', size: 3, min_doc_count: 1 } },
       years: { date_histogram: { field: 'publication_year', interval: 'year', min_doc_count: 1 } },
       registration_agencies: { terms: { field: 'agency', size: 10, min_doc_count: 1 } },
       created: { date_histogram: { field: 'created', interval: 'year', min_doc_count: 1 } },
       registered: { date_histogram: { field: 'registered', interval: 'year', min_doc_count: 1 } },
-      providers: { terms: { field: 'provider_id', size: 15, min_doc_count: 1} },
-      clients: { terms: { field: 'client_id', size: 15, min_doc_count: 1 } },
-      affiliations: { terms: { field: 'creators.affiliation.affiliationIdentifier', size: 15, min_doc_count: 1 } },
+      providers: { terms: { field: 'provider_id_and_name', size: 15, min_doc_count: 1} },
+      clients: { terms: { field: 'client_id_and_name', size: 15, min_doc_count: 1 } },
+      affiliations: { terms: { field: 'affiliation_id_and_name', size: 15, min_doc_count: 1 } },
       prefixes: { terms: { field: 'prefix', size: 15, min_doc_count: 1 } },
       schema_versions: { terms: { field: 'schema_version', size: 15, min_doc_count: 1 } },
       link_checks_status: { terms: { field: 'landing_page.status', size: 15, min_doc_count: 1 } },
@@ -735,7 +745,7 @@ class Doi < ActiveRecord::Base
     must << { terms: { aasm_state: options[:state].to_s.split(",") }} if options[:state].present?
     must << { range: { registered: { gte: "#{options[:registered].split(",").min}||/y", lte: "#{options[:registered].split(",").max}||/y", format: "yyyy" }}} if options[:registered].present?
     must << { term: { "creators.nameIdentifiers.nameIdentifier" => "https://orcid.org/#{orcid_from_url(options[:user_id])}" }} if options[:user_id].present?
-    must << { term: { "creators.affiliation.affiliationIdentifier" => "https://ror.org/#{ror_from_url(options[:affiliation_id])}" }} if options[:affiliation_id].present?
+    must << { term: { "affiliation_id" => "https://ror.org/#{ror_from_url(options[:affiliation_id])}" }} if options[:affiliation_id].present?
     must << { term: { "funding_references.funderIdentifier" => "https://doi.org/#{doi_from_url(options[:funder_id])}" }} if options[:funder_id].present?
     must << { term: { "creators.nameIdentifiers.nameIdentifierScheme" => "ORCID" }} if options[:has_person].present?
     must << { term: { "creators.affiliation.affiliationIdentifierScheme" => "ROR" }} if options[:has_organization].present?
@@ -1015,6 +1025,10 @@ class Doi < ActiveRecord::Base
     types["resourceTypeGeneral"].underscore.dasherize if types.to_h["resourceTypeGeneral"].present?
   rescue TypeError
     nil
+  end
+
+  def resource_type_id_and_name
+    "#{resource_type_id}:#{types["resourceTypeGeneral"]}" if types.to_h["resourceTypeGeneral"].present?
   end
 
   def media_ids
@@ -1336,6 +1350,10 @@ class Doi < ActiveRecord::Base
     client.symbol.downcase if client.present?
   end
 
+  def client_id_and_name
+    "#{client_id}:#{client.name}" if client.present?
+  end
+
   def client_id=(value)
     r = ::Client.where(symbol: value).first
     fail ActiveRecord::RecordNotFound unless r.present?
@@ -1345,6 +1363,30 @@ class Doi < ActiveRecord::Base
 
   def provider_id
     client.provider.symbol.downcase if client.present?
+  end
+
+  def provider_id_and_name
+    "#{provider_id}:#{client.provider.name}" if client.present?
+  end
+
+  def affiliation_id
+    Array.wrap(creators).reduce([]) do |sum, creator|
+      Array.wrap(creator.fetch("affiliation", nil)).each do |affiliation|
+        sum << affiliation.fetch("affiliationIdentifier", nil) if affiliation.fetch("affiliationIdentifierScheme", nil) == "ROR"
+      end
+
+      sum
+    end
+  end
+
+  def affiliation_id_and_name
+    Array.wrap(creators).reduce([]) do |sum, creator|
+      Array.wrap(creator.fetch("affiliation", nil)).each do |affiliation|
+        sum << "#{affiliation.fetch("affiliationIdentifier", nil).to_s}:#{affiliation.fetch("name", nil).to_s}" if affiliation.fetch("affiliationIdentifierScheme", nil) == "ROR"
+      end
+      
+      sum
+    end
   end
 
   def prefix

--- a/spec/concerns/indexable_spec.rb
+++ b/spec/concerns/indexable_spec.rb
@@ -184,22 +184,27 @@ describe "Indexable class methods", elasticsearch: true do
 
       it "as id" do
         ror_id = "ror.org/046ak2485"
-        expect(subject.ror_from_url(ror_id)).to eq("046ak2485")
+        expect(subject.ror_from_url(ror_id)).to eq("ror.org/046ak2485")
       end
 
       it "as short id" do
         ror_id = "046ak2485"
-        expect(subject.ror_from_url(ror_id)).to eq("046ak2485")
+        expect(subject.ror_from_url(ror_id)).to eq("ror.org/046ak2485")
       end
 
       it "as url" do
         ror_id = "https://ror.org/046ak2485"
-        expect(subject.ror_from_url(ror_id)).to eq("046ak2485")
+        expect(subject.ror_from_url(ror_id)).to eq("ror.org/046ak2485")
       end
 
       it "as http url" do
         ror_id = "http://ror.org/046ak2485"
-        expect(subject.ror_from_url(ror_id)).to eq("046ak2485")
+        expect(subject.ror_from_url(ror_id)).to eq("ror.org/046ak2485")
+      end
+
+      it "nil" do
+        ror_id = nil
+        expect(subject.ror_from_url(ror_id)).to be_nil
       end
     end
 


### PR DESCRIPTION
This change removes database or Elasticsearch calls from the facets used in the DOIs controller, and should give a significant performance boost. More details about the approach can be found in #468.