### PR TITLE
Update prefixes in Elasticsearch immediately

### DIFF
--- a/spec/fixtures/vcr_cassettes/Doi/citations/has_citations.yml
+++ b/spec/fixtures/vcr_cassettes/Doi/citations/has_citations.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://doi.org/ra/10.14454
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/4.7.2; mailto:info@datacite.org)
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Sun, 27 Sep 2020 06:16:34 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=da09fb0caf62154de1577c81a8c7b72c91601187394; expires=Tue, 27-Oct-20
+        06:16:34 GMT; path=/; domain=.doi.org; HttpOnly; SameSite=Lax; Secure
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - 056fcdcc9c000005d4973ef200000001
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 5d9318c0fefb05d4-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [
+          {
+            "DOI": "10.14454",
+            "RA": "DataCite"
+          }
+        ]
+    http_version: null
+  recorded_at: Sun, 27 Sep 2020 06:16:35 GMT
+recorded_with: VCR 5.1.0

--- a/spec/lib/tasks/datacite_doi_rake_spec.rb
+++ b/spec/lib/tasks/datacite_doi_rake_spec.rb
@@ -169,7 +169,7 @@ describe "datacite_doi:import_one", order: :defined do
   include_context "rake"
 
   let(:doi)  { create(:doi) }
-  let(:output) { "Imported DOI #{doi.doi}.\n" }
+  let(:output) { "[MySQL] Imported metadata for DOI #{doi.doi}.\n" }
 
   it "prerequisites should include environment" do
     expect(subject.prerequisites).to include("environment")

--- a/spec/requests/client_prefixes_spec.rb
+++ b/spec/requests/client_prefixes_spec.rb
@@ -116,4 +116,18 @@ describe "Client Prefixes", type: :request, elasticsearch: true do
       end
     end
   end
+
+  describe 'DELETE /client-prefixes/:uid' do
+    let!(:client_prefix) { create(:client_prefix) }
+
+    before do
+      ClientPrefix.import
+      sleep 2
+    end
+
+    it 'deletes the prefix' do
+      delete "/client-prefixes/#{client_prefix.uid}", nil, headers
+      expect(last_response.status).to eq(204)
+    end
+  end
 end

--- a/spec/requests/provider_prefixes_spec.rb
+++ b/spec/requests/provider_prefixes_spec.rb
@@ -153,4 +153,18 @@ describe ProviderPrefixesController, type: :request, elasticsearch: true do
       end
     end
   end
+
+  describe 'DELETE /provider-prefixes/:uid' do
+    let!(:provider_prefix) { create(:provider_prefix) }
+
+    before do
+      ProviderPrefix.import
+      sleep 2
+    end
+
+    it 'deletes the prefix' do
+      delete "/provider-prefixes/#{provider_prefix.uid}", nil, headers
+      expect(last_response.status).to eq(204)
+    end
+  end
 end

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -822,23 +822,17 @@ describe ProvidersController, type: :request, elasticsearch: true  do
     end
   end
 
-  # # Test suite for DELETE /providers/:id
-  # describe 'DELETE /providers/:id' do
-  #   before { delete "/providers/#{provider.symbol}", headers: headers }
+  describe 'DELETE /providers/:id' do
+    let!(:provider) { create(:provider) }
 
-  #   it 'returns status code 204' do
-  #     expect(response).to have_http_status(204)
-  #   end
-  #   context 'when the resources doesnt exist' do
-  #     before { delete '/providers/xxx', params: params.to_json, headers: headers }
+    before do
+      Provider.import
+      sleep 2
+    end
 
-  #     it 'returns status code 404' do
-  #       expect(response).to have_http_status(404)
-  #     end
-
-  #     it 'returns a validation failure message' do
-  #       expect(json["errors"].first).to eq("status"=>"404", "title"=>"The resource you are looking for doesn't exist.")
-  #     end
-  #   end
-  # end
+    it 'deletes the provider' do
+      delete "/providers/#{provider.symbol.downcase}", nil, admin_headers
+      expect(last_response.status).to eq(204)
+    end
+  end
 end


### PR DESCRIPTION
## Purpose
The display and potential changes for prefixes in Fabrica can get out of sync, requiring a screen refresh. We should avoid this by updating Elasticsearch immediately after prefix changes, rather than in a background job.

closes: datacite/bracco#422

## Approach
By updating Elasticsearch immediately, the API and what we see in Fabrica should always represent the current status. The API response will be slower, up prefix updates happen infrequently.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
