### PR TITLE
Allow export of multiple contacts with same email but different provider id

### DIFF
--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -51,23 +51,25 @@ class ExportController < ApplicationController
       csv = headers.to_csv
 
       # Use a hashmap for the contacts to avoid duplicated
-      contacts = Hash.new
+      contacts = {}
 
       add_contact = Proc.new { |contacts, email, id, firstname, lastname, type|
         if email
-          unless contacts.has_key?(email)
-            contacts[email] = {
+          fabrica_id = id + "-" + email
+          unless contacts.has_key?(fabrica_id)
+            contacts[fabrica_id] = {
               'fabricaAccountId' => id,
-              'fabricaId' => id + "-" + email,
+              'fabricaId' => fabrica_id,
+              'email' => email,
               'firstName' => firstname,
               'lastName' => lastname.present? ? lastname : email,
             }
           end
 
-          if contacts[email].has_key?('type')
-            contacts[email]['type'] += ";" + type
+          if contacts[fabrica_id].has_key?('type')
+            contacts[fabrica_id]['type'] += ";" + type
           else
-            contacts[email]['type'] = type
+            contacts[fabrica_id]['type'] = type
           end
         end
       }
@@ -90,11 +92,11 @@ class ExportController < ApplicationController
         end
       end
 
-      contacts.each do |email, contact|
+      contacts.each do |_, contact|
         csv += CSV.generate_line [
           contact['fabricaAccountId'],
           contact['fabricaId'],
-          email,
+          contact['email'],
           contact['firstName'],
           contact['lastName'],
           contact['type'],

--- a/spec/requests/exports_spec.rb
+++ b/spec/requests/exports_spec.rb
@@ -82,12 +82,16 @@ describe "exports", type: :request do
 
       expect(last_response.status).to eq(200)
       csv = last_response.body.lines
-      expect(csv.length).to eq(5)
+      expect(csv.length).to eq(9)
       expect(csv[0]).to eq("fabricaAccountId,fabricaId,email,firstName,lastName,type\n")
       expect(csv[1]).to start_with("VIVA,VIVA-kristian@example.com,kristian@example.com,Kristian,Garza,technical;secondaryTechnical")
       expect(csv[2]).to start_with("VIVA,VIVA-martin@example.com,martin@example.com,Martin,Fenner,service;secondaryService")
       expect(csv[3]).to start_with("VIVA,VIVA-robin@example.com,robin@example.com,Robin,Dasler,voting")
       expect(csv[4]).to start_with("VIVA,VIVA-trisha@example.com,trisha@example.com,Trisha,Cruse,billing;secondaryBilling")
+      expect(csv[5]).to start_with("UVA,UVA-kristian@example.com,kristian@example.com,Kristian,Garza,technical;secondaryTechnical")
+      expect(csv[6]).to start_with("UVA,UVA-martin@example.com,martin@example.com,Martin,Fenner,service;secondaryService")
+      expect(csv[7]).to start_with("UVA,UVA-robin@example.com,robin@example.com,Robin,Dasler,voting")
+      expect(csv[8]).to start_with("UVA,UVA-trisha@example.com,trisha@example.com,Trisha,Cruse,billing;secondaryBilling")
     end
 
     it 'returns all contacts from date', vcr: false do
@@ -95,12 +99,16 @@ describe "exports", type: :request do
 
       expect(last_response.status).to eq(200)
       csv = last_response.body.lines
-      expect(csv.length).to eq(5)
+      expect(csv.length).to eq(9)
       expect(csv[0]).to eq("fabricaAccountId,fabricaId,email,firstName,lastName,type\n")
       expect(csv[1]).to start_with("VIVA,VIVA-kristian@example.com,kristian@example.com,Kristian,Garza,technical;secondaryTechnical")
       expect(csv[2]).to start_with("VIVA,VIVA-martin@example.com,martin@example.com,Martin,Fenner,service;secondaryService")
       expect(csv[3]).to start_with("VIVA,VIVA-robin@example.com,robin@example.com,Robin,Dasler,voting")
       expect(csv[4]).to start_with("VIVA,VIVA-trisha@example.com,trisha@example.com,Trisha,Cruse,billing;secondaryBilling")
+      expect(csv[5]).to start_with("UVA,UVA-kristian@example.com,kristian@example.com,Kristian,Garza,technical;secondaryTechnical")
+      expect(csv[6]).to start_with("UVA,UVA-martin@example.com,martin@example.com,Martin,Fenner,service;secondaryService")
+      expect(csv[7]).to start_with("UVA,UVA-robin@example.com,robin@example.com,Robin,Dasler,voting")
+      expect(csv[8]).to start_with("UVA,UVA-trisha@example.com,trisha@example.com,Trisha,Cruse,billing;secondaryBilling")
     end
 
     it 'returns voting contacts', vcr: false do
@@ -108,9 +116,10 @@ describe "exports", type: :request do
 
       expect(last_response.status).to eq(200)
       csv = last_response.body.lines
-      expect(csv.length).to eq(2)
+      expect(csv.length).to eq(3)
       expect(csv[0]).to eq("fabricaAccountId,fabricaId,email,firstName,lastName,type\n")
       expect(csv[1]).to start_with("VIVA,VIVA-robin@example.com,robin@example.com,Robin,Dasler,voting")
+      expect(csv[2]).to start_with("UVA,UVA-robin@example.com,robin@example.com,Robin,Dasler,voting")
     end
 
     it 'returns billing contacts', vcr: false do
@@ -118,9 +127,10 @@ describe "exports", type: :request do
 
       expect(last_response.status).to eq(200)
       csv = last_response.body.lines
-      expect(csv.length).to eq(2)
+      expect(csv.length).to eq(3)
       expect(csv[0]).to eq("fabricaAccountId,fabricaId,email,firstName,lastName,type\n")
       expect(csv[1]).to start_with("VIVA,VIVA-trisha@example.com,trisha@example.com,Trisha,Cruse,billing;secondaryBilling")
+      expect(csv[2]).to start_with("UVA,UVA-trisha@example.com,trisha@example.com,Trisha,Cruse,billing;secondaryBilling")
     end
   end
 end


### PR DESCRIPTION
## Purpose
This pull request addresses #499, supporting the CSV export of multiple contacts with the same email address, but different provider id.

## Approach
The contact list was built using the email address as unique key. The pull request implements the fabricaId (providerId + email) as unique key.

#### Open Questions and Pre-Merge TODOs
- [ ] the outcome is multiple records of the same person in for example Salesforce, but that is intentional.
- [ ] at some point `add_contact` should be refactored into a standalone method, which simplifies unit testing.

## Learning
Only small changes in the code needed.
