### PR TITLE
Name for person, creator or actor is not required

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -51,7 +51,7 @@ interface ActorItem {
   """
   The name of the actor.
   """
-  name: String!
+  name: String
 
   """
   The type of the actor.
@@ -1416,7 +1416,7 @@ type Creator {
   """
   The name of the creator.
   """
-  name: String!
+  name: String
 
   """
   The type of the item.
@@ -3221,7 +3221,7 @@ type Funder implements ActorItem {
   """
   The name of the actor.
   """
-  name: String!
+  name: String
 
   """
   Funded publications
@@ -4887,7 +4887,7 @@ type Organization implements ActorItem {
   """
   The name of the actor.
   """
-  name: String!
+  name: String
 
   """
   Publications from this organization
@@ -5538,7 +5538,7 @@ type Person implements ActorItem {
   """
   The name of the actor.
   """
-  name: String!
+  name: String
 
   """
   Authored publications

--- a/app/graphql/types/actor_item.rb
+++ b/app/graphql/types/actor_item.rb
@@ -8,7 +8,7 @@ module ActorItem
 
   field :id, ID, null: false, description: "The persistent identifier for the actor."
   field :type, String, null: false, description: "The type of the actor."
-  field :name, String, null: false, description: "The name of the actor."
+  field :name, String, null: true, description: "The name of the actor."
   field :alternate_name, [String], null: true, description: "An alias for the actor."
 
   definition_methods do

--- a/app/graphql/types/creator_type.rb
+++ b/app/graphql/types/creator_type.rb
@@ -5,7 +5,7 @@ class CreatorType < BaseObject
 
   field :id, ID, null: true, description: "The ID of the creator."
   field :type, String, null: false, description: "The type of the item."
-  field :name, String, null: false, description: "The name of the creator."
+  field :name, String, null: true, description: "The name of the creator."
   field :given_name, String, null: true, description: "Given name. In the U.S., the first name of a Person."
   field :family_name, String, null: true, description: "Family name. In the U.S., the last name of an Person."
   field :affiliation, [OrganizationType], null: true, description: "The organizational or institutional affiliation of the creator."

--- a/spec/graphql/types/actor_item_spec.rb
+++ b/spec/graphql/types/actor_item_spec.rb
@@ -6,7 +6,7 @@ describe ActorItem do
 
     it { is_expected.to have_field(:id).of_type(!types.ID) }
     it { is_expected.to have_field(:type).of_type("String!") }
-    it { is_expected.to have_field(:name).of_type("String!") }
+    it { is_expected.to have_field(:name).of_type("String") }
   end
 
   describe "find actor", vcr: true do

--- a/spec/graphql/types/creator_type_spec.rb
+++ b/spec/graphql/types/creator_type_spec.rb
@@ -6,7 +6,7 @@ describe CreatorType do
 
     it { is_expected.to have_field(:id).of_type(types.ID) }
     it { is_expected.to have_field(:type).of_type("String!") }
-    it { is_expected.to have_field(:name).of_type("String!") }
+    it { is_expected.to have_field(:name).of_type("String") }
     it { is_expected.to have_field(:givenName).of_type("String") }
     it { is_expected.to have_field(:familyName).of_type("String") }
     it { is_expected.to have_field(:affiliation).of_type("[Organization!]") }

--- a/spec/graphql/types/funder_type_spec.rb
+++ b/spec/graphql/types/funder_type_spec.rb
@@ -6,7 +6,7 @@ describe FunderType do
 
     it { is_expected.to have_field(:id).of_type(!types.ID) }
     it { is_expected.to have_field(:type).of_type("String!") }
-    it { is_expected.to have_field(:name).of_type("String!") }
+    it { is_expected.to have_field(:name).of_type("String") }
     it { is_expected.to have_field(:alternateName).of_type("[String!]") }
     it { is_expected.to have_field(:citationCount).of_type("Int") }
     it { is_expected.to have_field(:viewCount).of_type("Int") }

--- a/spec/graphql/types/organization_type_spec.rb
+++ b/spec/graphql/types/organization_type_spec.rb
@@ -6,7 +6,7 @@ describe OrganizationType do
 
     it { is_expected.to have_field(:id).of_type(!types.ID) }
     it { is_expected.to have_field(:type).of_type("String!") }
-    it { is_expected.to have_field(:name).of_type("String!") }
+    it { is_expected.to have_field(:name).of_type("String") }
     it { is_expected.to have_field(:alternateName).of_type("[String!]") }
     it { is_expected.to have_field(:citationCount).of_type("Int") }
     it { is_expected.to have_field(:viewCount).of_type("Int") }

--- a/spec/graphql/types/person_type_spec.rb
+++ b/spec/graphql/types/person_type_spec.rb
@@ -6,7 +6,7 @@ describe PersonType do
 
     it { is_expected.to have_field(:id).of_type(!types.ID) }
     it { is_expected.to have_field(:type).of_type("String!") }
-    it { is_expected.to have_field(:name).of_type("String!") }
+    it { is_expected.to have_field(:name).of_type("String") }
     it { is_expected.to have_field(:givenName).of_type("String") }
     it { is_expected.to have_field(:familyName).of_type("String") }
     it { is_expected.to have_field(:alternateName).of_type("[String!]") }


### PR DESCRIPTION
## Purpose
A name is not required with ORCID. And while a creator name is required with DataCite metadata, we have DOIs where this information is missing. This creates errors in GraphQL queries.

## Approach
No longer require name in GraphQL.

#### Open Questions and Pre-Merge TODOs
- [ ] Going forward we need to make sure all registered DOIs have all required metadata.

