### PR TITLE
Add success check after DB update for ES indexing

### DIFF
--- a/app/models/concerns/helpable.rb
+++ b/app/models/concerns/helpable.rb
@@ -21,10 +21,6 @@ module Helpable
         raise ActionController::BadRequest.new(), "[Handle] Error updating DOI " + doi + ": client ID missing."
       end
 
-      unless match_url_with_domains(url: url, domains: client.domains)
-        raise ActionController::BadRequest.new(), "[Handle] Error updating DOI " + doi + ": URL not allowed by repository domains settings."
-      end
-
       unless is_registered_or_findable?
         raise ActionController::BadRequest.new(), "DOI is not registered or findable."
       end

--- a/app/models/concerns/helpable.rb
+++ b/app/models/concerns/helpable.rb
@@ -57,6 +57,7 @@ module Helpable
 
       if [200, 201].include?(response.status)
         # update minted column after first successful registration in handle system
+        success = true
         success = self.update_attributes(minted: Time.zone.now, updated: Time.zone.now) if minted.blank?
         Rails.logger.info "[Handle] URL for DOI " + doi + " updated to " + url + "." unless Rails.env.test?
 

--- a/app/models/concerns/helpable.rb
+++ b/app/models/concerns/helpable.rb
@@ -57,10 +57,12 @@ module Helpable
 
       if [200, 201].include?(response.status)
         # update minted column after first successful registration in handle system
-        self.update_attributes(minted: Time.zone.now, updated: Time.zone.now) if minted.blank?
+        success = self.update_attributes(minted: Time.zone.now, updated: Time.zone.now) if minted.blank?
         Rails.logger.info "[Handle] URL for DOI " + doi + " updated to " + url + "." unless Rails.env.test?
 
-        self.__elasticsearch__.index_document
+        if success
+          self.__elasticsearch__.index_document
+        end
       elsif response.status == 404
         Rails.logger.info "[Handle] Error updating URL for DOI " + doi + ": not found"
       elsif response.status == 408
@@ -134,7 +136,7 @@ module Helpable
       domain_list.any? do |d|
         # strip asterix for subdomain
         if d.starts_with?("*.")
-          d = d[1..-1] 
+          d = d[1..-1]
           uri.host.ends_with?(d)
         else
           uri.host == d

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -106,7 +106,7 @@ class Doi < ActiveRecord::Base
   validates_inclusion_of :agency, :in => %w(datacite crossref kisti medra istic jalc airiti cnki op), allow_blank: true
   validates :last_landing_page_status, numericality: { only_integer: true }, if: :last_landing_page_status?
   validates :xml, presence: true, xml_schema: true, if: Proc.new { |doi| doi.validatable? }
-  validate :check_url, if: :url?
+  validate :check_url, if: :url?, if: Proc.new { |doi| doi.is_registered_or_findable? }
   validate :check_dates, if: :dates?
   validate :check_rights_list, if: :rights_list?
   validate :check_titles, if: :titles?

--- a/spec/requests/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois_spec.rb
@@ -97,7 +97,7 @@ describe DataciteDoisController, type: :request, vcr: true do
       expect(Base64.urlsafe_decode64(cursor).split(",").last).to eq(@dois[3].uid)
       next_link_absolute = Addressable::URI.parse(json.dig('links', 'next'))
       next_link = next_link_absolute.path + "?" + next_link_absolute.query
-      
+
       get next_link, nil, headers
 
       expect(last_response.status).to eq(200)
@@ -108,7 +108,7 @@ describe DataciteDoisController, type: :request, vcr: true do
       expect(Base64.urlsafe_decode64(cursor).split(",").last).to eq(@dois[7].uid)
       next_link_absolute = Addressable::URI.parse(json.dig('links', 'next'))
       next_link = next_link_absolute.path + "?" + next_link_absolute.query
-      
+
       get next_link, nil, headers
 
       expect(last_response.status).to eq(200)
@@ -128,7 +128,7 @@ describe DataciteDoisController, type: :request, vcr: true do
       end
     end
   end
-  
+
   describe "GET /dois with query", elasticsearch: true do
     let!(:doi) { create(:doi, client: client, aasm_state: "findable", creators:
       [{
@@ -213,7 +213,7 @@ describe DataciteDoisController, type: :request, vcr: true do
 
     it 'returns dois with short ror id', vcr: true do
       get "/dois?affiliation-id=046ak2485&affiliation=true", nil, headers
-      
+
       expect(last_response.status).to eq(200)
       expect(json.dig('meta', 'total')).to eq(1)
       expect(json.dig('data', 0, 'attributes', 'creators')).to eq([{"name"=>"Garza, Kristian J.", "nameType"=>"Personal", "givenName"=>"Kristian J.", "familyName"=>"Garza", "affiliation"=>[{"name"=>"Freie Universität Berlin", "affiliationIdentifier"=>"https://ror.org/046ak2485", "affiliationIdentifierScheme"=>"ROR"}], "nameIdentifiers"=>[{"schemeUri"=>"https://orcid.org", "nameIdentifier"=>"https://orcid.org/0000-0003-3484-6875", "nameIdentifierScheme"=>"ORCID"}]}])
@@ -221,7 +221,7 @@ describe DataciteDoisController, type: :request, vcr: true do
 
     it 'returns dois with ror id', vcr: true do
       get "/dois?affiliation-id=ror.org/046ak2485&affiliation=true", nil, headers
-      
+
       expect(last_response.status).to eq(200)
       expect(json.dig('meta', 'total')).to eq(1)
       expect(json.dig('data', 0, 'attributes', 'creators')).to eq([{"name"=>"Garza, Kristian J.", "nameType"=>"Personal", "givenName"=>"Kristian J.", "familyName"=>"Garza", "affiliation"=>[{"name"=>"Freie Universität Berlin", "affiliationIdentifier"=>"https://ror.org/046ak2485", "affiliationIdentifierScheme"=>"ROR"}], "nameIdentifiers"=>[{"schemeUri"=>"https://orcid.org", "nameIdentifier"=>"https://orcid.org/0000-0003-3484-6875", "nameIdentifierScheme"=>"ORCID"}]}])
@@ -416,7 +416,7 @@ describe DataciteDoisController, type: :request, vcr: true do
       expect(json.dig('meta', 'resourceTypes')).to eq([])
     end
   end
-  
+
   describe 'GET /dois with views and downloads', elasticsearch: true, vcr: true do
     let(:doi) { create(:doi, client: client, aasm_state: "findable") }
     let!(:views) { create_list(:event_for_datacite_investigations, 2, obj_id: doi.doi) }
@@ -1112,7 +1112,7 @@ describe DataciteDoisController, type: :request, vcr: true do
             "attributes" => {
               "url" => "http://www.bl.uk/pdf/pat.pdf",
               "xml" => xml,
-              "dates" => { 
+              "dates" => {
                 "date" => ":tba",
                 "dateType" => "Issued"
               },
@@ -1561,7 +1561,7 @@ describe DataciteDoisController, type: :request, vcr: true do
 
       it 'fails to create a Doi' do
         post '/dois', valid_attributes, headers
-        expect(last_response.status).to eq(400)
+        expect(last_response.status).to eq(422)
       end
     end
 
@@ -1843,7 +1843,7 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(json.dig('data', 'attributes', 'titles')).to eq([{"lang"=>"en-US", "title"=>"Full DataCite XML Example"}, {"lang"=>"en-US", "title"=>"Demonstration of DataCite Properties.", "titleType"=>"Subtitle"}])
         expect(json.dig('data', 'attributes', 'identifiers')).to eq([{"identifier"=>"123", "identifierType"=>"Repository ID"}])
         expect(json.dig('data', 'attributes', 'alternateIdentifiers')).to eq([{"alternateIdentifier"=>"123", "alternateIdentifierType"=>"Repository ID"}])
-        
+
         doc = Nokogiri::XML(Base64.decode64(json.dig('data', 'attributes', 'xml')), nil, 'UTF-8', &:noblanks)
         expect(doc.at_css("identifier").content).to eq("10.14454/10703")
         expect(doc.at_css("alternateIdentifiers").content).to eq("123")
@@ -1872,7 +1872,7 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(json.dig('data', 'attributes', 'titles')).to eq([{"lang"=>"en-US", "title"=>"Full DataCite XML Example"}, {"lang"=>"en-US", "title"=>"Demonstration of DataCite Properties.", "titleType"=>"Subtitle"}])
         expect(json.dig('data', 'attributes', 'identifiers')).to eq([{"identifier"=>"123", "identifierType"=>"Repository ID"}])
         expect(json.dig('data', 'attributes', 'alternateIdentifiers')).to eq([{"alternateIdentifier"=>"123", "alternateIdentifierType"=>"Repository ID"}])
-        
+
         doc = Nokogiri::XML(Base64.decode64(json.dig('data', 'attributes', 'xml')), nil, 'UTF-8', &:noblanks)
         expect(doc.at_css("identifier").content).to eq("10.14454/10703")
         expect(doc.at_css("alternateIdentifiers").content).to eq("123")
@@ -3015,7 +3015,7 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(json.dig('data', 'attributes', 'schemaVersion')).to eq("http://datacite.org/schema/kernel-3")
 
         put '/dois/10.14454/10703', valid_attributes, headers
-       
+
         expect(json.dig('data', 'attributes', 'doi')).to eq("10.14454/10703")
         expect(json.dig('data', 'attributes', 'schemaVersion')).to eq("http://datacite.org/schema/kernel-3")
         expect(json.dig('data', 'attributes', 'titles')).to eq([{"title"=>"Data from: A new malaria agent in African hominids."}])


### PR DESCRIPTION
Only do an ES index if we successfully saved to the DB with correct information.

## Purpose
To fix accidental double indexing when record is in bad state:
https://github.com/datacite/datacite/issues/1134


## Approach
Just check to see if the save passed or not.

- [x ] Bug fix (non-breaking change which fixes an issue)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
