### PR TITLE
Add rake task to trigger updatedois based on query

### DIFF
--- a/lib/tasks/doi.rake
+++ b/lib/tasks/doi.rake
@@ -154,6 +154,24 @@ namespace :doi do
     Doi.loop_through_dois(options)
   end
 
+  desc "Trigger DOI Update based on query"
+  task update_dois_by_query: :environment do
+    # Ensure we have to specify a query of some kind.
+    if ENV['QUERY'].nil?
+      puts "ENV['QUERY'] is required"
+      exit
+    end
+
+    options = {
+      query: ENV["QUERY"],
+      label: "[UpdateDoiByQuery]",
+      job_name: "UpdateDoiJob",
+      cursor: ENV["CURSOR"].present? ? Base64.urlsafe_decode64(ENV["CURSOR"]).split(",", 2) : [],
+    }
+    puts Doi.loop_through_dois(options)
+  end
+
+
   # until all Crossref DOIs are indexed as otherDoi
   desc "Refresh metadata"
   task refresh: :environment do


### PR DESCRIPTION
## Purpose
Generic update dois rake task based on supplied query.

After looking at how the existing rake tasks work and what we need to do to fix missing data, triggering an update based on a query would be the easiest.
This generic allows us to 
a) do specific DOIs if need be
b) use things like -agency:* - To search for empty agency

## Approach
New take task based on existing

#### Open Questions and Pre-Merge TODOs
N/A
## Learning
Applied locally and checked behaviour
