### PR TITLE
Only allowed doi agency field from controlled list

### DIFF
--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -101,6 +101,7 @@ class Doi < ActiveRecord::Base
   validates_format_of :doi, with: /\A10\.\d{4,5}\/[-\._;()\/:a-zA-Z0-9\*~\$\=]+\z/, on: :create
   validates_format_of :url, with: /\A(ftp|http|https):\/\/[\S]+/, if: :url?, message: "URL is not valid"
   validates_uniqueness_of :doi, message: "This DOI has already been taken", unless: :only_validate
+  validates_inclusion_of :agency, :in => %w( DataCite Crossref KISTI mEDRA ISTIC JaLC Airiti CNKI OP)
   validates :last_landing_page_status, numericality: { only_integer: true }, if: :last_landing_page_status?
   validates :xml, presence: true, xml_schema: true, if: Proc.new { |doi| doi.validatable? }
   validate :check_dates, if: :dates?

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -27,6 +27,74 @@ describe Doi, type: :model, vcr: true do
     end
   end
 
+  describe "validate agency" do
+    it "DataCite" do
+      subject = build(:doi, agency: "DataCite")
+      expect(subject).to be_valid
+      expect(subject.agency).to eq("DataCite")
+    end
+
+    it "Crossref" do
+      subject = build(:doi, agency: "Crossref")
+      expect(subject).to be_valid
+      expect(subject.agency).to eq("Crossref")
+    end
+
+    it "KISTI" do
+      subject = build(:doi, agency: "KISTI")
+      expect(subject).to be_valid
+      expect(subject.agency).to eq("KISTI")
+    end
+
+    it "mEDRA" do
+      subject = build(:doi, agency: "mEDRA")
+      expect(subject).to be_valid
+      expect(subject.agency).to eq("mEDRA")
+    end
+
+    it "ISTIC" do
+      subject = build(:doi, agency: "ISTIC")
+      expect(subject).to be_valid
+      expect(subject.agency).to eq("ISTIC")
+    end
+
+    it "JaLC" do
+      subject = build(:doi, agency: "JaLC")
+      expect(subject).to be_valid
+      expect(subject.agency).to eq("JaLC")
+    end
+
+    it "Airiti" do
+      subject = build(:doi, agency: "Airiti")
+      expect(subject).to be_valid
+      expect(subject.agency).to eq("Airiti")
+    end
+
+    it "CNKI" do
+      subject = build(:doi, agency: "CNKI")
+      expect(subject).to be_valid
+      expect(subject.agency).to eq("CNKI")
+    end
+
+    it "OP" do
+      subject = build(:doi, agency: "OP")
+      expect(subject).to be_valid
+      expect(subject.agency).to eq("OP")
+    end
+
+    it "XXX" do
+      subject = build(:doi, agency: "XXX")
+      expect(subject).to_not be_valid
+      expect(subject.errors.messages).to eq(:agency=>["is not included in the list"])
+    end
+
+    it "default" do
+      subject = build(:doi)
+      expect(subject).to be_valid
+      expect(subject.agency).to eq("DataCite")
+    end
+  end
+
   describe "state" do
     subject { create(:doi) }
 


### PR DESCRIPTION
## Purpose
We will support faceting by DOI registration agency in common DOI search. We therefore need to make sure this field has always the correct value.

## Approach
A validation that uses a controlled list.
