### PR TITLE
Use instance variables to reduce  number of ES calls in other types

### DIFF
--- a/app/graphql/types/data_catalog_type.rb
+++ b/app/graphql/types/data_catalog_type.rb
@@ -145,24 +145,30 @@ class DataCatalogType < BaseObject
   end
 
   def view_count
-    if response.results.total.positive?
-      aggregate_count(response.response.aggregations.views.buckets)
+    args = { first: 0 }
+    @r = response(args) if @r.nil?
+    if @r.results.total.positive?
+      aggregate_count(@r.response.aggregations.views.buckets)
     else
       0
     end
   end
 
   def download_count
-    if response.results.total.positive?
-      aggregate_count(response.response.aggregations.downloads.buckets)
+    args = { first: 0 }
+    @r = response(args) if @r.nil?
+    if @r.results.total.positive?
+      aggregate_count(@r.response.aggregations.downloads.buckets)
     else
       0
     end
   end
 
   def citation_count
-    if response.results.total.positive?
-      aggregate_count(response.response.aggregations.citations.buckets)
+    args = { first: 0 }
+    @r = response(args) if @r.nil?
+    if @r.results.total.positive?
+      aggregate_count(@r.response.aggregations.citations.buckets)
     else
       0
     end

--- a/app/graphql/types/funder_type.rb
+++ b/app/graphql/types/funder_type.rb
@@ -218,20 +218,20 @@ class FunderType < BaseObject
 
   def view_count
     args = { first: 0 }
-    r = response(args)
-    r.response.aggregations.view_count.value.to_i
+    @r = response(args) if @r.nil?
+    @r.response.aggregations.view_count.value.to_i
   end
 
   def download_count
     args = { first: 0 }
-    r = response(args)
-    r.response.aggregations.download_count.value.to_i
+    @r = response(args) if @r.nil?
+    @r.response.aggregations.download_count.value.to_i
   end
 
   def citation_count
     args = { first: 0 }
-    r = response(args)
-    r.response.aggregations.citation_count.value.to_i
+    @r = response(args) if @r.nil?
+    @r.response.aggregations.citation_count.value.to_i
   end
 
   def response(**args)

--- a/app/graphql/types/member_type.rb
+++ b/app/graphql/types/member_type.rb
@@ -305,9 +305,9 @@ class MemberType < BaseObject
 
   def view_count
     args = { first: 0 }
-    r = response(args)
-    if r.results.total.positive?
-      aggregate_count(r.response.aggregations.views.buckets)
+    @r = response(args) if @r.nil?
+    if @r.results.total.positive?
+      aggregate_count(@r.response.aggregations.views.buckets)
     else
       0
     end
@@ -315,9 +315,9 @@ class MemberType < BaseObject
 
   def download_count
     args = { first: 0 }
-    r = response(args)
-    if r.results.total.positive?
-      aggregate_count(r.response.aggregations.downloads.buckets)
+    @r = response(args) if @r.nil?
+    if @r.results.total.positive?
+      aggregate_count(@r.response.aggregations.downloads.buckets)
     else
       0
     end
@@ -325,9 +325,9 @@ class MemberType < BaseObject
 
   def citation_count
     args = { first: 0 }
-    r = response(args)
-    if r.results.total.positive?
-      aggregate_count(r.response.aggregations.citations.buckets)
+    @r = response(args) if @r.nil?
+    if @r.results.total.positive?
+      aggregate_count(@r.response.aggregations.citations.buckets)
     else
       0
     end

--- a/app/graphql/types/organization_type.rb
+++ b/app/graphql/types/organization_type.rb
@@ -331,20 +331,20 @@ class OrganizationType < BaseObject
 
   def view_count
     args = { first: 0 }
-    r = response(args)
-    r.response.aggregations.view_count.value.to_i
+    @r = response(args) if @r.nil?
+    @r.response.aggregations.view_count.value.to_i
   end
 
   def download_count
     args = { first: 0 }
-    r = response(args)
-    r.response.aggregations.download_count.value.to_i
+    @r = response(args) if @r.nil?
+    @r.response.aggregations.download_count.value.to_i
   end
 
   def citation_count
     args = { first: 0 }
-    r = response(args)
-    r.response.aggregations.citation_count.value.to_i
+    @r = response(args) if @r.nil?
+    @r.response.aggregations.citation_count.value.to_i
   end
 
   def response(**args)

--- a/app/graphql/types/repository_type.rb
+++ b/app/graphql/types/repository_type.rb
@@ -275,20 +275,20 @@ class RepositoryType < BaseObject
 
   def view_count
     args = { first: 0 }
-    r = response(args)
-    r.response.aggregations.view_count.value.to_i
+    @r = response(args) if @r.nil?
+    @r.response.aggregations.view_count.value.to_i
   end
 
   def download_count
     args = { first: 0 }
-    r = response(args)
-    r.response.aggregations.download_count.value.to_i
+    @r = response(args) if @r.nil?
+    @r.response.aggregations.download_count.value.to_i
   end
 
   def citation_count
     args = { first: 0 }
-    r = response(args)
-    r.response.aggregations.citation_count.value.to_i
+    @r = response(args) if @r.nil?
+    @r.response.aggregations.citation_count.value.to_i
   end
 
   def response(**args)


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Our current methods to display metrics counts make multiple calls. 

related: https://github.com/datacite/lupo/pull/754

## Approach
<!--- _How does this change address the problem?_ -->

Reduce the number of calls by using an instance variable.

this has been seen to work in https://github.com/datacite/lupo/pull/754

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
