### PR TITLE
import dois by client rake task

### DIFF
--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -996,8 +996,9 @@ class Doi < ActiveRecord::Base
         body:    dois.map { |doi| { index: { _id: doi.id, data: doi.as_indexed_json } } }
 
       # try to handle errors
-      response['items'].select { |k, v| k.values.first['error'].present? }.each do |item|
-        errors += 1
+      errors_in_response = response['items'].select { |k, v| k.values.first['error'].present? }
+      errors += errors_in_response.length
+      errors_in_response.each do |item|
         Rails.logger.error "[Elasticsearch] " + item.inspect
         doi_id = item.dig("index", "_id").to_i
         import_one(doi_id: doi_id) if doi_id > 0
@@ -1039,7 +1040,9 @@ class Doi < ActiveRecord::Base
         body:    dois.map { |doi| { index: { _id: doi.id, data: doi.as_indexed_json } } }
 
       # try to handle errors
-      errors += response['items'].select { |k, v| k.values.first['error'].present? }.each do |item|
+      errors_in_response = response['items'].select { |k, v| k.values.first['error'].present? }
+      errors += errors_in_response.length
+      errors_in_response.each do |item|
         Rails.logger.error "[Elasticsearch] " + item.inspect
         doi_id = item.dig("index", "_id").to_i
         import_one(doi_id: doi_id) if doi_id > 0

--- a/lib/tasks/client.rake
+++ b/lib/tasks/client.rake
@@ -70,7 +70,7 @@ namespace :client do
   end
 
   desc 'Import DOIs by client'
-  task :import_all_dois => :environment do
+  task :import_dois => :environment do
     if ENV['CLIENT_ID'].nil?
       puts "ENV['CLIENT_ID'] is required."
       exit
@@ -83,26 +83,8 @@ namespace :client do
     end
 
     # import DOIs for client
-    # puts "#{client.dois.length} DOIs will be imported."
-    client.import_all_dois
-  end
-
-  desc 'Import missing DOIs by client'
-  task :import_missing_dois => :environment do
-    if ENV['CLIENT_ID'].nil?
-      puts "ENV['CLIENT_ID'] is required."
-      exit
-    end
-
-    client = Client.where(deleted_at: nil).where(symbol: ENV['CLIENT_ID']).first
-    if client.nil?
-      puts "Client not found for client ID #{ENV['CLIENT_ID']}."
-      exit
-    end
-
-    # import DOIs for client
-    # puts "#{client.dois.length} DOIs will be imported."
-    client.import_missing_dois
+    puts "#{client.dois.length} DOIs will be imported."
+    Doi.import_by_client(client_id: ENV['CLIENT_ID'])
   end
 
   desc 'Delete client transferred to other DOI registration agency'


### PR DESCRIPTION
## Purpose
Put all DOIs from a particular client into Elasticsearch. Main use case is DOis not transferred in a DOI transfer as DOis were not indexed in Elasticsearch.

## Approach
Using a rake task. 

#### Open Questions and Pre-Merge TODOs
- [ ] Potentially more error reporting

## Learning
This does not work so well for clients with many DOIs. Will test performance.
