### PR TITLE
fix: add relation between key and test

### DIFF
--- a/app/graphql/types/year_month_total_type.rb
+++ b/app/graphql/types/year_month_total_type.rb
@@ -3,6 +3,6 @@
 class YearMonthTotalType < BaseObject
   description "Information about totals over time (years)"
 
-  field :year_month, String, null: true, description: "Year-month"
+  field :year_month, String, null: true, hash_key: :yearMonth, description: "Year-month"
   field :total, Int, null: true, description: "Total"
 end


### PR DESCRIPTION
## Purpose

Fix null value key in graphql api for vies distribution. the issue is caused by setting the wrong key type and naming method.

closes: https://github.com/datacite/lupo/issues/563

## Approach

1. Set the correct type
https://github.com/datacite/lupo/commit/6d8caef2f7ee46ed55c41a93ce9412f3f96fc795
https://github.com/datacite/lupo/commit/fcf5bcf0606e955891279e12533971ded27ddeb7

2. Override year_month -> yearMonth 

#### Open Questions and Pre-Merge TODOs

## Learning

Method needs to be overridden when
https://graphql-ruby.org/fields/introduction.html#field-resolution

## Status
- [x] Ready for Review

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)