### PR TITLE
Facet for pid entities

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -6478,7 +6478,7 @@ type Query {
   repositories(after: String, first: Int = 25, query: String, software: String, year: String): RepositoryConnectionWithTotal!
   repository(id: ID!): Repository!
   service(id: ID!): Service!
-  services(after: String, first: Int = 25, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], memberId: String, query: String, repositoryId: String, userId: String): ServiceConnectionWithTotal!
+  services(after: String, first: Int = 25, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], memberId: String, pidEntity: String, query: String, repositoryId: String, userId: String): ServiceConnectionWithTotal!
   software(id: ID!): Software!
   softwares(after: String, first: Int = 25, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], memberId: String, query: String, repositoryId: String, userId: String): SoftwareConnectionWithTotal!
   sound(id: ID!): Sound!
@@ -7059,6 +7059,7 @@ type ServiceConnectionWithTotal {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  pidEntities: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
   totalCount: Int!

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -6484,7 +6484,7 @@ type Query {
   repositories(after: String, first: Int = 25, query: String, software: String, year: String): RepositoryConnectionWithTotal!
   repository(id: ID!): Repository!
   service(id: ID!): Service!
-  services(after: String, first: Int = 25, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], memberId: String, pidEntity: String, query: String, repositoryId: String, userId: String): ServiceConnectionWithTotal!
+  services(after: String, fieldOfScience: String, first: Int = 25, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], memberId: String, pidEntity: String, query: String, repositoryId: String, userId: String): ServiceConnectionWithTotal!
   software(id: ID!): Software!
   softwares(after: String, fieldOfScience: String, first: Int = 25, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], memberId: String, query: String, repositoryId: String, userId: String): SoftwareConnectionWithTotal!
   sound(id: ID!): Sound!

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -542,6 +542,7 @@ class QueryType < BaseObject
     argument :has_versions, Int, required: false
     argument :has_views, Int, required: false
     argument :has_downloads, Int, required: false
+    argument :pid_entity, String, required: false
     argument :first, Int, required: false, default_value: 25
     argument :after, String, required: false
   end
@@ -959,7 +960,7 @@ class QueryType < BaseObject
   end
 
   def response(**args)
-    Doi.query(args[:query], ids: args[:ids], user_id: args[:user_id], client_id: args[:repository_id], provider_id: args[:member_id], resource_type_id: args[:resource_type_id], resource_type: args[:resource_type], has_person: args[:has_person], has_funder: args[:has_funder], has_organization: args[:has_organization], has_citations: args[:has_citations], has_parts: args[:has_parts], has_versions: args[:has_versions], has_views: args[:has_views], has_downloads: args[:has_downloads], state: "findable", page: { cursor: args[:after].present? ? Base64.urlsafe_decode64(args[:after]) : nil, size: args[:first] })
+    Doi.query(args[:query], ids: args[:ids], user_id: args[:user_id], client_id: args[:repository_id], provider_id: args[:member_id], resource_type_id: args[:resource_type_id], resource_type: args[:resource_type], has_person: args[:has_person], has_funder: args[:has_funder], has_organization: args[:has_organization], has_citations: args[:has_citations], has_parts: args[:has_parts], has_versions: args[:has_versions], has_views: args[:has_views], has_downloads: args[:has_downloads], pid_entity: args[:pid_entity], state: "findable", page: { cursor: args[:after].present? ? Base64.urlsafe_decode64(args[:after]) : nil, size: args[:first] })
   end
 
   def set_doi(id)

--- a/app/graphql/types/service_connection_with_total_type.rb
+++ b/app/graphql/types/service_connection_with_total_type.rb
@@ -9,6 +9,7 @@ class ServiceConnectionWithTotalType < BaseConnection
   field :registration_agencies, [FacetType], null: true, cache: true
   field :repositories, [FacetType], null: true, cache: true
   field :affiliations, [FacetType], null: true, cache: true
+  field :pid_entities, [FacetType], null: true, cache: true
 
   def total_count
     object.total_count
@@ -28,5 +29,9 @@ class ServiceConnectionWithTotalType < BaseConnection
 
   def affiliations
     object.total_count.positive? ? facet_by_combined_key(object.aggregations.affiliations.buckets) : []
+  end
+
+  def pid_entities
+    object.total_count.positive? ? facet_by_combined_key(object.aggregations.pid_entities.subject.buckets) : []
   end
 end

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -267,11 +267,11 @@ class Doi < ActiveRecord::Base
         lang: { type: :keyword }
       }
       indexes :subjects,                       type: :object, properties: {
-        subject: { type: :keyword },
         subjectScheme: { type: :keyword },
+        subject: { type: :keyword },
         schemeUri: { type: :keyword },
         valueUri: { type: :keyword },
-        lang: { type: :keyword }
+        lang: { type: :keyword },
       }
       indexes :container,                     type: :object, properties: {
         type: { type: :keyword },
@@ -581,9 +581,10 @@ class Doi < ActiveRecord::Base
       # sources: { terms: { field: 'source', size: 15, min_doc_count: 1 } },
       subjects: { terms: { field: 'subjects.subject', size: 15, min_doc_count: 1 } },
       pid_entities: {
-        filter: { term: { "subjects.subjectScheme": "pidEntity" } },
+        filter: { term: { "subjects.subjectScheme": "PidEntity" } },
         aggs: {
-          subject: { terms: { field: 'subjects.subject', size: 10, min_doc_count: 1 } },
+          subject: { terms: { field: 'subjects.subject', size: 10, min_doc_count: 1, 
+            include: %w(Dataset Publication Software Organization Funder Person Grant Sample Instrument) } },
         },
       },
       certificates: { terms: { field: 'client.certificate', size: 10, min_doc_count: 1 } },
@@ -799,7 +800,7 @@ class Doi < ActiveRecord::Base
     filter << { term: { schema_version: "http://datacite.org/schema/kernel-#{options[:schema_version]}" }} if options[:schema_version].present?
     filter << { terms: { "subjects.subject": options[:subject].split(",") } } if options[:subject].present?
     if options[:pid_entity].present?
-      filter << { term: { "subjects.subjectScheme": "pidEntity" } }
+      filter << { term: { "subjects.subjectScheme": "PidEntity" } }
       filter << { terms: { "subjects.subject": options[:pid_entity].split(",") } }
     end
     filter << { term: { source: options[:source] } } if options[:source].present?

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -585,6 +585,8 @@ class Doi < ActiveRecord::Base
         aggs: {
           subject: { terms: { field: 'subjects.subject', size: 10, min_doc_count: 1, 
             include: %w(Dataset Publication Software Organization Funder Person Grant Sample Instrument) } },
+        },
+      },
       fields_of_science: {
         filter: { term: { "subjects.subjectScheme": "OECD" } },
         aggs: {

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -584,7 +584,7 @@ class Doi < ActiveRecord::Base
         filter: { term: { "subjects.subjectScheme": "PidEntity" } },
         aggs: {
           subject: { terms: { field: 'subjects.subject', size: 10, min_doc_count: 1, 
-            include: %w(Dataset Publication Software Organization Funder Person Grant Sample Instrument) } },
+            include: %w(Dataset Publication Software Organization Funder Person Grant Sample Instrument Repository Project) } },
         },
       },
       fields_of_science: {

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -580,6 +580,12 @@ class Doi < ActiveRecord::Base
       # links_checked: { value_count: { field: "landing_page.checked" } },
       # sources: { terms: { field: 'source', size: 15, min_doc_count: 1 } },
       subjects: { terms: { field: 'subjects.subject', size: 15, min_doc_count: 1 } },
+      pid_entities: {
+        filter: { term: { "subjects.subjectScheme": "pidEntity" } },
+        aggs: {
+          subject: { terms: { field: 'subjects.subject', size: 10, min_doc_count: 1 } },
+        },
+      },
       certificates: { terms: { field: 'client.certificate', size: 10, min_doc_count: 1 } },
       views: {
         date_histogram: { field: 'publication_year', interval: 'year', format: 'year', order: { _key: "desc" }, min_doc_count: 1 },
@@ -792,6 +798,10 @@ class Doi < ActiveRecord::Base
     filter << { range: { created: { gte: "#{options[:created].split(",").min}||/y", lte: "#{options[:created].split(",").max}||/y", format: "yyyy" }}} if options[:created].present?
     filter << { term: { schema_version: "http://datacite.org/schema/kernel-#{options[:schema_version]}" }} if options[:schema_version].present?
     filter << { terms: { "subjects.subject": options[:subject].split(",") } } if options[:subject].present?
+    if options[:pid_entity].present?
+      filter << { term: { "subjects.subjectScheme": "pidEntity" } }
+      filter << { terms: { "subjects.subject": options[:pid_entity].split(",") } }
+    end
     filter << { term: { source: options[:source] } } if options[:source].present?
     filter << { range: { reference_count: { "gte": options[:has_references].to_i } } } if options[:has_references].present?
     filter << { range: { citation_count: { "gte": options[:has_citations].to_i } } } if options[:has_citations].present?

--- a/spec/graphql/types/service_type_spec.rb
+++ b/spec/graphql/types/service_type_spec.rb
@@ -21,7 +21,7 @@ describe ServiceType do
       },
       {
         "subject": "Instrument",
-        "subjectScheme": "pidEntity"
+        "subjectScheme": "PidEntity"
       }])
     }
 
@@ -74,8 +74,7 @@ describe ServiceType do
       response = LupoSchema.execute(query).as_json
 
       expect(response.dig("data", "services", "totalCount")).to eq(3)
-      # TODO correctly filter out other subjects
-      # expect(response.dig("data", "services", "pidEntities")).to eq([{"id"=>"Instrument", "count"=>3}])
+      expect(response.dig("data", "services", "pidEntities")).to eq([{"id"=>"Instrument", "count"=>3}])
       expect(Base64.urlsafe_decode64(response.dig("data", "services", "pageInfo", "endCursor")).split(",", 2).last).to eq(services.last.uid)
       expect(response.dig("data", "services", "pageInfo", "hasNextPage")).to be false
       expect(response.dig("data", "services", "years")).to eq([{"count"=>3, "id"=>"2011"}])


### PR DESCRIPTION
## Purpose
Provide a facet in GraphQL for services that shows the PID entities (dataset, publication, funder, instrument, etc.) covered by the service.

## Approach
Using the subject field and the subjectScheme `pidEntity`.

#### Open Questions and Pre-Merge TODOs
- [ ] correctly filter out all subjects not using subjectScheme `pidEntity`

## Learning
Using filters in Elasticsearch aggregations.
