### PR TITLE
Revert "Cache graphQL response to improve Commons User Experience "

### DIFF
--- a/app/models/concerns/cacheable.rb
+++ b/app/models/concerns/cacheable.rb
@@ -65,23 +65,6 @@ module Cacheable
       end
     end
 
-    def cached_graphql_response(query, variables, context, operation_name)
-      hash = Base64.encode64(query.to_json + variables.to_json + context.to_json + operation_name.to_json)
-      if Rails.application.config.action_controller.perform_caching && !variables[:id].nil?
-        Rails.cache.fetch("akita_response/#{hash}", expires_in: 24.hours) do
-          LupoSchema.execute(
-            query,
-            variables: variables, context: context, operation_name: operation_name,
-          ).to_json
-        end
-      else
-        LupoSchema.execute(
-          query,
-          variables: variables, context: context, operation_name: operation_name,
-        )
-      end
-    end
-
     def cached_resource_type_response(id)
       Rails.cache.fetch("resource_type_response/#{id}", expires_in: 1.month) do
         resource_type = ResourceType.where(id: id)


### PR DESCRIPTION
Reverts datacite/lupo#756

This PR unfortunatly has some knock on effects where data needs to be more granular, caching the entire response causes some problems e.g. up to date orcid claims

Reverting for now in favour of future effort to do more granular caching, one potential solution si to do more fragment based caching on the individual fields (using graphql-cache plugin)