### PR TITLE
Implement content negotiation for all DOIs

### DIFF
--- a/app/controllers/index_controller.rb
+++ b/app/controllers/index_controller.rb
@@ -1,11 +1,35 @@
 class IndexController < ApplicationController
   include ActionController::MimeResponds
-
-  prepend_before_action :authenticate_user!
-  before_action :set_doi, only: [:show]
   
   def index
     render plain: ENV['SITE_TITLE']
+  end
+
+  def show
+    doi = Doi.where(doi: params[:id], aasm_state: "findable").first
+    fail ActiveRecord::RecordNotFound if doi.blank?
+
+    respond_to do |format|
+      format.html do
+        # forward to URL registered in handle system for no content negotiation
+        redirect_to doi.url, status: 303
+      end
+      format.citation do
+        # extract optional style and locale from header
+        headers = request.headers["HTTP_ACCEPT"].to_s.gsub(/\s+/, "").split(";", 3).reduce({}) do |sum, item|
+          sum[:style] = item.split("=").last if item.start_with?("style")
+          sum[:locale] = item.split("=").last if item.start_with?("locale")
+          sum
+        end
+        render citation: doi, style: params[:style] || headers[:style] || "apa", locale: params[:locale] || headers[:locale] || "en-US"
+      end
+      format.any(:bibtex, :citeproc, :codemeta, :crosscite, :datacite, :datacite_json, :jats, :ris, :schema_org) { render request.format.to_sym => doi }
+      header = %w(doi url registered state resourceTypeGeneral resourceType title author publisher publicationYear)
+      format.csv { render request.format.to_sym => doi, header: header }
+    end
+  rescue ActionController::UnknownFormat, ActionController::RoutingError
+    # forward to URL registered in handle system for unrecognized format
+    redirect_to doi.url, status: 303
   end
 
   def routing_error

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,6 @@ Rails.application.routes.draw do
   post "/client-api/graphql", to: "graphql#execute"
   get "/client-api/graphql", to: "index#method_not_allowed"
 
-  root to: "index#index"
-
   # authentication
   post "token", to: "sessions#create_token"
 
@@ -12,6 +10,20 @@ Rails.application.routes.draw do
 
   # send reset link
   post 'reset', :to => 'sessions#reset'
+
+  # content negotiation via index path
+  get '/application/vnd.datacite.datacite+xml/:id', :to => 'index#show', constraints: { :id => /.+/ }, defaults: { format: :datacite }
+  get '/application/vnd.datacite.datacite+json/:id', :to => 'index#show', constraints: { :id => /.+/ }, defaults: { format: :datacite_json }
+  get '/application/vnd.crosscite.crosscite+json/:id', :to => 'index#show', constraints: { :id => /.+/ }, defaults: { format: :crosscite }
+  get '/application/vnd.schemaorg.ld+json/:id', :to => 'index#show', constraints: { :id => /.+/ }, defaults: { format: :schema_org }
+  get '/application/ld+json/:id', :to => 'index#show', constraints: { :id => /.+/ }, defaults: { format: :schema_org }
+  get '/application/vnd.codemeta.ld+json/:id', :to => 'index#show', constraints: { :id => /.+/ }, defaults: { format: :codemeta }
+  get '/application/vnd.citationstyles.csl+json/:id', :to => 'index#show', constraints: { :id => /.+/ }, defaults: { format: :citeproc }
+  get '/application/vnd.jats+xml/:id', :to => 'index#show', constraints: { :id => /.+/ }, defaults: { format: :jats }
+  get '/application/x-bibtex/:id', :to => 'index#show', constraints: { :id => /.+/ }, defaults: { format: :bibtex }
+  get '/application/x-research-info-systems/:id', :to => 'index#show', constraints: { :id => /.+/ }, defaults: { format: :ris }
+  get '/text/csv/:id', :to => 'index#show', constraints: { :id => /.+/ }, defaults: { format: :csv }
+  get '/text/x-bibliography/:id', :to => 'index#show', constraints: { :id => /.+/ }, defaults: { format: :citation }
 
   # content negotiation
   get '/dois/application/vnd.datacite.datacite+xml/:id', :to => 'datacite_dois#show', constraints: { :id => /.+/ }, defaults: { format: :datacite }
@@ -72,8 +84,9 @@ Rails.application.routes.draw do
   get 'export/contacts', :to => 'exports#contacts', defaults: { format: :csv }
 
   resources :heartbeat, only: [:index]
-  resources :index, only: [:index]
-
+  resources :index, path: '/', only: [:show, :index], constraints: { id: /.+/, format: false }
+  root to: "index#index"
+  
   resources :activities, only: [:index, :show]
 
   resources :clients, constraints: { id: /.+/ } do

--- a/spec/requests/index_spec.rb
+++ b/spec/requests/index_spec.rb
@@ -1,0 +1,282 @@
+require "rails_helper"
+
+describe IndexController, type: :request do
+  let(:doi) { create(:doi, aasm_state: "findable") }
+
+  describe "content_negotation" do
+    context "application/vnd.jats+xml" do
+      it 'returns the Doi' do
+        get "/#{doi.doi}", nil, { "HTTP_ACCEPT" => "application/vnd.jats+xml" }
+
+        expect(last_response.status).to eq(200)
+        jats = Maremma.from_xml(last_response.body).fetch("element_citation", {})
+        expect(jats.dig("publication_type")).to eq("data")
+        expect(jats.dig("data_title")).to eq("Data from: A new malaria agent in African hominids.")
+      end
+    end
+
+    context "application/vnd.jats+xml link" do
+      it 'returns the Doi' do
+        get "/application/vnd.jats+xml/#{doi.doi}"
+
+        expect(last_response.status).to eq(200)
+        jats = Maremma.from_xml(last_response.body).fetch("element_citation", {})
+        expect(jats.dig("publication_type")).to eq("data")
+        expect(jats.dig("data_title")).to eq("Data from: A new malaria agent in African hominids.")
+      end
+    end
+
+    context "application/vnd.datacite.datacite+xml" do
+      it 'returns the Doi' do
+        get "/#{doi.doi}", nil, { "HTTP_ACCEPT" => "application/vnd.datacite.datacite+xml" }
+
+        expect(last_response.status).to eq(200)
+        data = Maremma.from_xml(last_response.body).to_h.fetch("resource", {})
+        expect(data.dig("xmlns")).to eq("http://datacite.org/schema/kernel-4")
+        expect(data.dig("publisher")).to eq("Dryad Digital Repository")
+        expect(data.dig("titles", "title")).to eq("Data from: A new malaria agent in African hominids.")
+      end
+    end
+
+    context "application/vnd.datacite.datacite+xml link" do
+      it 'returns the Doi' do
+        get "/application/vnd.datacite.datacite+xml/#{doi.doi}"
+
+        expect(last_response.status).to eq(200)
+        data = Maremma.from_xml(last_response.body).to_h.fetch("resource", {})
+        expect(data.dig("xmlns")).to eq("http://datacite.org/schema/kernel-4")
+        expect(data.dig("publisher")).to eq("Dryad Digital Repository")
+        expect(data.dig("titles", "title")).to eq("Data from: A new malaria agent in African hominids.")
+      end
+    end
+
+    # context "application/vnd.datacite.datacite+xml schema 3" do
+    #   let(:xml) { file_fixture('datacite_schema_3.xml').read }
+    #   let(:doi) { create(:doi, xml: xml, regenerate: false, aasm_state: "findable") }
+
+    #   it 'returns the Doi' do
+    #     get "/#{doi.doi}", nil, { "HTTP_ACCEPT" => "application/vnd.datacite.datacite+xml" }
+
+    #     expect(last_response.status).to eq(200)
+    #     data = Maremma.from_xml(last_response.body).to_h.fetch("resource", {})
+    #     expect(data.dig("xmlns")).to eq("http://datacite.org/schema/kernel-3")
+    #     expect(data.dig("publisher")).to eq("Dryad Digital Repository")
+    #     expect(data.dig("titles", "title")).to eq("Data from: A new malaria agent in African hominids.")
+    #   end
+    # end
+
+    context "application/vnd.datacite.datacite+xml not found" do
+      it 'returns error message' do
+        get "/xxx", nil, { "HTTP_ACCEPT" => "application/vnd.datacite.datacite+xml" }
+
+        expect(last_response.status).to eq(404)
+        expect(json["errors"]).to eq([{"status"=>"404", "title"=>"The resource you are looking for doesn't exist."}])
+      end
+    end
+
+    context "application/vnd.datacite.datacite+json" do
+      it 'returns the Doi' do
+        get "/#{doi.doi}", nil, { "HTTP_ACCEPT" => "application/vnd.datacite.datacite+json" }
+
+        expect(last_response.status).to eq(200)
+        expect(json["doi"]).to eq(doi.doi)
+      end
+    end
+
+    context "application/vnd.datacite.datacite+json link" do
+      it 'returns the Doi' do
+        get "/application/vnd.datacite.datacite+json/#{doi.doi}"
+
+        expect(last_response.status).to eq(200)
+        expect(json["doi"]).to eq(doi.doi)
+      end
+    end
+
+    context "application/vnd.crosscite.crosscite+json" do
+      it 'returns the Doi' do
+        get "/#{doi.doi}", nil, { "HTTP_ACCEPT" => "application/vnd.crosscite.crosscite+json" }
+
+        expect(last_response.status).to eq(200)
+        expect(json["doi"]).to eq(doi.doi)
+      end
+    end
+
+    context "application/vnd.crosscite.crosscite+json link" do
+      it 'returns the Doi' do
+        get "/application/vnd.crosscite.crosscite+json/#{doi.doi}"
+
+        expect(last_response.status).to eq(200)
+        expect(json["doi"]).to eq(doi.doi)
+      end
+    end
+
+    context "application/vnd.schemaorg.ld+json" do
+      it 'returns the Doi' do
+        get "/#{doi.doi}", nil, { "HTTP_ACCEPT" => "application/vnd.schemaorg.ld+json" }
+
+        expect(last_response.status).to eq(200)
+        expect(json["@type"]).to eq("Dataset")
+      end
+    end
+
+    context "application/vnd.schemaorg.ld+json link" do
+      it 'returns the Doi' do
+        get "/application/vnd.schemaorg.ld+json/#{doi.doi}"
+
+        expect(last_response.status).to eq(200)
+        expect(json["@type"]).to eq("Dataset")
+      end
+    end
+
+    context "application/ld+json" do
+      it 'returns the Doi' do
+        get "/#{doi.doi}", nil, { "HTTP_ACCEPT" => "application/ld+json" }
+
+        expect(last_response.status).to eq(200)
+        expect(json["@type"]).to eq("Dataset")
+      end
+    end
+
+    context "application/ld+json link" do
+      it 'returns the Doi' do
+        get "/application/ld+json/#{doi.doi}"
+
+        expect(last_response.status).to eq(200)
+        expect(json["@type"]).to eq("Dataset")
+      end
+    end
+
+    context "application/vnd.citationstyles.csl+json" do
+      it 'returns the Doi' do
+        get "/#{doi.doi}", nil, { "HTTP_ACCEPT" => "application/vnd.citationstyles.csl+json" }
+
+        expect(last_response.status).to eq(200)
+        expect(json["type"]).to eq("dataset")
+      end
+    end
+
+    context "application/vnd.citationstyles.csl+json link" do
+      it 'returns the Doi' do
+        get "/application/vnd.citationstyles.csl+json/#{doi.doi}"
+
+        expect(last_response.status).to eq(200)
+        expect(json["type"]).to eq("dataset")
+      end
+    end
+
+    context "application/x-research-info-systems" do
+      it 'returns the Doi' do
+        get "/#{doi.doi}", nil, { "HTTP_ACCEPT" => "application/x-research-info-systems" }
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to start_with("TY  - DATA")
+      end
+    end
+
+    context "application/x-research-info-systems link" do
+      it 'returns the Doi' do
+        get "/application/x-research-info-systems/#{doi.doi}"
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to start_with("TY  - DATA")
+      end
+    end
+
+    context "application/x-bibtex" do
+      it 'returns the Doi' do
+        get "/#{doi.doi}", nil, { "HTTP_ACCEPT" => "application/x-bibtex" }
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to start_with("@misc{https://doi.org/#{doi.doi.downcase}")
+      end
+    end
+
+    context "application/x-bibtex link" do
+      it 'returns the Doi' do
+        get "/application/x-bibtex/#{doi.doi}"
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to start_with("@misc{https://doi.org/#{doi.doi.downcase}")
+      end
+    end
+
+    context "text/csv" do
+      it 'returns the Doi' do
+        get "/#{doi.doi}", nil, { "HTTP_ACCEPT" => "text/csv" }
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to include(doi.doi)
+      end
+    end
+
+    context "text/csv link" do
+      it 'returns the Doi' do
+        get "/text/csv/#{doi.doi}"
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to include(doi.doi)
+      end
+    end
+
+    context "text/x-bibliography" do
+      context "default style" do
+        it 'returns the Doi' do
+          get "/#{doi.doi}", nil, { "HTTP_ACCEPT" => "text/x-bibliography" }
+
+          expect(last_response.status).to eq(200)
+          expect(last_response.body).to start_with("Ollomo, B.")
+        end
+      end
+
+      it "header with style" do
+        get "/#{doi.doi}", nil, { "HTTP_ACCEPT" => "text/x-bibliography; style=ieee" }
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to start_with("B. Ollomo")
+      end
+  
+      it "header with style and locale" do
+        get "/#{doi.doi}", nil, { "HTTP_ACCEPT" => "text/x-bibliography; style=vancouver; locale=de" }
+        
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to start_with("Ollomo B")
+      end
+
+      context "default style link" do
+        it 'returns the Doi' do
+          get "/text/x-bibliography/#{doi.doi}"
+
+          expect(last_response.status).to eq(200)
+          expect(last_response.body).to start_with("Ollomo, B.")
+        end
+      end
+
+      context "ieee style link" do
+        it 'returns the Doi' do
+          get "/text/x-bibliography/#{doi.doi}?style=ieee"
+
+          expect(last_response.status).to eq(200)
+          expect(last_response.body).to start_with("B. Ollomo")
+        end
+      end
+    end
+
+    context "unknown content type" do
+      it 'returns the Doi' do
+        get "/#{doi.doi}", nil, { "HTTP_ACCEPT" => "application/vnd.ms-excel" }
+
+        expect(last_response.status).to eq(303)
+        expect(last_response.headers["Location"]).to eq(doi.url)
+      end
+    end
+
+    context "missing content type" do
+      it 'returns the Doi' do
+        get "/#{doi.doi}"
+
+        expect(last_response.status).to eq(303)
+        expect(last_response.headers["Location"]).to eq(doi.url)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Purpose
The current content negotiation implementation depends on the REST API, which excludes non-DataCite DOIs.

## Approach
Add a new content negotiation endpoint under the root path that handles all DOIs in the index, not just DataCite DOIs.

#### Open Questions
- [ ] Will evaluate content negotiation strategy after launch of DataCite Commons MVP, to consolidate the currently available three content negotiation endpoints.

