### PR TITLE
Feature rake tasks for data cleaning in our index

### DIFF
--- a/app/jobs/delete_event_by_attribute_job.rb
+++ b/app/jobs/delete_event_by_attribute_job.rb
@@ -1,0 +1,9 @@
+class DeleteEventByAttributeJob < ActiveJob::Base
+  queue_as :lupo_background
+
+  def perform(ids, options = {})
+    ids.each do |id|
+      Event.where({ uuid: id }.merge(options)).destroy_all
+    end
+  end
+end

--- a/app/jobs/delete_event_by_attribute_job.rb
+++ b/app/jobs/delete_event_by_attribute_job.rb
@@ -1,9 +1,7 @@
 class DeleteEventByAttributeJob < ActiveJob::Base
   queue_as :lupo_background
 
-  def perform(ids, options = {})
-    ids.each do |id|
-      Event.where({ uuid: id }.merge(options)).destroy_all
-    end
+  def perform(id, options = {})
+    Event.where({ uuid: id }.merge(options)).destroy_all
   end
 end

--- a/app/jobs/schema_version_job.rb
+++ b/app/jobs/schema_version_job.rb
@@ -3,19 +3,17 @@ class SchemaVersionJob < ActiveJob::Base
 
   include Crosscitable
 
-  def perform(ids, options = {})
-    ids.each do |id|
-      doi = Doi.where(doi: id, schema_version: nil).first
-      xml = doi.xml
-      metadata = xml.present? ? parse_xml(xml, doi: id) : {}
+  def perform(id, options = {})
+    doi = Doi.where(doi: id, schema_version: nil).first
+    xml = doi.xml
+    metadata = xml.present? ? parse_xml(xml, doi: id) : {}
 
-      if doi.blank? || metadata["schema_version"].blank?
-        Rails.logger.error "[SchemaVersion] Error updating schema_version for DOI " + id + ": not found"
-      elsif doi.update(schema_version: metadata["schema_version"])
-        Rails.logger.info "[SchemaVersion] Successfully updated schema_version for DOI " + id
-      else
-        Rails.logger.error "[SchemaVersion] Error updating schema_version for DOI " + id + ": " + errors.inspect
-      end
+    if doi.blank? || metadata["schema_version"].blank?
+      Rails.logger.error "[SchemaVersion] Error updating schema_version for DOI " + id + ": not found"
+    elsif doi.update(schema_version: metadata["schema_version"])
+      Rails.logger.info "[SchemaVersion] Successfully updated schema_version for DOI " + id
+    else
+      Rails.logger.error "[SchemaVersion] Error updating schema_version for DOI " + id + ": " + errors.inspect
     end
   end
 end

--- a/app/jobs/schema_version_job.rb
+++ b/app/jobs/schema_version_job.rb
@@ -1,0 +1,21 @@
+class SchemaVersionJob < ActiveJob::Base
+  queue_as :lupo_background
+
+  include Crosscitable
+
+  def perform(ids, options = {})
+    ids.each do |id|
+      doi = Doi.where(doi: id, schema_version: nil).first
+      xml = doi.xml
+      metadata = xml.present? ? parse_xml(xml, doi: id) : {}
+
+      if doi.blank? || metadata["schema_version"].blank?
+        Rails.logger.error "[SchemaVersion] Error updating schema_version for DOI " + id + ": not found"
+      elsif doi.update(schema_version: metadata["schema_version"])
+        Rails.logger.info "[SchemaVersion] Successfully updated schema_version for DOI " + id
+      else
+        Rails.logger.error "[SchemaVersion] Error updating schema_version for DOI " + id + ": " + errors.inspect
+      end
+    end
+  end
+end

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -28,7 +28,11 @@ module Indexable
     after_commit on: [:destroy] do
       begin
         __elasticsearch__.delete_document
-        Rails.logger.warn "#{self.class.name} #{uid} deleted from Elasticsearch index."
+        if self.class.name == "Event"
+          Rails.logger.warn "#{self.class.name} #{uuid} deleted from Elasticsearch index."
+        else
+          Rails.logger.warn "#{self.class.name} #{uid} deleted from Elasticsearch index."
+        end
         # send_delete_message(self.to_jsonapi) if self.class.name == "Doi" && !Rails.env.test?
 
         # reindex prefix

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -1776,7 +1776,7 @@ class Doi < ActiveRecord::Base
     query_hsh = {page: { size: 1, cursor: [] } }.merge(filter)
 
     response = Doi.query(query, query_hsh)
-    Rails.logger.warn "#{label} #{response.results.total} Dois with #{label}."
+    Rails.logger.info "#{label} #{response.results.total} Dois with #{label}."
 
     # walk through results using cursor
     if response.results.total.positive?
@@ -1784,12 +1784,14 @@ class Doi < ActiveRecord::Base
         response = Doi.query(query, query_hsh.merge!(page: { size: size, cursor: cursor }))
         break unless response.results.results.length.positive?
 
-        Rails.logger.warn "#{label} #{response.results.results.length}  Dois starting with _id #{response.results.to_a.first[:_id]}."
+        Rails.logger.info "#{label} #{response.results.results.length}  Dois starting with _id #{response.results.to_a.first[:_id]}."
         cursor = response.results.to_a.last[:sort]
-        Rails.logger.warn "#{label} Cursor: #{cursor} "
+        Rails.logger.info "#{label} Cursor: #{cursor} "
 
-        ids = response.results.results.map(&:uid).uniq
-        Object.const_get(job_name).perform_later(ids, filter)
+        ids = response.results.results.map(&:uid)
+        ids.each do |id|
+          Object.const_get(job_name).perform_later(id, filter)
+        end
       end
     end
   end

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -1786,7 +1786,7 @@ class Doi < ActiveRecord::Base
     # walk through results using cursor
     if response.results.total.positive?
       while response.results.results.length.positive?
-        response = Doi.query(query, filter.merge!(page: { size: size, cursor: cursor }))
+        response = Doi.query(query, filter.merge(page: { size: size, cursor: cursor }))
         break unless response.results.results.length.positive?
 
         Rails.logger.info "#{label} #{response.results.results.length}  Dois starting with _id #{response.results.to_a.first[:_id]}."

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -1765,6 +1765,36 @@ class Doi < ActiveRecord::Base
     response.results.total
   end
 
+  def self.loop_through_dois(options)
+    size = (options[:size] || 1000).to_i
+    cursor = [options[:from_id], options[:until_id]]
+    filter = options[:filter] || {}  
+    label = options[:label] || "" 
+    job_name = options[:job_name] || "" 
+    query = options[:query] || nil
+
+    query_hsh = {page: { size: 1, cursor: [] } }.merge(filter)
+
+    response = Doi.query(query, query_hsh)
+    Rails.logger.warn "#{label} #{response.results.total} Dois with #{label}."
+
+    # walk through results using cursor
+    if response.results.total.positive?
+      while response.results.results.length.positive?
+        response = Doi.query(query, query_hsh.merge!(page: { size: size, cursor: cursor }))
+        break unless response.results.results.length.positive?
+
+        Rails.logger.warn "#{label} #{response.results.results.length}  Dois starting with _id #{response.results.to_a.first[:_id]}."
+        cursor = response.results.to_a.last[:sort]
+        Rails.logger.warn "#{label} Cursor: #{cursor} "
+
+        ids = response.results.results.map(&:uid).uniq
+        Object.const_get(job_name).perform_later(ids, filter)
+      end
+    end
+  end
+
+
   # save to metadata table when xml has changed
   def save_metadata
     metadata.build(doi: self, xml: xml, namespace: schema_version) if xml.present? && xml_changed?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -511,23 +511,27 @@ class Event < ActiveRecord::Base
     end
   end
 
+  # Transverses the index in batches and using the cursor pagination and executes a Job that matches the query and filer
+  # Options:
+  # +filter+:: paramaters to filter the index
+  # +label+:: String to output in the logs printout
+  # +query+:: ES query to filter the index
+  # +job_name+:: Acive Job class name of the Job that would be executed on every matched results 
   def self.loop_through_events(options)
     size = (options[:size] || 1000).to_i
     cursor = [options[:from_id], options[:until_id]]
-    filter = options[:filter] || {} 
-    label = options[:label] || "" 
-    job_name = options[:job_name] || "" 
+    filter = options[:filter] || {}
+    label = options[:label] || ""
+    job_name = options[:job_name] || ""
     query = options[:query] || nil
 
-    query_hsh = {page: { size: 1, cursor: [] } }.merge(filter)
-
-    response = Event.query(query, query_hsh)
+    response = Event.query(query, filter.merge(page: { size: 1, cursor: [] }))
     Rails.logger.info "#{label} #{response.results.total} events with #{label}."
 
     # walk through results using cursor
     if response.results.total.positive?
       while response.results.results.length.positive?
-        response = Event.query(query, query_hsh.merge!(page: { size: size, cursor: cursor }))
+        response = Event.query(query, filter.merge(page: { size: size, cursor: cursor }))
         break unless response.results.results.length.positive?
 
         Rails.logger.info "#{label} #{response.results.results.length}  events starting with _id #{response.results.to_a.first[:_id]}."

--- a/lib/tasks/doi.rake
+++ b/lib/tasks/doi.rake
@@ -94,7 +94,7 @@ namespace :doi do
     options = {
       from_id: (ENV["FROM_ID"] || Doi.minimum(:id)).to_i,
       until_id: (ENV["UNTIL_ID"] || Doi.maximum(:id)).to_i,
-      query: "+aasm_state:findable -schema_version:*",
+      query: "+aasm_state:findable&&registered -schema_version:*",
       label: "[SetSchemaVersion]",
       job_name: "SchemaVersionJob",
     }

--- a/lib/tasks/doi.rake
+++ b/lib/tasks/doi.rake
@@ -89,6 +89,18 @@ namespace :doi do
     Doi.set_minted
   end
 
+  desc "Set schema version"
+  task set_schema_version: :environment do
+    options = {
+      from_id: (ENV["FROM_ID"] || Doi.minimum(:id)).to_i,
+      until_id: (ENV["UNTIL_ID"] || Doi.maximum(:id)).to_i,
+      query: "+aasm_state:findable -schema_version:*",
+      label: "[SetSchemaVersion]",
+      job_name: "SchemaVersionJob",
+    }
+    Doi.loop_through_dois(options)
+  end
+
   desc 'Convert affiliations to new format'
   task :convert_affiliations => :environment do
     from_id = (ENV['FROM_ID'] || Doi.minimum(:id)).to_i

--- a/lib/tasks/doi.rake
+++ b/lib/tasks/doi.rake
@@ -94,7 +94,7 @@ namespace :doi do
     options = {
       from_id: (ENV["FROM_ID"] || Doi.minimum(:id)).to_i,
       until_id: (ENV["UNTIL_ID"] || Doi.maximum(:id)).to_i,
-      query: "+aasm_state:findable&&registered -schema_version:*",
+      query: "+aasm_state:(findable OR registered) -schema_version:*",
       label: "[SetSchemaVersion]",
       job_name: "SchemaVersionJob",
     }

--- a/lib/tasks/event.rake
+++ b/lib/tasks/event.rake
@@ -79,12 +79,25 @@ namespace :crossref do
 end
 
 namespace :subj_id_check do
-  desc 'checks that events subject node congruency'
-  task :check => :environment do
-    from_id = (ENV['FROM_ID'] || Event.minimum(:id)).to_i
-    until_id = (ENV['UNTIL_ID'] || Event.maximum(:id)).to_i
-    
+  desc "checks that events subject node congruency"
+  task check: :environment do
+    from_id = (ENV["FROM_ID"] || Event.minimum(:id)).to_i
+    until_id = (ENV["UNTIL_ID"] || Event.maximum(:id)).to_i
     Event.subj_id_check(from_id: from_id, until_id: until_id)
+  end
+end
+
+namespace :crossref_events do
+  desc "delete events labeled with crossref errors"
+  task delete: :environment do
+    options = {
+      from_id: (ENV["FROM_ID"] || Event.minimum(:id)).to_i,
+      until_id: (ENV["UNTIL_ID"] || Event.maximum(:id)).to_i,
+      filter: { state_event: "crossref_citations_error" },
+      label: "[DeleteEventwithCrossrefError]",
+      job_name: "DeleteEventByAttributeJob",
+    }
+    Event.loop_through_events(options)
   end
 end
 

--- a/lib/tasks/event.rake
+++ b/lib/tasks/event.rake
@@ -78,22 +78,21 @@ namespace :crossref do
   end
 end
 
-namespace :subj_id_check do
-  desc "checks that events subject node is congruent with relation_type and source"
+namespace :crossref_events do
+  desc "checks that events subject node is congruent with relation_type and source. it labels it with an error if not"
   task check: :environment do
     from_id = (ENV["FROM_ID"] || Event.minimum(:id)).to_i
     until_id = (ENV["UNTIL_ID"] || Event.maximum(:id)).to_i
     Event.subj_id_check(from_id: from_id, until_id: until_id)
   end
-end
 
-namespace :crossref_events do
   desc "delete events labeled with crossref errors"
   task delete: :environment do
     options = {
       from_id: (ENV["FROM_ID"] || Event.minimum(:id)).to_i,
       until_id: (ENV["UNTIL_ID"] || Event.maximum(:id)).to_i,
       filter: { state_event: "crossref_citations_error" },
+      query: "+state_event:crossref_citations_error",
       label: "[DeleteEventwithCrossrefError]",
       job_name: "DeleteEventByAttributeJob",
     }

--- a/lib/tasks/event.rake
+++ b/lib/tasks/event.rake
@@ -79,7 +79,7 @@ namespace :crossref do
 end
 
 namespace :subj_id_check do
-  desc "checks that events subject node congruency"
+  desc "checks that events subject node is congruent with relation_type and source"
   task check: :environment do
     from_id = (ENV["FROM_ID"] || Event.minimum(:id)).to_i
     until_id = (ENV["UNTIL_ID"] || Event.maximum(:id)).to_i


### PR DESCRIPTION
## Description

Two rake tasks to clear erroneous data in our index/db.

- Rake task to remove events with double crossref errors, that have been already labeled. This task can be used once Crossref green-flag us from removing the events. related: #351
- Rake task to schema_version for old dois missing schema version. related: datacite/bracco#225

## List of General Components affected

- rake task
- model method
- background job

## Status
- [x] Ready for Review

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Non Functional Requirement
- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] All new and existing tests passed.
- [ ] Documentation
