### PR TITLE
Add contributor to graphql

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -139,7 +139,7 @@ type Audiovisual implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -297,7 +297,7 @@ type Audiovisual implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -430,7 +430,7 @@ type Book implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -588,7 +588,7 @@ type Book implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -678,7 +678,7 @@ type BookChapter implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -836,7 +836,7 @@ type BookChapter implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -1012,7 +1012,7 @@ type Collection implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -1170,7 +1170,7 @@ type Collection implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -1302,7 +1302,7 @@ type ConferencePaper implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -1460,7 +1460,7 @@ type ConferencePaper implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -1875,7 +1875,13 @@ type DataManagementPlan implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -2030,7 +2036,7 @@ type DataManagementPlan implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -2164,7 +2170,7 @@ type DataPaper implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -2322,7 +2328,7 @@ type DataPaper implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -2455,7 +2461,7 @@ type Dataset implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -2613,7 +2619,7 @@ type Dataset implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -2857,7 +2863,7 @@ type Dissertation implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -3015,7 +3021,7 @@ type Dissertation implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -3152,7 +3158,7 @@ interface DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -3310,7 +3316,7 @@ interface DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -3400,7 +3406,7 @@ type Event implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -3558,7 +3564,7 @@ type Event implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -3676,7 +3682,7 @@ type EventData implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -3834,7 +3840,7 @@ type EventData implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -4244,7 +4250,7 @@ type Image implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -4402,7 +4408,7 @@ type Image implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -4535,7 +4541,7 @@ type Instrument implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -4693,7 +4699,7 @@ type Instrument implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -4825,7 +4831,7 @@ type InteractiveResource implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -4983,7 +4989,7 @@ type InteractiveResource implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -5141,7 +5147,7 @@ type JournalArticle implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -5299,7 +5305,7 @@ type JournalArticle implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -5678,7 +5684,7 @@ type Model implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -5836,7 +5842,7 @@ type Model implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -6094,7 +6100,7 @@ type Other implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -6252,7 +6258,7 @@ type Other implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -6410,7 +6416,7 @@ type PeerReview implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -6568,7 +6574,7 @@ type PeerReview implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -6832,7 +6838,7 @@ type PhysicalObject implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -6990,7 +6996,7 @@ type PhysicalObject implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -7176,7 +7182,7 @@ type Preprint implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -7334,7 +7340,7 @@ type Preprint implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -7468,7 +7474,7 @@ type Publication implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -7626,7 +7632,7 @@ type Publication implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -8204,7 +8210,7 @@ type Service implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -8362,7 +8368,7 @@ type Service implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -8497,7 +8503,7 @@ type Software implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -8655,7 +8661,7 @@ type Software implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -8820,7 +8826,7 @@ type Sound implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -8978,7 +8984,7 @@ type Sound implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -9294,7 +9300,7 @@ type Work implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -9452,7 +9458,7 @@ type Work implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 
@@ -9587,7 +9593,7 @@ type Workflow implements DoiItem {
   The institution or person responsible for collecting, managing, distributing,
   or otherwise contributing to the development of the resource.
   """
-  contributors(first: Int = 20): [Contributor!]
+  contributors(contributorType: String, first: Int = 20): [Contributor!]
 
   """
   The main researchers involved in producing the data, or the authors of the publication, in priority order.
@@ -9745,7 +9751,7 @@ type Workflow implements DoiItem {
   subjects: [Subject!]
 
   """
-  A name or title by which a resource is known
+  A name or title by which a resource is known.
   """
   titles(first: Int = 5): [Title!]
 

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -136,7 +136,13 @@ type Audiovisual implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -421,7 +427,13 @@ type Book implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -663,7 +675,13 @@ type BookChapter implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -991,7 +1009,13 @@ type Collection implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -1275,7 +1299,13 @@ type ConferencePaper implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -1580,6 +1610,46 @@ type Container {
 }
 
 """
+A contributor.
+"""
+type Contributor {
+  """
+  The organizational or institutional affiliation of the contributor.
+  """
+  affiliation: [Affiliation!]
+
+  """
+  The type of the item.
+  """
+  contributorType: String!
+
+  """
+  Family name. In the U.S., the last name of an person.
+  """
+  familyName: String
+
+  """
+  Given name. In the U.S., the first name of a person.
+  """
+  givenName: String
+
+  """
+  The ID of the contributor.
+  """
+  id: ID
+
+  """
+  The name of the contributor.
+  """
+  name: String
+
+  """
+  The type of the item.
+  """
+  type: String!
+}
+
+"""
 Information about countries
 """
 type Country {
@@ -1805,7 +1875,13 @@ type DataPaper implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -2090,7 +2166,13 @@ type Dataset implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -2486,7 +2568,13 @@ type Dissertation implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -2775,7 +2863,13 @@ interface DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -3017,7 +3111,13 @@ type Event implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -3287,7 +3387,13 @@ type EventData implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -3849,7 +3955,13 @@ type Image implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -4134,7 +4246,13 @@ type Instrument implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -4418,7 +4536,13 @@ type InteractiveResource implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -4728,7 +4852,13 @@ type JournalArticle implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -5259,7 +5389,13 @@ type Model implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -5669,7 +5805,13 @@ type Other implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -5979,7 +6121,13 @@ type PeerReview implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -6395,7 +6543,13 @@ type PhysicalObject implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -6733,7 +6887,13 @@ type Preprint implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -7019,7 +7179,13 @@ type Publication implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -7747,7 +7913,13 @@ type Service implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -8034,7 +8206,13 @@ type Software implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -8351,7 +8529,13 @@ type Sound implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -8819,7 +9003,13 @@ type Work implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 
@@ -9106,7 +9296,13 @@ type Workflow implements DoiItem {
   container: Container
 
   """
-  The main researchers involved in producing the data, or the authors of the publication, in priority order
+  The institution or person responsible for collecting, managing, distributing,
+  or otherwise contributing to the development of the resource.
+  """
+  contributors(first: Int = 20): [Contributor!]
+
+  """
+  The main researchers involved in producing the data, or the authors of the publication, in priority order.
   """
   creators(first: Int = 20): [Creator!]
 

--- a/app/graphql/types/contributor_type.rb
+++ b/app/graphql/types/contributor_type.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ContributorType < BaseObject
+  description "A contributor."
+
+  field :id, ID, null: true, description: "The ID of the contributor."
+  field :type, String, null: false, description: "The type of the item."
+  field :contributor_type, String, null: false, description: "The type of the item."
+  field :name, String, null: true, description: "The name of the contributor."
+  field :given_name, String, null: true, description: "Given name. In the U.S., the first name of a person."
+  field :family_name, String, null: true, description: "Family name. In the U.S., the last name of an person."
+  field :affiliation, [AffiliationType], null: true, description: "The organizational or institutional affiliation of the contributor."
+
+  def type
+    object.name_type == "Organizational" ? "Organization" : "Person"
+  end
+end

--- a/app/graphql/types/doi_item.rb
+++ b/app/graphql/types/doi_item.rb
@@ -26,8 +26,9 @@ module DoiItem
   end
   field :contributors, [ContributorType], null: true, description: "The institution or person responsible for collecting, managing, distributing, or otherwise contributing to the development of the resource." do
     argument :first, Int, required: false, default_value: 20
+    argument :contributor_type, String, required: false
   end
-  field :titles, [TitleType], null: true, description: "A name or title by which a resource is known" do
+  field :titles, [TitleType], null: true, description: "A name or title by which a resource is known." do
     argument :first, Int, required: false, default_value: 5
   end
   field :publication_year, Int, null: true, description: "The year when the data was or will be made publicly available"
@@ -283,7 +284,7 @@ module DoiItem
   end
 
   def contributors(**args)
-    Array.wrap(object.contributors[0...args[:first]]).map do |c|
+    Array.wrap(object.contributors[0...args[:first]]).select { |c| c["contributorType"] == args[:contributor_type] }.map do |c|
       Hashie::Mash.new(
         "id" => c.fetch("nameIdentifiers", []).find { |n| %w(ORCID ROR).include?(n.fetch("nameIdentifierScheme", nil)) }.to_h.fetch("nameIdentifier", nil),
         "contributor_type" => c.fetch("contributorType", nil),

--- a/spec/graphql/types/contributor_type_spec.rb
+++ b/spec/graphql/types/contributor_type_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+describe ContributorType do
+  describe "fields" do
+    subject { described_class }
+
+    it { is_expected.to have_field(:id).of_type(types.ID) }
+    it { is_expected.to have_field(:type).of_type("String!") }
+    it { is_expected.to have_field(:contributorType).of_type("String!") }
+    it { is_expected.to have_field(:name).of_type("String") }
+    it { is_expected.to have_field(:givenName).of_type("String") }
+    it { is_expected.to have_field(:familyName).of_type("String") }
+    it { is_expected.to have_field(:affiliation).of_type("[Affiliation!]") }
+  end
+end

--- a/spec/graphql/types/dissertation_type_spec.rb
+++ b/spec/graphql/types/dissertation_type_spec.rb
@@ -195,7 +195,7 @@ describe DissertationType do
           }
           nodes {
             id
-            contributors {
+            dataManagers: contributors(contributorType: "DataManager") {
               id
               type
               name
@@ -208,11 +208,11 @@ describe DissertationType do
 
     it "returns dissertations" do
       response = LupoSchema.execute(query).as_json
-
+      puts response
       expect(response.dig("data", "dissertations", "totalCount")).to eq(3)
       expect(response.dig("data", "dissertations", "published")).to eq([{"count"=>3, "id"=>"2011", "title"=>"2011"}])
       expect(response.dig("data", "dissertations", "nodes").length).to eq(3)
-      expect(response.dig("data", "dissertations", "nodes", 0, "contributors")).to eq([{"contributorType"=>"HostingInstitution", "id"=>"https://ror.org/046ak2485", "name"=>"Freie Universität Berlin", "type"=>"Organization"}])
+      expect(response.dig("data", "dissertations", "nodes", 0, "dataManagers")).to eq([])
     end
   end
 end

--- a/spec/graphql/types/dissertation_type_spec.rb
+++ b/spec/graphql/types/dissertation_type_spec.rb
@@ -162,7 +162,13 @@ describe DissertationType do
   end
 
   describe "query dissertations by person", elasticsearch: true do
-    let!(:dissertations) { create_list(:doi, 3, types: { "resourceTypeGeneral" => "Text", "resourceType" => "Dissertation" }, aasm_state: "findable") }
+    let!(:dissertations) { create_list(:doi, 3, types: { "resourceTypeGeneral" => "Text", "resourceType" => "Dissertation" }, aasm_state: "findable", contributors: 
+      [{
+        "name" => "Freie Universität Berlin",
+        "contributorType" => "HostingInstitution",
+        "nameIdentifiers" => [{"nameIdentifier"=>"https://ror.org/046ak2485", "nameIdentifierScheme"=>"ROR", "schemeUri"=>"https://ror.org"}],
+        "nameType" => "Organizational",
+      }]) }
     let!(:dissertation) { create(:doi, types: { "resourceTypeGeneral" => "Text", "resourceType" => "Dissertation" }, aasm_state: "findable", creators:
       [{
         "familyName" => "Garza",
@@ -189,6 +195,12 @@ describe DissertationType do
           }
           nodes {
             id
+            contributors {
+              id
+              type
+              name
+              contributorType
+            }
           }
         }
       })
@@ -200,7 +212,7 @@ describe DissertationType do
       expect(response.dig("data", "dissertations", "totalCount")).to eq(3)
       expect(response.dig("data", "dissertations", "published")).to eq([{"count"=>3, "id"=>"2011", "title"=>"2011"}])
       expect(response.dig("data", "dissertations", "nodes").length).to eq(3)
-      # expect(response.dig("data", "dissertations", "nodes", 0, "id")).to eq(@dois.first.identifier)
+      expect(response.dig("data", "dissertations", "nodes", 0, "contributors")).to eq([{"contributorType"=>"HostingInstitution", "id"=>"https://ror.org/046ak2485", "name"=>"Freie Universität Berlin", "type"=>"Organization"}])
     end
   end
 end


### PR DESCRIPTION
## Purpose
Support DOI contributors in GraphQL API.

closes: #611 

## Approach
Implementation is very similar to `contributor`.

#### Open Questions and Pre-Merge TODOs
[ ] Going forward we want to use an ENUM for the `contributorType`, as it is a controlled list.

## Types of changes

- [ ] New feature (non-breaking change which adds functionality)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
