### PR TITLE
use correct hash_key for repository and member. #501

### DIFF
--- a/app/graphql/types/doi_item.rb
+++ b/app/graphql/types/doi_item.rb
@@ -32,8 +32,8 @@ module DoiItem
   end
   field :funding_references, [FundingType], null: true, description: "Information about financial support (funding) for the resource being registered"
   field :url, Url, null: true, description: "The URL registered for the resource"
-  field :repository, RepositoryType, null: true, description: "The repository account managing this resource"
-  field :member, MemberType, null: true, description: "The member account managing this resource"
+  field :repository, RepositoryType, null: true,  hash_key: "client", description: "The repository account managing this resource"
+  field :member, MemberType, null: true, hash_key: "provider", description: "The member account managing this resource"
   field :registration_agency, String, hash_key: "agency", null: true, description: "The DOI registration agency for the resource"
   field :formatted_citation, String, null: true, description: "Metadata as formatted citation" do
     argument :style, String, required: false, default_value: "apa"

--- a/spec/graphql/types/work_type_spec.rb
+++ b/spec/graphql/types/work_type_spec.rb
@@ -20,6 +20,16 @@ describe WorkType do
       %(query {
         work(id: "https://doi.org/#{work.doi}") {
           id
+          repository {
+            id
+            type
+            name
+          }
+          member {
+            id
+            type
+            name
+          }
           bibtex
         }
       })
@@ -28,6 +38,11 @@ describe WorkType do
     it "returns work" do
       response = LupoSchema.execute(query).as_json
 
+      expect(response.dig("data", "work", "id")).to eq("https://handle.test.datacite.org/#{work.doi.downcase}")
+      expect(response.dig("data", "work", "repository", "id")).to eq(work.client_id)
+      expect(response.dig("data", "work", "repository", "name")).to eq(work.client.name)
+      expect(response.dig("data", "work", "member", "id")).to eq(work.provider_id)
+      expect(response.dig("data", "work", "member", "name")).to eq(work.provider.name)
       expect(response.dig("data", "work", "id")).to eq("https://handle.test.datacite.org/#{work.doi.downcase}")
       bibtex = BibTeX.parse(response.dig("data", "work", "bibtex")).to_a(quotes: '').first
       expect(bibtex[:bibtex_type].to_s).to eq("misc")


### PR DESCRIPTION
Custom hash_key for `doi_item`.

Fixing #501 
