### PR TITLE
Log post and put actions for dois and events

### DIFF
--- a/app/controllers/dois_controller.rb
+++ b/app/controllers/dois_controller.rb
@@ -356,6 +356,7 @@ class DoisController < ApplicationController
         affiliation: params[:affiliation]
       }
 
+      logger.warn "Created DOI #{@doi.doi}"
       render json: DoiSerializer.new(@doi, options).serialized_json, status: :created, location: @doi
     else
       logger.error @doi.errors.inspect
@@ -405,6 +406,7 @@ class DoisController < ApplicationController
         affiliation: params[:affiliation],
       }
 
+      logger.warn exists ? "Updated DOI #{@doi.doi}" : "Created DOI #{@doi.doi}"
       render json: DoiSerializer.new(@doi, options).serialized_json, status: exists ? :ok : :created
     else
       logger.error @doi.errors.messages

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -26,9 +26,10 @@ class EventsController < ApplicationController
     if @event.update_attributes(safe_params)
       options = {}
       options[:is_collection] = false
-
+      logger.warn "Created event #{@event.uuid} with source_id #{@event.source_id}"
       render json: EventSerializer.new(@event, options).serialized_json, status: exists ? :ok : :created
     else
+      logger.error @event.errors.inspect
       errors = @event.errors.full_messages.map { |message| { status: 422, title: message } }
       render json: { errors: errors }, status: :unprocessable_entity
     end
@@ -47,8 +48,10 @@ class EventsController < ApplicationController
       options = {}
       options[:is_collection] = false
 
+      logger.warn "Updated event #{@event.uuid} with source_id #{@event.source_id}"
       render json: EventSerializer.new(@event, options).serialized_json, status: exists ? :ok : :created
     else
+      logger.error @event.errors.inspect
       errors = @event.errors.full_messages.map { |message| { status: 422, title: message } }
       render json: { errors: errors }, status: :unprocessable_entity
     end


### PR DESCRIPTION
Our logs currently don't capture all POST and PUT events for dois and events, as not all go via the load balancer. This makes it hard to track the number of dois and events where the database is updated.