### PR TITLE
WIP: Update OpenAPI schema to latest version of metadata.xsd

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1170,7 +1170,16 @@ components:
                       familyName:
                         type: string
                       affiliation:
-                        type: string
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            affiliationIdentifier:
+                              type: string
+                            affiliationIdentifierScheme:
+                              type: string
+                            schemeUri:
+                              type: string
                 titles:
                   type: array
                   items:
@@ -1246,7 +1255,16 @@ components:
                       familyName:
                         type: string
                       affiliation:
-                        type: string
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            affiliationIdentifier:
+                              type: string
+                            affiliationIdentifierScheme:
+                              type: string
+                            schemeUri:
+                              type: string
                       contributorType:
                         type: string
                 dates:


### PR DESCRIPTION
## Purpose

I were unable to parse "get doi" request via autogenerated code by the openapi generator. 
It seems the openapi specification could need some updates according to the changelog in http://schema.datacite.org/meta/kernel-4/metadata.xsd . Seems like there is another relevant issue open about other missing openapi definitions, see #506 . 

I tested this towards my test DOI in the test environment: https://api.test.datacite.org/dois/application/vnd.datacite.datacite+json/10.16903/test-rono-dev-example1

With these changes, I could parse the response for the DOI above. I suspect there might be other updates that are missing to the openapi schema definitions as well. 

## What currently has been done

* Adding affiliation subproperties according to change log in metadata.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
