### PR TITLE
use correct sqs queue

### DIFF
--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -296,7 +296,6 @@ module Indexable
         filter << { terms: { client_ids: options[:client_id].to_s.split(",") }} if options[:client_id].present?
         filter << { terms: { state: options[:state].to_s.split(",") }} if options[:state].present?
       elsif self.name == "ProviderPrefix"
-        Rails.logger.warn query.inspect
         if query.present?
           must = [{ prefix: { prefix_id: query }}]
         else

--- a/config/application.rb
+++ b/config/application.rb
@@ -155,7 +155,13 @@ module Lupo
     else
       config.active_job.queue_adapter = :inline
     end
-    config.active_job.queue_name_prefix = Rails.env
+
+    # use SQS based on environment, use "test" prefix for test system
+    if Rails.env == "stage" 
+      config.active_job.queue_name_prefix = ENV['ES_PREFIX'].present? ? "stage" : "test"
+    else
+      config.active_job.queue_name_prefix = Rails.env
+    end
 
     config.generators do |g|
       g.fixture_replacement :factory_bot


### PR DESCRIPTION
## Purpose
Lupo is using the same SQS queue for `stage` and `test`, as it based on the environment, which is `stage` in both cases.

## Approach
Queue prefix should not be based purely on the Rails environment. Using the `ES_PREFIX` ENV variable to differentiate.