### PR TITLE
Remove client prefixes first before adding them.

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -539,6 +539,9 @@ class Client < ApplicationRecord
     if prefix_ids.present?
       response = ProviderPrefix.where("prefix_id IN (?)", prefix_ids).destroy_all
       Rails.logger.info "[Transfer][Prefix] #{response.count} provider prefixes deleted. #{prefix_ids}"
+
+      response = ClientPrefix.where("prefix_id IN (?)", prefix_ids).destroy_all
+      Rails.logger.info "[Transfer][Prefix] #{response.count} client prefixes deleted. #{prefix_ids}"
     end
 
     # Assign prefix(es) to provider and client


### PR DESCRIPTION
Part of ensuring client_prefixes is correct in index.

## Purpose
By ensuring we remove the client_prefixes before creating we dont end up with bad data in the index.

## Approach
See above.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
