### PR TITLE
Fix Name type return value when is not set

### DIFF
--- a/app/graphql/types/contributor_type.rb
+++ b/app/graphql/types/contributor_type.rb
@@ -12,6 +12,11 @@ class ContributorType < BaseObject
   field :affiliation, [AffiliationType], null: true, description: "The organizational or institutional affiliation of the contributor."
 
   def type
-    object.name_type == "Organizational" ? "Organization" : "Person"
+    case object.name_type
+    when "Organizational"
+      "Organization"
+    when "Personal"
+      "Person"
+    end
   end
 end

--- a/app/graphql/types/creator_type.rb
+++ b/app/graphql/types/creator_type.rb
@@ -11,6 +11,11 @@ class CreatorType < BaseObject
   field :affiliation, [AffiliationType], null: true, description: "The organizational or institutional affiliation of the creator."
 
   def type
-    object.name_type == "Organizational" ? "Organization" : "Person"
+    case object.name_type
+    when "Organizational"
+      "Organization"
+    when "Personal"
+      "Person"
+    end
   end
 end

--- a/spec/graphql/types/work_type_spec.rb
+++ b/spec/graphql/types/work_type_spec.rb
@@ -158,6 +158,9 @@ describe WorkType do
           nodes {
             id
             doi
+            creators{
+              type
+            }
           }
         }
         associated: works(hasAffiliation: true, hasFunder: true, hasOrganization: true, hasMember: true) {
@@ -228,6 +231,16 @@ describe WorkType do
             "affiliationIdentifierScheme": "ROR"
           },
         ]
+      },
+      {
+        "name" => "University of Cambridge",
+        "affiliation": [
+          {
+            "name": "University of Cambridge",
+            "affiliationIdentifier": "https://ror.org/013meh722",
+            "affiliationIdentifierScheme": "ROR"
+          },
+        ]
       }])
     }
     let!(:organization_doi) { create(:doi, aasm_state: "findable", client: client_without_ror, creators:
@@ -261,6 +274,7 @@ describe WorkType do
       expect(response.dig("data", "works", "pageInfo", "hasNextPage")).to be true
       expect(response.dig("data", "works", "nodes").length).to eq(4)
       expect(response.dig("data", "works", "nodes", 0, "id")).to eq(@works[0].identifier)
+      expect(response.dig("data", "works", "nodes", 0, "creators", 1, "type")).to be nil
       end_cursor = response.dig("data", "works", "pageInfo", "endCursor")
 
       response = LupoSchema.execute(query, variables: { first: 4, cursor: end_cursor }).as_json


### PR DESCRIPTION

## Purpose
`nametype` is not mandatory and it shouldn't default to person. Currently returns person even when the value is not set.

![image](https://user-images.githubusercontent.com/1092861/93775316-8ba2a080-fc22-11ea-9e44-e7321543ba29.png)

## Approach
return null if there is not nametype


#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
