### PR TITLE
Refactor strong params to deal with replacement of values

### DIFF
--- a/spec/fixtures/files/datacite_no_alt_indeitifer.xml
+++ b/spec/fixtures/files/datacite_no_alt_indeitifer.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.1/metadata.xsd">
+  <identifier identifierType="DOI">10.24397/PANGLOSS-0000008</identifier>
+  <titles>
+    <title xml:lang="en">Wild yam and yam 2</title>
+  </titles>
+  <creators>
+    <creator>
+      <creatorName nameType="Personal">Ridge, Eleanor</creatorName>
+    </creator>
+  </creators>
+  <contributors>
+    <contributor contributorType="Other">
+      <contributorName nameType="Personal">Elder Saksak Ruben</contributorName>
+    </contributor>
+    <contributor contributorType="Researcher">
+      <contributorName nameType="Personal">Ridge, Eleanor</contributorName>
+    </contributor>
+    <contributor contributorType="ContactPerson">
+      <contributorName>Ridge, Eleanor</contributorName>
+    </contributor>
+    <contributor contributorType="Producer">
+      <contributorName nameType="Organizational">Laboratoire de langues et civilisations à tradition orale</contributorName>
+    </contributor>
+    <contributor contributorType="HostingInstitution">
+      <contributorName nameType="Organizational">COllections de COrpus Oraux Numériques</contributorName>
+    </contributor>
+    <contributor contributorType="HostingInstitution">
+      <contributorName nameType="Organizational">Huma-Num</contributorName>
+    </contributor>
+    <contributor contributorType="HostingInstitution">
+      <contributorName nameType="Organizational">Langues et Civilisations à Tradition Orale</contributorName>
+    </contributor>
+    <contributor contributorType="HostingInstitution">
+      <contributorName nameType="Organizational">Centre Informatique National de l'Enseignement Supérieur</contributorName>
+    </contributor>
+    <contributor contributorType="RightsHolder">
+      <contributorName>Ridge, Eleanor</contributorName>
+    </contributor>
+  </contributors>
+  <rightsList>
+    <rights>Freely available for non-commercial use</rights>
+    <rights rightsURI="http://creativecommons.org/licenses/by-nc-nd/3.0/">Creative Commons Attribution-NonCommercial 2.5 Generic</rights>
+  </rightsList>
+  <publisher>Pangloss</publisher>
+  <publicationYear>2018</publicationYear>
+  <language>tvk</language>
+  <subjects>
+    <subject>Linguistique</subject>
+    <subject schemeURI="http://search.language-archives.org/index.html" subjectScheme="OLAC">Vatlongos</subject>
+  </subjects>
+  <resourceType resourceTypeGeneral="Text">narrative</resourceType>
+  <dates>
+    <date dateType="Available">2018-10-10</date>
+  </dates>
+  <alternateIdentifiers>
+    <alternateIdentifier alternateIdentifierType="internal ID">oai:crdo.vjf.cnrs.fr:cocoon-8e9a93c3-d071-3005-bf82-32d45148bfe8</alternateIdentifier>
+    <alternateIdentifier alternateIdentifierType="PURL">http://purl.org/poi/crdo.vjf.cnrs.fr/cocoon-8e9a93c3-d071-3005-bf82-32d45148bfe8</alternateIdentifier>
+    <alternateIdentifier alternateIdentifierType="ARK">https://cocoon.huma-num.fr/exist/crdo/ark:/87895/1.17-961772</alternateIdentifier>
+    <alternateIdentifier alternateIdentifierType="Handle">http://hdl.handle.net/10670/1.5e16l6</alternateIdentifier>
+  </alternateIdentifiers>
+  <relatedIdentifiers>
+    <relatedIdentifier relatedIdentifierType="PURL" relationType="Requires">http://purl.org/poi/crdo.vjf.cnrs.fr/cocoon-99af8135-a22e-3cb3-b49e-96ac48701180</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsPartOf">10.24397/Pangloss</relatedIdentifier>
+  </relatedIdentifiers>
+  <formats>
+    <format>text</format>
+    <format>xml</format>
+  </formats>
+  <descriptions>
+    <description descriptionType="Abstract" xml:lang="en">Elder Saksak describes different kinds of yam and wild yam, how to grow them and how to use for them for food, raising money and in custom ceremonies.</description>
+  </descriptions>
+</resource>

--- a/spec/fixtures/vcr_cassettes/EventsController/update_datacite_doi/registered.yml
+++ b/spec/fixtures/vcr_cassettes/EventsController/update_datacite_doi/registered.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://doi.org/ra/10.1241
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/4.7.2; mailto:info@datacite.org)
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 28 Sep 2020 12:01:00 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d5c3ef0bb356d49db2f690ac84f1e88fb1601294460; expires=Wed, 28-Oct-20
+        12:01:00 GMT; path=/; domain=.doi.org; HttpOnly; SameSite=Lax; Secure
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - 05762f7ed3000005cc253a6200000001
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 5d9d4eaaee5405cc-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [
+          {
+            "DOI": "10.1241",
+            "RA": "JaLC"
+          }
+        ]
+    http_version: null
+  recorded_at: Wed, 08 Apr 2015 00:00:00 GMT
+recorded_with: VCR 5.1.0

--- a/spec/requests/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois_spec.rb
@@ -703,7 +703,6 @@ describe DataciteDoisController, type: :request do
 
       it 'updates the record' do
         patch "/dois/#{doi_id}", valid_attributes, headers
-
         expect(last_response.status).to eq(201)
         expect(json.dig('data', 'attributes', 'doi')).to eq(doi_id.downcase)
         expect(json.dig('data', 'attributes', 'url')).to eq("http://www.bl.uk/pdf/pat.pdf")

--- a/spec/requests/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois_spec.rb
@@ -3026,6 +3026,52 @@ describe DataciteDoisController, type: :request do
       end
     end
 
+    context 'mds doi with alternateIdentifiers' do
+      let(:xml) { Base64.strict_encode64(file_fixture('datacite_no_alt_indeitifer.xml').read) }
+      let(:valid_attributes) do
+        {
+          "data" => {
+            "type" => "dois",
+            "attributes" => {
+              "url" => "http://www.bl.uk/pdf/patspec.pdf",
+              "should_validate" => "true",
+              "source" => "mds",
+              "event" => "publish"
+            }
+          }
+        }
+      end
+
+      let(:update_attributes) do
+        {
+          "data" => {
+            "type" => "dois",
+            "attributes" => {
+              "doi" => "10.14454/10703",
+              "should_validate" => "true",
+              "xml" => xml,
+              "source" => "mds",
+              "event" => "show"
+            }
+          }
+        }
+      end
+
+      it 'add metadata' do
+        put "/dois/10.14454/10703", update_attributes, headers
+
+        expect(json.dig('data', 'attributes', 'doi')).to eq("10.14454/10703")
+        expect(json.dig('data', 'attributes', 'identifiers').length).to eq(4)
+
+         
+        put '/dois/10.14454/10703', valid_attributes, headers
+       
+        expect(json.dig('data', 'attributes', 'doi')).to eq("10.14454/10703")
+        expect(json.dig('data', 'attributes', 'identifiers').length).to eq(4)
+      end
+    end
+
+
     # Funder has been removed as valid contributor type in schema 4.0
     context 'update contributor type with funder', elasticsearch: true do
       let(:update_attributes) do


### PR DESCRIPTION
## Purpose

There is a problem in that replace the `alternatedIdentifiers` with `identifiers`.  

When sending XML the identifier field is `blank` but is not `nil` therefore the API takes it (see [lupo:L147](https://github.com/datacite/lupo/blob/a85b412/app/controllers/datacite_dois_controller.rb#L714) ) as if the request included an empty value.  This condition is not necessarily wrong as API might want to replace a value with `blank`.

closes: https://github.com/datacite/lupo/issues/641

## Approach

conditioning of which parameters (json params or xml params) are accepted from the API is complex and by the look at the problem of  `alternatedIdentifiers`  inconsistent.

Here I opted for refactoring `strong_params` to accept parameters in separated methods.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning

We accept data even when is contradictory:

```
      {
          "data" => {
            "type" => "dois",
            "attributes" => {
              "url" => "http://www.bl.uk/pdf/pat.pdf",
              "xml" => xml,
              "titles" => "Submitted chemical data for InChIKey=YAPQBXQYLJRXSA-UHFFFAOYSA-N",
              "event" => "publish"
            }
          }
        }

```

this payload can include different values for the same parameters.


<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
