### PR TITLE
Only trigger import message on changes in specific fields

### DIFF
--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -7,7 +7,7 @@ module Indexable
     after_commit on: [:create, :update] do
       # use index_document instead of update_document to also update virtual attributes
       IndexJob.perform_later(self)
-      if self.class.name == "Doi"
+      if self.class.name == "Doi" && (saved_change_to_attribute?("related_identifiers") || saved_change_to_attribute?("creators") || saved_change_to_attribute?("funding_references"))
         send_import_message(self.to_jsonapi) if aasm_state == "findable" && !Rails.env.test? && !%w(crossref.citations medra.citations jalc.citations kisti.citations op.citations).include?(client.symbol.downcase)
       # reindex prefix, not triggered by standard callbacks
       elsif ["ProviderPrefix", "ClientPrefix"].include?(self.class.name)

--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -14,6 +14,6 @@ groups:
     queues:
       - lupo_transfer
   background:
-    concurrency: 5
+    concurrency: 3
     queues:
       - lupo_background


### PR DESCRIPTION
## Purpose
Updates of DOI metadata should only trigger sending a message to `levriero` if the change is relevant for Event Data.

## Approach
* use `saved_change_to_attribute?("name")` method
* watch changes in `related_identifiers`, `creators`, `funding_references`

#### Open Questions and Pre-Merge TODOs
- [ ] this needs to be tested in AWS infrastructure including SQS
