### PR TITLE
Fix prefixes build order in repository transfer

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -366,13 +366,16 @@ class Client < ActiveRecord::Base
 
     if prefix_ids.present?
       response = ProviderPrefix.where("prefix_id IN (?)", prefix_ids).destroy_all
-      puts "#{response.count} provider prefixes deleted."
+      Rails.logger.info "[Transfer] #{response.count} provider prefixes deleted."
     end
 
-    # Assign prefix(es) to provider
+    # Assign prefix(es) to provider and client
     prefixes_names.each do |prefix|
-      ProviderPrefix.create(provider_id: target_id, prefix_id: prefix)
-      puts "Provider prefix for provider #{target_id} and prefix #{prefix} created."
+      provider_prefix = ProviderPrefix.create(provider_id: target_id, prefix_id: prefix)
+      Rails.logger.info "[Transfer] Provider prefix for provider #{target_id} and prefix #{prefix} created."
+
+      ClientPrefix.create(client_id: symbol, provider_prefix_id: provider_prefix.uid, prefix_id: prefix)
+      Rails.logger.info "Client prefix for client #{symbol} and prefix #{prefix} created."
     end
   end
 

--- a/db/seeds/development/base.seeds.rb
+++ b/db/seeds/development/base.seeds.rb
@@ -8,7 +8,7 @@ provider = Provider.where(symbol: "DATACITE").first || FactoryBot.create(:provid
 client = Client.where(symbol: "DATACITE.TEST").first || FactoryBot.create(:client, provider: provider, symbol: ENV["MDS_USERNAME"], password: ENV["MDS_PASSWORD"]) 
 if Prefix.where(uid: "10.14454").blank?
   prefix = FactoryBot.create(:prefix, uid: "10.14454") 
-  FactoryBot.create(:provider_prefix, provider_id: provider.symbol, prefix_id: prefix.uid) 
+  ### This creates both the client_prefix and the pprovider association
   FactoryBot.create(:client_prefix, client_id: client.symbol, prefix_id: prefix.uid) 
 end
 dois = FactoryBot.create_list(:doi, 10, client: client, state: "findable")

--- a/db/seeds/development/consortium_transfer.seeds.rb
+++ b/db/seeds/development/consortium_transfer.seeds.rb
@@ -3,13 +3,13 @@ require "factory_bot_rails"
 fail "Seed tasks can only be used in the development enviroment" if Rails.env.production?
 
 after "development:base" do
-
   provider = Provider.where(symbol: "QUECHUA").first || FactoryBot.create(:provider, symbol: "QUECHUA")
   client = Client.where(symbol: "QUECHUA.TEXT").first || FactoryBot.create(:client, provider: provider, symbol: "QUECHUA.TEXT", password: ENV["MDS_PASSWORD"]) 
   if Prefix.where(uid: "10.14459").blank?
     prefix = FactoryBot.create(:prefix, uid: "10.14459")
-    FactoryBot.create(:provider_prefix, provider_id: provider.symbol, prefix_id: prefix.uid) 
-    FactoryBot.create(:client_prefix, client_id: client.symbol, prefix_id: prefix.uid)
+    ## one needs to create the provider first so the assignation is made
+    provider_prefix_id = FactoryBot.create(:provider_prefix, provider_id: provider.symbol, prefix_id: prefix.uid) 
+    FactoryBot.create(:client_prefix, client_id: client.symbol, prefix_id: prefix.uid, provider_prefix_id: provider_prefix_id.uid)
   end
   dois = FactoryBot.create_list(:doi, 10, client: client, state: "findable")
   FactoryBot.create_list(:event_for_datacite_related, 3, obj_id: dois.first.doi)

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -27,9 +27,11 @@ describe Client, type: :model do
     let!(:prefixes) { create_list(:prefix, 3) }
     let!(:prefix) { prefixes.first }
 
-    let!(:client_prefix)  { create(:client_prefix, client: client, prefix: prefix) }
+    ### Order is important in creating prefixes relations
     let!(:provider_prefix)  { create(:provider_prefix, provider: provider, prefix: prefix) }
     let!(:provider_prefix_more) { create(:provider_prefix, provider: provider, prefix: prefixes.last) }
+    let!(:client_prefix)  { create(:client_prefix, client: client, prefix: prefix, provider_prefix_id: provider_prefix.uid) }
+
     let(:new_provider) { create(:provider, symbol: "QUECHUA", member_type: "direct_member") }
     let(:options) { { target_id: new_provider.symbol } }
     let(:bad_options) { { target_id: "SALS" } }
@@ -44,6 +46,8 @@ describe Client, type: :model do
 
         expect(new_provider.prefix_ids).to include(prefix.uid)
         expect(provider.prefix_ids).not_to include(prefix.uid)
+
+        expect(client.prefix_ids).to include(prefix.uid)
       end
 
       it "it doesn't transfer" do
@@ -101,9 +105,10 @@ describe Client, type: :model do
   describe "Client prefixes transfer" do
     let!(:prefixes) { create_list(:prefix, 3) }
     let!(:prefix) { prefixes.first }
-    let!(:client_prefix)  { create(:client_prefix, client: client, prefix: prefix) }
-    let!(:provider_prefix)  { create(:provider_prefix, provider: provider, prefix: prefix) }
+     ### Order is important in creating prefixes relations
+    let!(:provider_prefix) { create(:provider_prefix, provider: provider, prefix: prefix) }
     let!(:provider_prefix_more) { create(:provider_prefix, provider: provider, prefix: prefixes.last) }
+    let!(:client_prefix) { create(:client_prefix, client: client, prefix: prefix , provider_prefix_id: provider_prefix.uid) }
     let(:new_provider) { create(:provider, symbol: "QUECHUA") }
 
     it "works" do
@@ -114,9 +119,9 @@ describe Client, type: :model do
 
       expect(new_provider.prefix_ids).to include(prefix.uid)
       expect(provider.prefix_ids).not_to include(prefix.uid)
+      expect(client.prefix_ids).to include(prefix.uid)
     end
   end
-
 
   describe "methods" do
     it "should not update the symbol" do

--- a/spec/requests/clients_spec.rb
+++ b/spec/requests/clients_spec.rb
@@ -222,12 +222,10 @@ describe 'Clients', type: :request, elasticsearch: true do
       let(:new_provider) { create(:provider, symbol: "QUECHUA", password_input: "12345") }
       let!(:prefixes) { create_list(:prefix, 3) }
       let!(:prefix) { prefixes.first }
-      let!(:client_prefix) { create(:client_prefix, client: client, prefix: prefix) }
-      let!(:provider_prefix) { create(:provider_prefix, provider: provider, prefix: prefix) }
       let!(:provider_prefix_more) { create(:provider_prefix, provider: provider, prefix: prefixes.last) }
+      let!(:provider_prefix) { create(:provider_prefix, provider: provider, prefix: prefix) }
+      let!(:client_prefix) { create(:client_prefix, client: client, prefix: prefix, provider_prefix_id: provider_prefix.uid) }
       let(:doi) { create_list(:doi, 10, client: client) }
-
-
       let(:params) do
         {
           "data" => {
@@ -254,8 +252,10 @@ describe 'Clients', type: :request, elasticsearch: true do
         expect(json.dig("data", "relationships", "prefixes", "data").first.dig("id")).to eq(prefixes.last.uid)
 
         get "/providers/#{new_provider.symbol}"
-
         expect(json.dig("data", "relationships", "prefixes", "data").first.dig("id")).to eq(prefix.uid)
+
+        get "/prefixes/#{prefix.uid}"
+        expect(json.dig("data", "relationships", "clients", "data").first.dig("id")).to eq(client.symbol.downcase)
       end
     end
 

--- a/spec/requests/repositories_spec.rb
+++ b/spec/requests/repositories_spec.rb
@@ -287,8 +287,8 @@ describe 'Repositories', type: :request, elasticsearch: true do
 
       let(:new_provider) { create(:provider, symbol: "QUECHUA", password_input: "12345") }
       let!(:prefix) { create(:prefix) }
-      let!(:client_prefix) { create(:client_prefix, client: client, prefix: prefix) }
       let!(:provider_prefix) { create(:provider_prefix, provider: provider, prefix: prefix) }
+      let!(:client_prefix) { create(:client_prefix, client: client, prefix: prefix, provider_prefix_id: provider_prefix.uid) }
       let(:doi) { create_list(:doi, 10, client: client) }
 
       let(:params) do
@@ -318,6 +318,9 @@ describe 'Repositories', type: :request, elasticsearch: true do
         get "/providers/#{new_provider.symbol}"
 
         expect(json.dig("data", "relationships", "prefixes", "data").first.dig("id")).to eq(prefix.uid)
+
+        get "/prefixes/#{prefix.uid}"
+        expect(json.dig("data", "relationships", "clients", "data").first.dig("id")).to eq(client.symbol.downcase)
       end
     end
 


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Repository transfer was not assigning prefixes to the repository at the end of the transfer. Test were not failing because the order of building prefixes associations was not correct.

related: https://github.com/datacite/lupo/pull/493

## Approach
<!--- _How does this change address the problem?_ -->

- changed order of data building in tests
- add recreate association step in transfer prefix method


## Learning
<!--- _Describe the research stage_ -->

ProviderPrefixes dependant association remove ClientPrefixes automatically.
https://github.com/datacite/lupo/blob/a59d225/app/models/provider_prefix.rb#L12

ProviderPrefixes building order when creating factory data matters.

<!--- _Links to blog posts, patterns, libraries or addons used to solve  -->

## Status
- [x] Ready for Review

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
