### PR TITLE
Disable ActiveJob logging

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -95,6 +95,9 @@ module Lupo
       c.analytics_enabled = true
     end
 
+    # disable ActiveJob logging, as it is very verbose at log level INFO
+    config.active_job.logger = Logger.new(nil)
+
     config.lograge.enabled = true
     config.lograge.formatter = Lograge::Formatters::Logstash.new
     config.lograge.logger = LogStashLogger.new(type: :stdout)


### PR DESCRIPTION
## Purpose
ActiveJob logging is too verbose at log level INFO.

## Approach
Disable logging. Filtering out the logs doesn't work for `development` and `test`. ActiveJob logging is not essential.
