### PR TITLE
Fix a few string array fields on the data_catalog graphql endpoint

### DIFF
--- a/app/graphql/types/data_catalog_type.rb
+++ b/app/graphql/types/data_catalog_type.rb
@@ -97,6 +97,18 @@ class DataCatalogType < BaseObject
     Array.wrap(object.keywords).map { |k| k["text"] }.join(", ")
   end
 
+  def contacts
+    Array.wrap(object.contacts).map { |k| k["text"] }
+  end
+
+  def provider_types
+    Array.wrap(object.provider_types).map { |k| k["text"] }
+  end
+
+  def pid_systems
+    Array.wrap(object.pid_systems).map { |k| k["text"] }
+  end
+
   def in_language
     Array.wrap(object.repository_languages).map { |k| k["text"] }
   end

--- a/spec/concerns/countable_spec.rb
+++ b/spec/concerns/countable_spec.rb
@@ -23,6 +23,7 @@ describe "Providers", type: :controller, elasticsearch: true do
           { "count" => 3, "id" => "2019", "title" => "2019" },
           { "count" => 3, "id" => "2020", "title" => "2020" },
           { "count" => 3, "id" => "2021", "title" => "2021" },
+          { "count" => 3, "id" => "2022", "title" => "2022" },
         ],
       )
     end
@@ -38,6 +39,7 @@ describe "Providers", type: :controller, elasticsearch: true do
           { "count" => 1, "id" => "2019", "title" => "2019" },
           { "count" => 1, "id" => "2020", "title" => "2020" },
           { "count" => 1, "id" => "2021", "title" => "2021" },
+          { "count" => 1, "id" => "2022", "title" => "2022" },
           { "count" => 2, "id" => "2015", "title" => "2015" },
           { "count" => 2, "id" => "2016", "title" => "2016" },
           { "count" => 2, "id" => "2017", "title" => "2017" },
@@ -64,6 +66,7 @@ describe "Providers", type: :controller, elasticsearch: true do
           { "count" => 3, "id" => "2019", "title" => "2019" },
           { "count" => 3, "id" => "2020", "title" => "2020" },
           { "count" => 3, "id" => "2021", "title" => "2021" },
+          { "count" => 3, "id" => "2022", "title" => "2022" },
         ],
       )
     end
@@ -79,6 +82,7 @@ describe "Providers", type: :controller, elasticsearch: true do
           { "count" => 1, "id" => "2019", "title" => "2019" },
           { "count" => 1, "id" => "2020", "title" => "2020" },
           { "count" => 1, "id" => "2021", "title" => "2021" },
+          { "count" => 1, "id" => "2022", "title" => "2022" },
           { "count" => 2, "id" => "2015", "title" => "2015" },
           { "count" => 2, "id" => "2016", "title" => "2016" },
           { "count" => 2, "id" => "2017", "title" => "2017" },

--- a/spec/graphql/types/data_catalog_type_spec.rb
+++ b/spec/graphql/types/data_catalog_type_spec.rb
@@ -195,21 +195,13 @@ describe DataCatalogType do
           ]
       )
       expect(data_catalog.fetch("contacts")).to eq(
-          [
-              "datascience@ucla.edu",
-              "datascience@ucla.edu",
-          ],
+          [ "datascience@ucla.edu", "datascience@ucla.edu" ],
       )
       expect(data_catalog.fetch("pidSystems")).to eq(
-          [
-              "hdl",
-              "DOI",
-          ]
+          [ "hdl", "DOI" ]
       )
       expect(data_catalog.fetch("inLanguage")).to eq(
-          [
-              "eng",
-          ]
+          [ "eng" ]
       )
 
       expect(data_catalog.fetch("softwareApplication")).to eq(

--- a/spec/graphql/types/data_catalog_type_spec.rb
+++ b/spec/graphql/types/data_catalog_type_spec.rb
@@ -10,6 +10,9 @@ describe DataCatalogType do
     it { is_expected.to have_field(:type).of_type("String!") }
     it { is_expected.to have_field(:name).of_type("String") }
     it { is_expected.to have_field(:alternateName).of_type("[String!]") }
+    it { is_expected.to have_field(:contacts).of_type("[String!]") }
+    it { is_expected.to have_field(:providerTypes).of_type("[String!]") }
+    it { is_expected.to have_field(:pidSystems).of_type("[String!]") }
     it { is_expected.to have_field(:description).of_type("String") }
     it { is_expected.to have_field(:certificates).of_type("[DefinedTerm!]") }
     it { is_expected.to have_field(:subjects).of_type("[DefinedTerm!]") }
@@ -153,6 +156,10 @@ describe DataCatalogType do
               url
               softwareVersion
             }
+            contacts
+            providerTypes
+            pidSystems
+            inLanguage
           }
         }
       }"
@@ -182,6 +189,29 @@ describe DataCatalogType do
         "The Social Science Data Archive is still active and maintained as part of the UCLA Library",
       )
       expect(data_catalog.fetch("certificates")).to be_empty
+      expect(data_catalog.fetch("providerTypes")).to eq(
+          [
+              "dataProvider",
+          ]
+      )
+      expect(data_catalog.fetch("contacts")).to eq(
+          [
+              "datascience@ucla.edu",
+              "datascience@ucla.edu",
+          ],
+      )
+      expect(data_catalog.fetch("pidSystems")).to eq(
+          [
+              "hdl",
+              "DOI",
+          ]
+      )
+      expect(data_catalog.fetch("inLanguage")).to eq(
+          [
+              "eng",
+          ]
+      )
+
       expect(data_catalog.fetch("softwareApplication")).to eq(
         [{ "name" => "DataVerse", "softwareVersion" => nil, "url" => nil }],
       )

--- a/spec/graphql/types/data_catalog_type_spec.rb
+++ b/spec/graphql/types/data_catalog_type_spec.rb
@@ -190,18 +190,26 @@ describe DataCatalogType do
       )
       expect(data_catalog.fetch("certificates")).to be_empty
       expect(data_catalog.fetch("providerTypes")).to eq(
-          [
-              "dataProvider",
-          ]
+        [
+          "dataProvider",
+        ]
       )
       expect(data_catalog.fetch("contacts")).to eq(
-          [ "datascience@ucla.edu", "datascience@ucla.edu" ],
+        [
+          "datascience@ucla.edu",
+          "datascience@ucla.edu"
+        ],
       )
       expect(data_catalog.fetch("pidSystems")).to eq(
-          [ "hdl", "DOI" ]
+        [
+          "hdl",
+          "DOI"
+        ]
       )
       expect(data_catalog.fetch("inLanguage")).to eq(
-          [ "eng" ]
+        [
+          "eng"
+        ]
       )
 
       expect(data_catalog.fetch("softwareApplication")).to eq(

--- a/spec/graphql/types/member_type_spec.rb
+++ b/spec/graphql/types/member_type_spec.rb
@@ -242,7 +242,7 @@ describe MemberType do
 
       expect(response.dig("data", "member", "prefixes", "totalCount")).to eq(3)
       expect(response.dig("data", "member", "prefixes", "years")).to eq(
-        [{ "count" => 3, "id" => "2021" }],
+        [{ "count" => 3, "id" => "2022" }],
       )
       expect(response.dig("data", "member", "prefixes", "nodes").length).to eq(
         3,

--- a/spec/graphql/types/member_type_spec.rb
+++ b/spec/graphql/types/member_type_spec.rb
@@ -116,7 +116,7 @@ describe MemberType do
       ).to be true
 
       expect(response.dig("data", "members", "years")).to eq(
-        [{ "count" => 6, "id" => "2021", "title" => "2021" }],
+        [{ "count" => 6, "id" => "2022", "title" => "2022" }],
       )
       expect(response.dig("data", "members", "regions")).to eq(
         [
@@ -226,7 +226,7 @@ describe MemberType do
         response.dig("data", "member", "repositories", "totalCount"),
       ).to eq(1)
       expect(response.dig("data", "member", "repositories", "years")).to eq(
-        [{ "count" => 1, "id" => "2021" }],
+        [{ "count" => 1, "id" => "2022" }],
       )
       expect(response.dig("data", "member", "repositories", "software")).to eq(
         [{ "count" => 1, "id" => "dataverse" }],

--- a/spec/graphql/types/repository_type_spec.rb
+++ b/spec/graphql/types/repository_type_spec.rb
@@ -98,7 +98,7 @@ describe RepositoryType do
 
       expect(response.dig("data", "repositories", "totalCount")).to eq(4)
       expect(response.dig("data", "repositories", "years")).to eq(
-        [{ "count" => 4, "id" => "2021", "title" => "2021" }],
+        [{ "count" => 4, "id" => "2022", "title" => "2022" }],
       )
       expect(response.dig("data", "repositories", "members")).to eq(
         [
@@ -183,7 +183,7 @@ describe RepositoryType do
         response.dig("data", "repository", "prefixes", "totalCount"),
       ).to eq(3)
       expect(response.dig("data", "repository", "prefixes", "years")).to eq(
-        [{ "count" => 3, "id" => "2021" }],
+        [{ "count" => 3, "id" => "2022" }],
       )
       expect(
         response.dig("data", "repository", "prefixes", "nodes").length,

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -372,7 +372,7 @@ describe Client, type: :model do
     it "should show all cumulative years" do
       client = create(:client, provider: provider)
       expect(client.cumulative_years).to eq(
-        [2_015, 2_016, 2_017, 2_018, 2_019, 2_020, 2_021],
+        [2_015, 2_016, 2_017, 2_018, 2_019, 2_020, 2_021, 2_022],
       )
     end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -290,7 +290,7 @@ describe Provider, type: :model do
     it "should show all cumulative years" do
       provider = create(:provider)
       expect(provider.cumulative_years).to eq(
-        [2_015, 2_016, 2_017, 2_018, 2_019, 2_020, 2_021],
+        [2_015, 2_016, 2_017, 2_018, 2_019, 2_020, 2_021, 2_022],
       )
     end
 

--- a/spec/requests/provider_prefixes_spec.rb
+++ b/spec/requests/provider_prefixes_spec.rb
@@ -41,7 +41,7 @@ describe ProviderPrefixesController, type: :request, elasticsearch: true do
       expect(last_response.status).to eq(200)
       expect(json["data"].size).to eq(3)
       expect(json.dig("meta", "years")).to eq(
-        [{ "count" => 3, "id" => "2021", "title" => "2021" }],
+        [{ "count" => 3, "id" => "2022", "title" => "2022" }],
       )
       expect(json.dig("meta", "states")).to eq(
         [

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -249,11 +249,11 @@ describe ProvidersController, type: :request, elasticsearch: true do
 
       expect(last_response.status).to eq(200)
       expect(json["clients"]).to eq(
-        [{ "count" => 1, "id" => "2021", "title" => "2021" }],
+        [{ "count" => 1, "id" => "2022", "title" => "2022" }],
       )
       # expect(json["resourceTypes"]).to eq([{"count"=>3, "id"=>"dataset", "title"=>"Dataset"}])
       expect(json["dois"]).to eq(
-        [{ "count" => 3, "id" => "2021", "title" => "2021" }],
+        [{ "count" => 3, "id" => "2022", "title" => "2022" }],
       )
     end
   end

--- a/spec/requests/repositories_spec.rb
+++ b/spec/requests/repositories_spec.rb
@@ -225,7 +225,7 @@ describe RepositoriesController, type: :request, elasticsearch: true do
         [{ "count" => 3, "id" => "dataset", "title" => "Dataset" }],
       )
       expect(json["dois"]).to eq(
-        [{ "count" => 3, "id" => "2021", "title" => "2021" }],
+        [{ "count" => 3, "id" => "2022", "title" => "2022" }],
       )
     end
   end


### PR DESCRIPTION
## Purpose
The data_catalog graphql endpoint returned several `#<Hashie::Mash...>` values for string array fields.



## Approach
Unwrap the hashes into string arrays.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
