### PR TITLE
Don't reindex on doi transfer if no db update

### DIFF
--- a/app/jobs/transfer_job.rb
+++ b/app/jobs/transfer_job.rb
@@ -10,9 +10,13 @@ class TransferJob < ActiveJob::Base
     doi = Doi.where(doi: doi_id).first
 
     if doi.present? && options[:client_target_id].present?
-      doi.update_attributes(datacentre: options[:client_target_id])
+      # Success starts as true because update_attributes only returns false on error.
+      success = true
+      success = doi.update_attributes(datacentre: options[:client_target_id])
 
-      doi.__elasticsearch__.index_document
+      if success
+        self.__elasticsearch__.index_document
+      end
 
       Rails.logger.info "[Transfer] Transferred DOI #{doi.doi}."
     elsif doi.present?


### PR DESCRIPTION
## Purpose

Dont do an ES document index if the database failed to update.

Related to https://github.com/datacite/lupo/issues/669

## Approach
Success check

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
