### PR TITLE
Fix provider-prefixes paging (#722)

### DIFF
--- a/app/controllers/provider_prefixes_controller.rb
+++ b/app/controllers/provider_prefixes_controller.rb
@@ -75,7 +75,7 @@ class ProviderPrefixesController < ApplicationController
           if provider_prefixes.blank?
             nil
           else
-            request.base_url + "/provider_prefixes?" +
+            request.base_url + "/provider-prefixes?" +
               {
                 query: params[:query],
                 prefix: params[:prefix],

--- a/spec/requests/provider_prefixes_spec.rb
+++ b/spec/requests/provider_prefixes_spec.rb
@@ -112,6 +112,16 @@ describe ProviderPrefixesController, type: :request, elasticsearch: true do
       expect(last_response.status).to eq(200)
       expect(json["data"].size).to eq(5)
     end
+
+    it "returns correct paging links" do
+      get "/provider-prefixes", nil, headers
+      self_link_absolute = Addressable::URI.parse(json.dig("links", "self"))
+      expect(self_link_absolute.path).to eq("/provider-prefixes")
+
+      next_link_absolute = Addressable::URI.parse(json.dig("links", "next"))
+      next_link = next_link_absolute.path + "?" + next_link_absolute.query
+      expect(next_link).to eq("/provider-prefixes?page%5Bnumber%5D=2&page%5Bsize%5D=25")
+    end
   end
 
   describe "GET /provider-prefixes/:uid" do


### PR DESCRIPTION
## Purpose
This PR fixes paging links for the `provider-prefixes` endpoint and adds rspec tests to ensure the correct URLs are returned

closes: #722 

## Approach
Fix a typo in the endpoint controller, which used an underscore instead of a hyphen

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->
- [ ] Are the tests added in the right place for the logical format of the rspec file? I added them under the `describe "GET /provider-prefixes"` block as it seemed like each endpoint request had one top level block, even if slightly different functionalities of the endpoint were being tested.

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
