### PR TITLE
Fix schema_org type

### DIFF
--- a/lib/tasks/doi.rake
+++ b/lib/tasks/doi.rake
@@ -149,6 +149,16 @@ namespace :doi do
     Doi.loop_through_dois(options)
   end
 
+  desc "Set types"
+  task set_types: :environment do
+    options = {
+      query: "types.resourceTypeGeneral:* AND -types.schemaOrg:*",
+      label: "[SetTypes]",
+      job_name: "UpdateDoiJob",
+    }
+    Doi.loop_through_dois(options)
+  end
+
   desc 'Convert affiliations to new format'
   task :convert_affiliations => :environment do
     from_id = (ENV['FROM_ID'] || Doi.minimum(:id)).to_i

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -492,6 +492,44 @@ describe Doi, type: :model, vcr: true do
     end
   end
 
+  describe "types" do
+    let(:doi) { build(:doi) }
+
+    it "string" do
+      doi.types = "Dataset"
+      expect(doi.save).to be false
+      expect(doi.errors.details).to eq(:types=>[{:error=>"Types 'Dataset' should be an object instead of a string."}])
+    end
+
+    it "only resource_type_general" do
+      doi.types = { "resourceTypeGeneral" => "Dataset" }
+      expect(doi.save).to be true
+      expect(doi.errors.details).to be_empty
+      expect(doi.types).to eq("bibtex"=>"misc", "citeproc"=>"dataset", "resourceTypeGeneral"=>"Dataset", "ris"=>"DATA", "schemaOrg"=>"Dataset")
+    end
+
+    it "resource_type and resource_type_general" do
+      doi.types = { "resourceTypeGeneral" => "Dataset", "resourceType" => "EEG data"}
+      expect(doi.save).to be true
+      expect(doi.errors.details).to be_empty
+      expect(doi.types).to eq("bibtex"=>"misc", "citeproc"=>"dataset", "resourceTypeGeneral"=>"Dataset", "resourceType" => "EEG data", "ris"=>"DATA", "schemaOrg"=>"Dataset")
+    end
+
+    it "resource_type_general and different schema_org" do
+      doi.types = { "resourceTypeGeneral" => "Dataset", "schemaOrg" => "JournalArticle" }
+      expect(doi.save).to be true
+      expect(doi.errors.details).to be_empty
+      expect(doi.types).to eq("bibtex"=>"misc", "citeproc"=>"dataset", "resourceTypeGeneral"=>"Dataset", "ris"=>"DATA", "schemaOrg"=>"JournalArticle")
+    end
+
+    it "resource_type_general and different ris" do
+      doi.types = { "resourceTypeGeneral" => "Dataset", "ris" => "GEN" }
+      expect(doi.save).to be true
+      expect(doi.errors.details).to be_empty
+      expect(doi.types).to eq("bibtex"=>"misc", "citeproc"=>"dataset", "resourceTypeGeneral"=>"Dataset", "ris"=>"GEN", "schemaOrg"=>"Dataset")
+    end
+  end
+
   # describe "related_identifiers" do
   #   it "has part" do
   #     subject = build(:doi, related_identifiers: [      {


### PR DESCRIPTION
## Purpose
Fix the missing schemaOrg type if resourceTypeGeneral is set to `Dataset`.

## Approach
Check the types before saving, update with same logic as in `bolognese`. A rake task will do this for all DOIs with resourceTypeGeneral but no schemaOrg type.