### PR TITLE
show provider facets for repositories and prefixes

### DIFF
--- a/app/controllers/provider_prefixes_controller.rb
+++ b/app/controllers/provider_prefixes_controller.rb
@@ -33,9 +33,9 @@ class ProviderPrefixesController < ApplicationController
     begin
       total = response.results.total
       total_pages = page[:size].positive? ? (total.to_f / page[:size]).ceil : 0
-      years = total.positive? ? facet_by_year(response.response.aggregations.years.buckets) : nil
-      states = total.positive? ? facet_by_key(response.response.aggregations.states.buckets) : nil
-      providers = total.positive? ? facet_by_combined_key(response.response.aggregations.providers.buckets) : nil
+      years = total.positive? ? facet_by_year(response.aggregations.years.buckets) : nil
+      states = total.positive? ? facet_by_key(response.aggregations.states.buckets) : nil
+      providers = total.positive? ? facet_by_combined_key(response.aggregations.providers.buckets) : nil
 
       provider_prefixes = response.results
 

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -86,6 +86,7 @@ class Client < ActiveRecord::Base
       indexes :uid,           type: :keyword, normalizer: "keyword_lowercase"
       indexes :symbol,        type: :keyword
       indexes :provider_id,   type: :keyword
+      indexes :provider_id_and_name, type: :keyword
       indexes :consortium_id, type: :keyword
       indexes :re3data_id,    type: :keyword
       indexes :opendoar_id,   type: :integer
@@ -211,6 +212,7 @@ class Client < ActiveRecord::Base
       "id" => uid,
       "uid" => uid,
       "provider_id" => provider_id,
+      "provider_id_and_name" => provider_id_and_name,
       "consortium_id" => consortium_id,
       "re3data_id" => re3data_id,
       "opendoar_id" => opendoar_id,
@@ -252,7 +254,7 @@ class Client < ActiveRecord::Base
       years: { date_histogram: { field: 'created', interval: 'year', format: 'year', order: { _key: "desc" }, min_doc_count: 1 },
                aggs: { bucket_truncate: { bucket_sort: { size: 10 } } } },
       cumulative_years: { terms: { field: 'cumulative_years', size: 10, min_doc_count: 1, order: { _count: "asc" } } },
-      providers: { terms: { field: 'provider_id', size: 10, min_doc_count: 1 } },
+      providers: { terms: { field: 'provider_id_and_name', size: 10, min_doc_count: 1 } },
       software: { terms: { field: 'software.keyword', size: 10, min_doc_count: 1 } },
       client_types: { terms: { field: 'client_type', size: 10, min_doc_count: 1 } },
       repository_types: { terms: { field: 'repository_type', size: 10, min_doc_count: 1 } },
@@ -289,6 +291,10 @@ class Client < ActiveRecord::Base
   # workaround for non-standard database column names and association
   def provider_id
     provider_symbol.downcase
+  end
+
+  def provider_id_and_name
+    "#{provider_id}:#{provider.name}"
   end
 
   def provider_id=(value)

--- a/app/models/provider_prefix.rb
+++ b/app/models/provider_prefix.rb
@@ -24,6 +24,7 @@ class ProviderPrefix < ActiveRecord::Base
     indexes :uid,               type: :keyword
     indexes :state,             type: :keyword
     indexes :provider_id,       type: :keyword
+    indexes :provider_id_and_name, type: :keyword
     indexes :consortium_id,     type: :keyword
     indexes :prefix_id,         type: :keyword
     indexes :client_ids,        type: :keyword
@@ -51,6 +52,7 @@ class ProviderPrefix < ActiveRecord::Base
       "id" => uid,
       "uid" => uid,
       "provider_id" => provider_id,
+      "provider_id_and_name" => provider_id_and_name,
       "consortium_id" => consortium_id,
       "prefix_id" => prefix_id,
       "client_ids" => client_ids,

--- a/spec/requests/provider_prefixes_spec.rb
+++ b/spec/requests/provider_prefixes_spec.rb
@@ -23,6 +23,9 @@ describe "Provider Prefixes", type: :request, elasticsearch: true do
 
       expect(last_response.status).to eq(200)
       expect(json["data"].size).to eq(3)
+      expect(json.dig('meta', 'years')).to eq([{"count"=>3, "id"=>"2020", "title"=>"2020"}])
+      expect(json.dig('meta', 'states')).to eq([{"count"=>3, "id"=>"without-repository", "title"=>"Without Repository"}])
+      expect(json.dig('meta', 'providers')).to eq([{"count"=>3, "id"=>provider.symbol.downcase, "title"=>"My provider"}])
     end
   end
 

--- a/spec/requests/repositories_spec.rb
+++ b/spec/requests/repositories_spec.rb
@@ -44,6 +44,8 @@ describe 'Repositories', type: :request, elasticsearch: true do
       expect(last_response.status).to eq(200)
       expect(json['data'].size).to eq(4)
       expect(json.dig('meta', 'total')).to eq(4)
+      expect(json.dig('meta', 'providers').length).to eq(4)
+      expect(json.dig('meta', 'providers').first).to eq("count"=>1, "id"=>provider.symbol.downcase, "title"=>"My provider")
     end
   end
 


### PR DESCRIPTION
This is a regression error from the changes we made to facets with providers two weeks ago. This pull request fixes that, and adds tests.

Fixes https://github.com/datacite/bracco/issues/409