### PR TITLE
Gracefully handle routing errors

### DIFF
--- a/app/controllers/index_controller.rb
+++ b/app/controllers/index_controller.rb
@@ -8,9 +8,9 @@ class IndexController < ApplicationController
     render plain: ENV['SITE_TITLE']
   end
 
-  # def routing_error
-  #   fail ActionController::RoutingError
-  # end
+  def routing_error
+    fail ActiveRecord::RecordNotFound
+  end
 
   def method_not_allowed
     response.set_header('Allow', 'POST')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,5 +128,5 @@ Rails.application.routes.draw do
   resources :works, only: [:show, :index], constraints: { id: /.+/ }
 
   # rescue routing errors
-  #match "*path", to: "index#routing_error", via: :all
+  match "*path", to: "index#routing_error", via: :all
 end


### PR DESCRIPTION
## Purpose
The REST API should return a standard 404 Not Found message when an unknown route is called.

## Approach
Use a catch all route in the Router as the last step and raise `ActiveRecord::RecordNotFound`.
