### PR TITLE
Set registration-agency

### DIFF
--- a/app/jobs/update_doi_job.rb
+++ b/app/jobs/update_doi_job.rb
@@ -1,0 +1,15 @@
+class UpdateDoiJob < ActiveJob::Base
+  queue_as :lupo_background
+
+  def perform(doi_id, options={})
+    doi = Doi.where(doi: doi_id).first
+
+    if doi.blank?
+      Rails.logger.error "[UpdateDoi] Error updating DOI " + doi_id + ": not found"
+    elsif doi.update_attributes(version: doi.version.to_i + 1)
+      Rails.logger.debug "[UpdateDoi] Successfully updated DOI " + doi_id
+    else
+      Rails.logger.error "[UpdateDoi] Error updating DOI " + doi_id + ": " + doi.errors.messages.inspect
+    end
+  end
+end

--- a/lib/tasks/doi.rake
+++ b/lib/tasks/doi.rake
@@ -106,7 +106,7 @@ namespace :doi do
     options = {
       from_id: (ENV["FROM_ID"] || Doi.minimum(:id)).to_i,
       until_id: (ENV["UNTIL_ID"] || Doi.maximum(:id)).to_i,
-      query: "agency:DataCite OR agency:Crossref",
+      query: "agency:DataCite OR agency:Crossref OR -agency:*",
       label: "[SetRegistrationAgency]",
       job_name: "UpdateDoiJob",
     }

--- a/lib/tasks/doi.rake
+++ b/lib/tasks/doi.rake
@@ -101,6 +101,18 @@ namespace :doi do
     Doi.loop_through_dois(options)
   end
 
+  desc "Set registration agency"
+  task set_registration_agency: :environment do
+    options = {
+      from_id: (ENV["FROM_ID"] || Doi.minimum(:id)).to_i,
+      until_id: (ENV["UNTIL_ID"] || Doi.maximum(:id)).to_i,
+      query: "agency:DataCite OR agency:Crossref",
+      label: "[SetRegistrationAgency]",
+      job_name: "UpdateDoiJob",
+    }
+    Doi.loop_through_dois(options)
+  end
+
   desc 'Convert affiliations to new format'
   task :convert_affiliations => :environment do
     from_id = (ENV['FROM_ID'] || Doi.minimum(:id)).to_i


### PR DESCRIPTION
## Purpose
Set DOI registration agency for all DOIs using the lowercase id.

## Approach
To allow queries by DOI registration agency, we want to use a lowercase string, so `datacite` instead of `DataCite`, `crossref` instead of `Crossref` and `medra` instead of `mEDRA`. This pull request implements a rake task to update this information for all DOIs that need the update. It will also add `agency` information to those DOIs that don't have it.

## Learning
Using the `Doi.loop_through_dois` method greatly simplifies these kinds of metadata updates.
