### PR TITLE
Remove v3 rspec tests from pull_request action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -83,6 +83,5 @@ jobs:
           bundle exec rspec spec/lib
           bundle exec rspec spec/models
           bundle exec rspec spec/requests/*.rb
-          bundle exec rspec spec/requests/v3/*.rb
           bundle exec rspec spec/routing
           echo $?


### PR DESCRIPTION
## Purpose
V3 Rest api has been pulled from main branch.  We do not need to test for it on PRs.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
