### PR TITLE
Add provider relationships to serializer on detail

### DIFF
--- a/app/serializers/datacite_doi_serializer.rb
+++ b/app/serializers/datacite_doi_serializer.rb
@@ -8,8 +8,9 @@ class DataciteDoiSerializer
 
   attributes :doi, :prefix, :suffix, :identifiers, :alternate_identifiers, :creators, :titles, :publisher, :container, :publication_year, :subjects, :contributors, :dates, :language, :types, :related_identifiers, :sizes, :formats, :version, :rights_list, :descriptions, :geo_locations, :funding_references, :xml, :url, :content_url, :metadata_version, :schema_version, :source, :is_active, :state, :reason, :landing_page, :view_count, :views_over_time, :download_count, :downloads_over_time, :reference_count, :citation_count, :citations_over_time, :part_count, :part_of_count, :version_count, :version_of_count, :created, :registered, :published, :updated
   attributes :prefix, :suffix, :views_over_time, :downloads_over_time, :citations_over_time, if: Proc.new { |object, params| params && params[:detail] }
-  
+
   belongs_to :client, record_type: :clients
+  belongs_to :provider, record_type: :providers, if: Proc.new { |object, params| params && params[:detail] }
   has_many :media, record_type: :media, id_method_name: :uid, if: Proc.new { |object, params| params && params[:detail] && !params[:is_collection]}
   has_many :references, record_type: :dois, serializer: DataciteDoiSerializer, object_method_name: :indexed_references, if: Proc.new { |object, params| params && params[:detail] }
   has_many :citations, record_type: :dois, serializer: DataciteDoiSerializer, object_method_name: :indexed_citations, if: Proc.new { |object, params| params && params[:detail] }
@@ -38,7 +39,7 @@ class DataciteDoiSerializer
         if params[:affiliation]
           a
         else
-          a["name"] 
+          a["name"]
         end
       end.compact
       c
@@ -53,7 +54,7 @@ class DataciteDoiSerializer
         if params[:affiliation]
           a
         else
-          a["name"] 
+          a["name"]
         end
       end.compact
       c

--- a/spec/requests/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois_spec.rb
@@ -127,6 +127,15 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(doi.dig('attributes')).to include('xml')
       end
     end
+
+    it 'returns related provider when detail is enabled', vcr: true do
+      get '/dois?detail=true', nil, headers
+
+      expect(last_response.status).to eq(200)
+      json['data'].each do |doi|
+        expect(doi.dig('relationships', 'provider','data','id')).to eq(provider.symbol.downcase)
+      end
+    end
   end
 
   describe "GET /dois with query", elasticsearch: true do


### PR DESCRIPTION
When detail is requested, additionally return the provider relationship.

## Purpose

So we can do: https://api.datacite.org/dois?client_id=delft.uu&detail=true
And get:

`"relationships":{"provider":{"data":{"id":"pzax","type":"providers"}}`

This is so when we need to provider information on who the member(provider) i.e. in OAI

Related to https://github.com/datacite/viringo/issues/53

## Approach
On ?detail param we additionally serialize provider.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
