### PR TITLE
Prefix transfer fix

### DIFF
--- a/app/controllers/client_prefixes_controller.rb
+++ b/app/controllers/client_prefixes_controller.rb
@@ -128,27 +128,6 @@ class ClientPrefixesController < ApplicationController
     authorize! :create, @client_prefix
 
     if @client_prefix.save
-      if @client_prefix.__elasticsearch__.index_document.dig("result") !=
-          "created"
-        logger.error "Error adding Client Prefix #{
-                       @client_prefix.uid
-                     } to Elasticsearch index."
-      end
-      if @client_prefix.prefix.__elasticsearch__.index_document.dig("result") !=
-          "updated"
-        logger.error "Error updating Elasticsearch index for Prefix #{
-                       @client_prefix.prefix.uid
-                     }."
-      end
-      if @client_prefix.provider_prefix.__elasticsearch__.index_document.dig(
-        "result",
-      ) !=
-          "updated"
-        logger.error "Error updating Elasticsearch index for Provider Prefix #{
-                       @client_prefix.provider_prefix.uid
-                     }."
-      end
-
       options = {}
       options[:include] = @include
       options[:is_collection] = false
@@ -174,27 +153,8 @@ class ClientPrefixesController < ApplicationController
 
   def destroy
     message = "Client prefix #{@client_prefix.uid} deleted."
-
     if @client_prefix.destroy
-      if @client_prefix.__elasticsearch__.delete_document.dig("result") !=
-          "deleted"
-        logger.error "Error deleting Client Prefix #{
-                       @client_prefix.uid
-                     } from Elasticsearch index."
-      end
-      if @client_prefix.prefix.__elasticsearch__.index_document.dig("result") !=
-          "updated"
-        logger.error "Error updating Elasticsearch index for Prefix #{
-                       @client_prefix.prefix.uid
-                     }."
-      end
-      if @client_prefix.provider_prefix.__elasticsearch__.index_document
-        logger.error "Error updating Elasticsearch index for Provider Prefix #{
-                       @client_prefix.provider_prefix.uid
-                     }."
-      end
-
-      logger.warn message
+      Rails.logger.warn message
       head :no_content
     else
       Rails.logger.error @client_prefix.errors.inspect

--- a/app/controllers/provider_prefixes_controller.rb
+++ b/app/controllers/provider_prefixes_controller.rb
@@ -125,29 +125,8 @@ class ProviderPrefixesController < ApplicationController
     @provider_prefix = ProviderPrefix.new(safe_params)
     authorize! :create, @provider_prefix
 
-    if @provider_prefix.save
-      if @provider_prefix.__elasticsearch__.index_document.dig("result") !=
-          "created"
-        logger.error "Error adding Provider Prefix #{
-                       @provider_prefix.uid
-                     } to Elasticsearch index."
-      end
-      if @provider_prefix.prefix.__elasticsearch__.index_document.dig(
-        "result",
-      ) !=
-          "updated"
-        logger.error "Error updating Elasticsearch index for Prefix #{
-                       @provider_prefix.prefix.uid
-                     }."
-      end
-      if @provider_prefix.provider.__elasticsearch__.index_document.dig(
-        "result",
-      ) !=
-          "updated"
-        logger.error "Error updating Elasticsearch index for Provider #{
-                       @provider_prefix.provider.uid
-                     }."
-      end
+    if @provider_prefix.save && @provider_prefix.__elasticsearch__.index_document.dig("result") == "created"
+      @provider_prefix.prefix.__elasticsearch__.index_document
 
       options = {}
       options[:include] = @include
@@ -173,32 +152,9 @@ class ProviderPrefixesController < ApplicationController
   end
 
   def destroy
-    message = "Provider Prefix #{@provider_prefix.uid} deleted."
+    message = "Provider prefix #{@provider_prefix.uid} deleted."
     if @provider_prefix.destroy
-      if @provider_prefix.__elasticsearch__.delete_document.dig("result") !=
-          "deleted"
-        logger.error "Error deleting Provider Prefix #{
-                       @provider_prefix.uid
-                     } from Elasticsearch index."
-      end
-      if @provider_prefix.prefix.__elasticsearch__.index_document.dig(
-        "result",
-      ) !=
-          "updated"
-        logger.error "Error updating Elasticsearch index for Prefix #{
-                       @provider_prefix.prefix.uid
-                     }."
-      end
-      if @provider_prefix.provider.__elasticsearch__.index_document.dig(
-        "result",
-      ) !=
-          "updated"
-        logger.error "Error updating Elasticsearch index for Provider #{
-                       @provider_prefix.provider.uid
-                     }."
-      end
-
-      logger.info message
+      Rails.logger.warn message
       head :no_content
     else
       Rails.logger.error @provider_prefix.errors.inspect

--- a/app/controllers/repository_prefixes_controller.rb
+++ b/app/controllers/repository_prefixes_controller.rb
@@ -127,27 +127,6 @@ class RepositoryPrefixesController < ApplicationController
     authorize! :create, @client_prefix
 
     if @client_prefix.save
-      if @client_prefix.__elasticsearch__.index_document.dig("result") !=
-          "created"
-        logger.error "Error adding Repository Prefix #{
-                       @client_prefix.uid
-                     } to Elasticsearch index."
-      end
-      if @client_prefix.prefix.__elasticsearch__.index_document.dig("result") !=
-          "updated"
-        logger.error "Error updating Elasticsearch index for Prefix #{
-                       @client_prefix.prefix.uid
-                     }."
-      end
-      if @client_prefix.provider_prefix.__elasticsearch__.index_document.dig(
-        "result",
-      ) !=
-          "updated"
-        logger.error "Error updating Elasticsearch index for Provider Prefix #{
-                       @client_prefix.provider_prefix.uid
-                     }."
-      end
-
       options = {}
       options[:include] = @include
       options[:is_collection] = false
@@ -175,27 +154,8 @@ class RepositoryPrefixesController < ApplicationController
   def destroy
     authorize! :destroy, @client_prefix
     message = "Client prefix #{@client_prefix.uid} deleted."
-
     if @client_prefix.destroy
-      if @client_prefix.__elasticsearch__.delete_document.dig("result") !=
-          "deleted"
-        logger.error "Error deleting Repository Prefix #{
-                       @client_prefix.uid
-                     } from Elasticsearch index."
-      end
-      if @client_prefix.prefix.__elasticsearch__.index_document.dig("result") !=
-          "updated"
-        logger.error "Error updating Elasticsearch index for Prefix #{
-                       @client_prefix.prefix.uid
-                     }."
-      end
-      if @client_prefix.provider_prefix.__elasticsearch__.index_document
-        logger.error "Error updating Elasticsearch index for Provider Prefix #{
-                       @client_prefix.provider_prefix.uid
-                     }."
-      end
-
-      logger.warn message
+      Rails.logger.warn message
       head :no_content
     else
       Rails.logger.error @client_prefix.errors.inspect

--- a/spec/requests/clients_spec.rb
+++ b/spec/requests/clients_spec.rb
@@ -295,6 +295,11 @@ describe ClientsController, type: :request, elasticsearch: true do
         }
       end
 
+      before do
+        ProviderPrefix.import
+        sleep 2
+      end
+
       it "updates the record" do
         put "/clients/#{client.symbol}", params, headers
 
@@ -325,6 +330,15 @@ describe ClientsController, type: :request, elasticsearch: true do
         expect(
           json.dig("data", "relationships", "clients", "data").first.dig("id"),
         ).to eq(client.symbol.downcase)
+
+        get "provider-prefixes?query=#{prefix.uid}"
+        puts json
+        expect(
+          json.dig("meta", "total"),
+        ).to eq(1)
+        expect(
+          json.dig("data").first.dig("relationships", "provider", "data", "id"),
+        ).to eq("quechua")
       end
     end
 


### PR DESCRIPTION
This is effectively a revert of PR #642
the reasoning is this caused subtle bugs with
model changes that did not go via a controller.

The problem this caused was that the database would be out of sync
with the index.

This was most notable in repository transfers where the DB
would show correct transfers but index remained unchanged.

## Purpose
To fix transfers so prefixes are correctly indexed.

## Approach
Core is that we only want to change the ES index when model changes happen, not only on controllers.

However to accommodate the original idea of the previous commits, this will now immediately do a index job on the model changes rather than wait on a queue.

## Post merge
Test on staging to ensure transfers behave correctly.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
