### PR TITLE
Updates to bring Lupo up to full support for Metadata Schema v4.4

### DIFF
--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -959,6 +959,34 @@ class DataciteDoisController < ApplicationController
             lastPage
           ],
         },
+        :relatedItems,
+        {
+          relatedItems: [
+            :relationType,
+            :relatedItemType,
+            {
+              relatedItemIdentifier: %i[relatedItemIdentifier relatedItemIdentifierType relatedMetadataScheme schemeURI schemeType],
+            },
+            {
+              creators: %i[nameType name givenName familyName],
+            },
+            {
+              titles: %i[title titleType],
+            },
+            :publicationYear,
+            :volume,
+            :issue,
+            :number,
+            :numberType,
+            :firstPage,
+            :lastPage,
+            :publisher,
+            :edition,
+            {
+              contributors: %i[contributorType name givenName familyName],
+            },
+          ],
+        },
         :published,
         :downloadsOverTime,
         { downloadsOverTime: %i[yearMonth total] },
@@ -1152,6 +1180,7 @@ class DataciteDoisController < ApplicationController
         :alternateIdentifiers,
         :rightsList,
         :relatedIdentifiers,
+        :relatedItems,
         :fundingReferences,
         :geoLocations,
         :metadataVersion,

--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -983,7 +983,7 @@ class DataciteDoisController < ApplicationController
             :publisher,
             :edition,
             {
-              contributors: %i[contributorType name givenName familyName],
+              contributors: %i[contributorType name givenName familyName nameType],
             },
           ],
         },

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -282,6 +282,12 @@ type Audiovisual implements DoiItem {
   relatedIdentifiers: [RelatedIdentifier!]
 
   """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
+
+  """
   The repository account managing this resource
   """
   repository: Repository
@@ -585,6 +591,12 @@ type Book implements DoiItem {
   relatedIdentifiers: [RelatedIdentifier!]
 
   """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
+
+  """
   The repository account managing this resource
   """
   repository: Repository
@@ -841,6 +853,12 @@ type BookChapter implements DoiItem {
   Identifiers of related resources. These must be globally unique identifiers
   """
   relatedIdentifiers: [RelatedIdentifier!]
+
+  """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
 
   """
   The repository account managing this resource
@@ -1231,6 +1249,12 @@ type Collection implements DoiItem {
   relatedIdentifiers: [RelatedIdentifier!]
 
   """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
+
+  """
   The repository account managing this resource
   """
   repository: Repository
@@ -1531,6 +1555,12 @@ type ConferencePaper implements DoiItem {
   Identifiers of related resources. These must be globally unique identifiers
   """
   relatedIdentifiers: [RelatedIdentifier!]
+
+  """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
 
   """
   The repository account managing this resource
@@ -2128,6 +2158,12 @@ type DataManagementPlan implements DoiItem {
   relatedIdentifiers: [RelatedIdentifier!]
 
   """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
+
+  """
   The repository account managing this resource
   """
   repository: Repository
@@ -2431,6 +2467,12 @@ type DataPaper implements DoiItem {
   relatedIdentifiers: [RelatedIdentifier!]
 
   """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
+
+  """
   The repository account managing this resource
   """
   repository: Repository
@@ -2731,6 +2773,12 @@ type Dataset implements DoiItem {
   Identifiers of related resources. These must be globally unique identifiers
   """
   relatedIdentifiers: [RelatedIdentifier!]
+
+  """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
 
   """
   The repository account managing this resource
@@ -3154,6 +3202,12 @@ type Dissertation implements DoiItem {
   relatedIdentifiers: [RelatedIdentifier!]
 
   """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
+
+  """
   The repository account managing this resource
   """
   repository: Repository
@@ -3458,6 +3512,12 @@ interface DoiItem {
   Identifiers of related resources. These must be globally unique identifiers
   """
   relatedIdentifiers: [RelatedIdentifier!]
+
+  """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
 
   """
   The repository account managing this resource
@@ -3768,6 +3828,12 @@ type Event implements DoiItem {
   relatedIdentifiers: [RelatedIdentifier!]
 
   """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
+
+  """
   The repository account managing this resource
   """
   repository: Repository
@@ -4053,6 +4119,12 @@ type EventData implements DoiItem {
   Identifiers of related resources. These must be globally unique identifiers
   """
   relatedIdentifiers: [RelatedIdentifier!]
+
+  """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
 
   """
   The repository account managing this resource
@@ -4638,6 +4710,12 @@ type Image implements DoiItem {
   relatedIdentifiers: [RelatedIdentifier!]
 
   """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
+
+  """
   The repository account managing this resource
   """
   repository: Repository
@@ -4939,6 +5017,12 @@ type Instrument implements DoiItem {
   relatedIdentifiers: [RelatedIdentifier!]
 
   """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
+
+  """
   The repository account managing this resource
   """
   repository: Repository
@@ -5238,6 +5322,12 @@ type InteractiveResource implements DoiItem {
   Identifiers of related resources. These must be globally unique identifiers
   """
   relatedIdentifiers: [RelatedIdentifier!]
+
+  """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
 
   """
   The repository account managing this resource
@@ -5565,6 +5655,12 @@ type JournalArticle implements DoiItem {
   Identifiers of related resources. These must be globally unique identifiers
   """
   relatedIdentifiers: [RelatedIdentifier!]
+
+  """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
 
   """
   The repository account managing this resource
@@ -6165,6 +6261,12 @@ type Model implements DoiItem {
   relatedIdentifiers: [RelatedIdentifier!]
 
   """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
+
+  """
   The repository account managing this resource
   """
   repository: Repository
@@ -6639,6 +6741,12 @@ type Other implements DoiItem {
   relatedIdentifiers: [RelatedIdentifier!]
 
   """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
+
+  """
   The repository account managing this resource
   """
   repository: Repository
@@ -6964,6 +7072,12 @@ type PeerReview implements DoiItem {
   Identifiers of related resources. These must be globally unique identifiers
   """
   relatedIdentifiers: [RelatedIdentifier!]
+
+  """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
 
   """
   The repository account managing this resource
@@ -7405,6 +7519,12 @@ type PhysicalObject implements DoiItem {
   relatedIdentifiers: [RelatedIdentifier!]
 
   """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
+
+  """
   The repository account managing this resource
   """
   repository: Repository
@@ -7760,6 +7880,12 @@ type Preprint implements DoiItem {
   relatedIdentifiers: [RelatedIdentifier!]
 
   """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
+
+  """
   The repository account managing this resource
   """
   repository: Repository
@@ -8062,6 +8188,12 @@ type Publication implements DoiItem {
   relatedIdentifiers: [RelatedIdentifier!]
 
   """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
+
+  """
   The repository account managing this resource
   """
   repository: Repository
@@ -8329,6 +8461,167 @@ type RelatedIdentifier {
   Resource type general
   """
   resourceTypeGeneral: String
+
+  """
+  Scheme type
+  """
+  schemeType: String
+
+  """
+  Scheme URI
+  """
+  schemeUri: String
+}
+
+"""
+Information about related items
+"""
+type RelatedItem {
+  """
+  The institutions or persons responsible for collecting, managing,
+  distributing, or otherwise contributing to the development of the resource.
+  """
+  contributors: [RelatedItemContributor!]
+
+  """
+  The institutions or persons responsible for creating the related resource
+  """
+  creators: [RelatedItemCreator!]
+
+  """
+  Edition or version of the related item
+  """
+  edition: String
+
+  """
+  First page of the related item
+  """
+  firstPage: String
+
+  """
+  Issue number or name of the related item
+  """
+  issue: String
+
+  """
+  Last page of the related item
+  """
+  lastPage: String
+
+  """
+  Number of the related item, e.g., report number of article number
+  """
+  number: String
+
+  """
+  Type of the related item's number
+  """
+  numberType: String
+
+  """
+  Publication year of the related item
+  """
+  publicationYear: String
+
+  """
+  Publisher of the related item
+  """
+  publisher: String
+
+  """
+  Related item identifier
+  """
+  relatedItemIdentifier: RelatedItemIdentifier
+
+  """
+  Related item type
+  """
+  relatedItemType: String!
+
+  """
+  Relation type
+  """
+  relationType: String!
+
+  """
+  Titles of the related item
+  """
+  titles: [Title!]!
+
+  """
+  Volume of the related item
+  """
+  volume: String
+}
+
+"""
+A contributor to a related item
+"""
+type RelatedItemContributor {
+  """
+  The type of contributor.
+  """
+  contributorType: String
+
+  """
+  Family name. In the U.S., the last name of a Person.
+  """
+  familyName: String
+
+  """
+  Given name. In the U.S., the first name of a Person.
+  """
+  givenName: String
+
+  """
+  The name of the contributor.
+  """
+  name: String!
+}
+
+"""
+A creator of a related item
+"""
+type RelatedItemCreator {
+  """
+  Family name. In the U.S., the last name of an Person.
+  """
+  familyName: String
+
+  """
+  Given name. In the U.S., the first name of a Person.
+  """
+  givenName: String
+
+  """
+  The name of the creator.
+  """
+  name: String!
+
+  """
+  The type of name.
+  """
+  nameType: String
+}
+
+"""
+Information about the related item identifier
+"""
+type RelatedItemIdentifier {
+  """
+  Related item identifier
+  """
+  relatedItemIdentifier: String!
+
+  """
+  Related item identifier type
+  """
+  relatedItemIdentifierType: String
+
+  """
+  Related metadata scheme
+  """
+  relatedMetadataScheme: String
 
   """
   Scheme type
@@ -8814,6 +9107,12 @@ type Service implements DoiItem {
   relatedIdentifiers: [RelatedIdentifier!]
 
   """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
+
+  """
   The repository account managing this resource
   """
   repository: Repository
@@ -9115,6 +9414,12 @@ type Software implements DoiItem {
   Identifiers of related resources. These must be globally unique identifiers
   """
   relatedIdentifiers: [RelatedIdentifier!]
+
+  """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
 
   """
   The repository account managing this resource
@@ -9450,6 +9755,12 @@ type Sound implements DoiItem {
   relatedIdentifiers: [RelatedIdentifier!]
 
   """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
+
+  """
   The repository account managing this resource
   """
   repository: Repository
@@ -9583,6 +9894,11 @@ type SoundEdge {
 Subject information
 """
 type Subject {
+  """
+  The classification code used for the subject term in the subject scheme
+  """
+  classificationCode: String
+
   """
   Language
   """
@@ -9958,6 +10274,12 @@ type Work implements DoiItem {
   relatedIdentifiers: [RelatedIdentifier!]
 
   """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
+
+  """
   The repository account managing this resource
   """
   repository: Repository
@@ -10264,6 +10586,12 @@ type Workflow implements DoiItem {
   Identifiers of related resources. These must be globally unique identifiers
   """
   relatedIdentifiers: [RelatedIdentifier!]
+
+  """
+  Information about a resource related to the one being registered e.g. a
+  journal or book of which the article or chapter is part.
+  """
+  relatedItems: [RelatedItem!]
 
   """
   The repository account managing this resource

--- a/app/graphql/types/doi_item.rb
+++ b/app/graphql/types/doi_item.rb
@@ -85,6 +85,11 @@ module DoiItem
         null: true,
         description:
           "Identifiers of related resources. These must be globally unique identifiers"
+  field :related_items,
+        [RelatedItemType],
+        null: true,
+        description:
+          "Information about a resource related to the one being registered e.g. a journal or book of which the article or chapter is part."
   field :types, ResourceTypeType, null: false, description: "The resource type"
   field :formats,
         [String],

--- a/app/graphql/types/related_item_contributor_type.rb
+++ b/app/graphql/types/related_item_contributor_type.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class RelatedItemContributorType < BaseObject
+  description "A contributor to a related item"
+
+  field :contributor_type,
+        String,
+        null: true,
+        hash_key: "contributorType",
+        description: "The type of contributor."
+  field :name,
+        String,
+        null: false,
+        hash_key: "contributorName"
+        description: "The name of the contributor."
+  field :given_name,
+        String,
+        null: true,
+        hash_key: "givenName",
+        description: "Given name. In the U.S., the first name of a Person."
+  field :family_name,
+        String,
+        null: true,
+        hash_key: "familyName",
+        description: "Family name. In the U.S., the last name of a Person."
+  
+  def type
+    case object.name_type
+    when "Organizational"
+      "Organization"
+    when "Personal"
+      "Person"
+    end
+  end
+end

--- a/app/graphql/types/related_item_contributor_type.rb
+++ b/app/graphql/types/related_item_contributor_type.rb
@@ -11,7 +11,7 @@ class RelatedItemContributorType < BaseObject
   field :name,
         String,
         null: false,
-        hash_key: "contributorName"
+        hash_key: "contributorName",
         description: "The name of the contributor."
   field :given_name,
         String,

--- a/app/graphql/types/related_item_contributor_type.rb
+++ b/app/graphql/types/related_item_contributor_type.rb
@@ -23,7 +23,7 @@ class RelatedItemContributorType < BaseObject
         null: true,
         hash_key: "familyName",
         description: "Family name. In the U.S., the last name of a Person."
-  
+
   def type
     case object.name_type
     when "Organizational"

--- a/app/graphql/types/related_item_creator_type.rb
+++ b/app/graphql/types/related_item_creator_type.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class RelatedItemCreatorType < BaseObject
+  description "A creator of a related item"
+
+  field :name_type,
+        String,
+        null: true,
+        hash_key: "nameType",
+        description: "The type of name."
+  field :name,
+        String,
+        null: false,
+        hash_key: "creatorName"
+        description: "The name of the creator."
+  field :given_name,
+        String,
+        null: true,
+        hash_key: "givenName",
+        description: "Given name. In the U.S., the first name of a Person."
+  field :family_name,
+        String,
+        null: true,
+        hash_key: "familyName",
+        description: "Family name. In the U.S., the last name of an Person."
+  
+  def type
+    case object.name_type
+    when "Organizational"
+      "Organization"
+    when "Personal"
+      "Person"
+    end
+  end
+end

--- a/app/graphql/types/related_item_creator_type.rb
+++ b/app/graphql/types/related_item_creator_type.rb
@@ -23,7 +23,7 @@ class RelatedItemCreatorType < BaseObject
         null: true,
         hash_key: "familyName",
         description: "Family name. In the U.S., the last name of an Person."
-  
+
   def type
     case object.name_type
     when "Organizational"

--- a/app/graphql/types/related_item_creator_type.rb
+++ b/app/graphql/types/related_item_creator_type.rb
@@ -11,7 +11,7 @@ class RelatedItemCreatorType < BaseObject
   field :name,
         String,
         null: false,
-        hash_key: "creatorName"
+        hash_key: "creatorName",
         description: "The name of the creator."
   field :given_name,
         String,

--- a/app/graphql/types/related_item_identifier_type.rb
+++ b/app/graphql/types/related_item_identifier_type.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class RelatedItemIdentifierType < BaseObject
+  description "Information about the related item identifier"
+
+  field :related_item_identifier,
+        String,
+        null: false,
+        hash_key: "relatedItemIdentifier",
+        description: "Related item identifier"
+  field :related_item_identifier_type,
+        String,
+        null: true,
+        hash_key: "relatedItemIdentifierType",
+        description: "Related item identifier type"
+  field :related_metadata_scheme,
+        String,
+        null: true,
+        hash_key: "relatedMetadataScheme",
+        description: "Related metadata scheme"
+  field :scheme_uri,
+        String,
+        null: true, hash_key: "schemeUri", description: "Scheme URI"
+  field :scheme_type,
+        String,
+        null: true, hash_key: "schemeType", description: "Scheme type"
+end

--- a/app/graphql/types/related_item_type.rb
+++ b/app/graphql/types/related_item_type.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+class RelatedItemType < BaseObject
+  description "Information about related items"
+
+  field :related_item_type,
+        String,
+        null: false,
+        hash_key: "relatedItemType",
+        description: "Related item type"
+  field :relation_type,
+        String,
+        null: false,
+        hash_key: "relationType",
+        description: "Relation type"
+  field :related_item_identifier,
+        RelatedItemIdentifierType,
+        null: true,
+        hash_key: "relatedItemIdentifier",
+        description: "Related item identifier"
+  field :creators,
+        [RelatedItemCreatorType],
+        null: true,
+        description: "The institutions or persons responsible for creating the related resource"
+  field :contributors,
+        [RelatedItemContributorType],
+        null: true,
+        description: 
+          "The institutions or persons responsible for collecting, managing, distributing, or otherwise contributing to the development of the resource."
+  field :titles,
+        [TitleType],
+        null: false,
+        description: "Titles of the related item"
+  field :volume,
+        String,
+        null: true,
+        description: "Volume of the related item"
+  field :issue,
+        String,
+        null: true,
+        description: "Issue number or name of the related item"
+  field :number,
+        String,
+        null: true,
+        description: "Number of the related item, e.g., report number of article number"
+  field :number_type,
+        String,
+        null: true,
+        hash_key: "numberType",
+        description: "Type of the related item's number"
+  field :first_page,
+        String,
+        null: true,
+        hash_key: "firstPage",
+        description: "First page of the related item"
+  field :last_page,
+        String,
+        null: true,
+        hash_key: "lastPage",
+        description: "Last page of the related item"
+  field :publisher,
+        String,
+        null: true,
+        description: "Publisher of the related item"
+  field :publication_year,
+        String,
+        null: true,
+        hash_key: "publicationYear",
+        description: "Publication year of the related item"
+  field :edition,
+        String,
+        null: true,
+        description: "Edition or version of the related item"
+end

--- a/app/graphql/types/related_item_type.rb
+++ b/app/graphql/types/related_item_type.rb
@@ -25,7 +25,7 @@ class RelatedItemType < BaseObject
   field :contributors,
         [RelatedItemContributorType],
         null: true,
-        description: 
+        description:
           "The institutions or persons responsible for collecting, managing, distributing, or otherwise contributing to the development of the resource."
   field :titles,
         [TitleType],

--- a/app/graphql/types/subject_type.rb
+++ b/app/graphql/types/subject_type.rb
@@ -24,5 +24,10 @@ class SubjectType < BaseObject
         null: true,
         hash_key: "valueUri",
         description: "The URI of the subject term"
+  field :classification_code,
+        String,
+        null: true,
+        hash_key: "classificationCode",
+        description: "The classification code used for the subject term in the subject scheme"
   field :lang, ID, null: true, description: "Language"
 end

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -1651,6 +1651,11 @@ class Doi < ApplicationRecord
     write_attribute(:related_identifiers, Array.wrap(value))
   end
 
+  def related_items=(value)
+    write_attribute(:related_items, Array.wrap(value))
+  end
+
+
   def funding_references=(value)
     write_attribute(:funding_references, Array.wrap(value))
   end

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -282,6 +282,7 @@ class Doi < ApplicationRecord
         contributors: { type: :object, properties: {
           contributorType: { type: :text },
           contributorName: { type: :text },
+          nameType: { type: :text},
           givenName: { type: :text },
           familyName: { type: :text },
         } },

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -850,6 +850,7 @@ class Doi < ApplicationRecord
     if query.present?
       query = query.gsub(/publicationYear/, "publication_year")
       query = query.gsub(/relatedIdentifiers/, "related_identifiers")
+      query = query.gsub(/relatedItems/, "related_items")
       query = query.gsub(/rightsList/, "rights_list")
       query = query.gsub(/fundingReferences/, "funding_references")
       query = query.gsub(/geoLocations/, "geo_locations")
@@ -1047,6 +1048,7 @@ class Doi < ApplicationRecord
     if query.present?
       query = query.gsub(/publicationYear/, "publication_year")
       query = query.gsub(/relatedIdentifiers/, "related_identifiers")
+      query = query.gsub(/relatedItems/, "related_items")
       query = query.gsub(/rightsList/, "rights_list")
       query = query.gsub(/fundingReferences/, "funding_references")
       query = query.gsub(/geoLocations/, "geo_locations")

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -282,7 +282,7 @@ class Doi < ApplicationRecord
         contributors: { type: :object, properties: {
           contributorType: { type: :text },
           contributorName: { type: :text },
-          nameType: { type: :text},
+          nameType: { type: :text },
           givenName: { type: :text },
           familyName: { type: :text },
         } },

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -648,6 +648,7 @@ class Event < ApplicationRecord
         dates
         identifiers
         related_identifiers
+        related_items
         funding_references
         geo_locations
         rights_list

--- a/app/serializers/datacite_doi_serializer.rb
+++ b/app/serializers/datacite_doi_serializer.rb
@@ -24,6 +24,7 @@ class DataciteDoiSerializer
              :language,
              :types,
              :related_identifiers,
+             :related_items,
              :sizes,
              :formats,
              :version,
@@ -188,6 +189,10 @@ class DataciteDoiSerializer
                 params && params[:composite].blank?
               } do |object|
     Array.wrap(object.related_identifiers)
+  end
+
+  attribute :related_items do |object|
+    Array.wrap(object.related_items)
   end
 
   attribute :geo_locations,

--- a/app/serializers/work_serializer.rb
+++ b/app/serializers/work_serializer.rb
@@ -23,6 +23,7 @@ class WorkSerializer
              :schema_version,
              :results,
              :related_identifiers,
+             :related_items,
              :citation_count,
              :citations_over_time,
              :view_count,
@@ -96,6 +97,10 @@ class WorkSerializer
   end
 
   attribute :related_identifiers do |_object|
+    []
+  end
+
+  attribute :related_items do |_object|
     []
   end
 

--- a/app/validators/xml_schema_validator.rb
+++ b/app/validators/xml_schema_validator.rb
@@ -8,6 +8,7 @@ class XmlSchemaValidator < ActiveModel::EachValidator
       "publicationYear" => "publication_year",
       "alternateIdentifiers" => "identifiers",
       "relatedIdentifiers" => "related_identifiers",
+      "relatedItems" => "related_items",
       "geoLocations" => "geo_locations",
       "rightsList" => "rights_list",
       "fundingReferences" => "funding_references",

--- a/spec/fixtures/files/datacite-example-relateditems.xml
+++ b/spec/fixtures/files/datacite-example-relateditems.xml
@@ -51,7 +51,7 @@
       <edition>1</edition>
       <contributors>
         <contributor contributorType="ProjectLeader">
-            <contributorName>Richard, Hallett</contributorName>
+            <contributorName nameType="Personal">Richard, Hallett</contributorName>
             <givenName>Richard</givenName>
             <familyName>Hallett</familyName>
         </contributor>

--- a/spec/models/resource_type_spec.rb
+++ b/spec/models/resource_type_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe ResourceType, type: :model do
   describe "from new object" do
-    let(:rt) { ResourceType.new({ 'id' => "BookChapter", 'title' => "BookChapter" }) }
+    let(:rt) { ResourceType.new({ "id" => "BookChapter", "title" => "BookChapter" }) }
 
     describe "attributes" do
       it "formats the id attribute correctly" do
@@ -54,19 +54,19 @@ RSpec.describe ResourceType, type: :model do
     describe "#parse_data" do
       # let(:rt) { ResourceType.parse_data(ResourceType.get_data(), options={ :id => "dissertation" }) }
       it "finds an item by id" do
-        rt = ResourceType.parse_data(ResourceType.get_data(), options={ :id => "dissertation" })
+        rt = ResourceType.parse_data(ResourceType.get_data(), { id: "dissertation" })
         expect(rt[:data]).to be_instance_of ResourceType
         expect(rt[:data].id).to eq("dissertation")
         expect(rt[:data].title).to eq("Dissertation")
       end
 
       it "returns nil for a non-existent resource type" do
-        rt = ResourceType.parse_data(ResourceType.get_data(), options={ :id => "fake-resource" })
+        rt = ResourceType.parse_data(ResourceType.get_data(), { id: "fake-resource" })
         expect(rt).to be_nil
       end
-      
+
       it "finds a single item by id query" do
-        rt = ResourceType.parse_data(ResourceType.get_data(), options={ :query => "softw" })
+        rt = ResourceType.parse_data(ResourceType.get_data(), { query: "softw" })
         expect(rt[:data][0]).to be_instance_of ResourceType
         expect(rt[:data][0].id).to eq("software")
         expect(rt[:data][0].title).to eq("Software")
@@ -74,7 +74,7 @@ RSpec.describe ResourceType, type: :model do
       end
 
       it "finds a single item by description query" do
-        rt = ResourceType.parse_data(ResourceType.get_data(), options={ :query => "managementplan" })
+        rt = ResourceType.parse_data(ResourceType.get_data(), { query: "managementplan" })
         expect(rt[:data][0]).to be_instance_of ResourceType
         expect(rt[:data][0].id).to eq("output-management-plan")
         expect(rt[:data][0].title).to eq("OutputManagementPlan")
@@ -82,7 +82,7 @@ RSpec.describe ResourceType, type: :model do
       end
 
       it "finds all items matching a query" do
-        rt = ResourceType.parse_data(ResourceType.get_data(), options={ :query => "conference" })
+        rt = ResourceType.parse_data(ResourceType.get_data(), { query: "conference" })
         expect(rt[:data][0]).to be_instance_of ResourceType
         expect(rt[:data][0].id).to eq("conference-paper")
         expect(rt[:data][0].title).to eq("ConferencePaper")
@@ -93,20 +93,19 @@ RSpec.describe ResourceType, type: :model do
       end
 
       it "returns empty results for a non-matching query" do
-        rt = ResourceType.parse_data(ResourceType.get_data(), options={ :query => "fake-resource" })
+        rt = ResourceType.parse_data(ResourceType.get_data(), { query: "fake-resource" })
         expect(rt[:meta]).to eq({ :total => 0, "total-pages" => 0, :page => 1 })
       end
 
       it "returns multiple pages when necessary" do
-        rt = ResourceType.parse_data(ResourceType.get_data(), options={ :query => "a", :page => { :size => 5 } })
+        rt = ResourceType.parse_data(ResourceType.get_data(), { query: "a", page: { size: 5 } })
         expect(rt[:meta]).to include("total-pages" => (a_value > 1), :page => 1)
       end
 
       it "pages past the first page of results" do
-        rt = ResourceType.parse_data(ResourceType.get_data(), options={ :query => "a", :page => { :size => 5, :number => 2 } })
+        rt = ResourceType.parse_data(ResourceType.get_data(), { query: "a", page: { size: 5, number: 2 } })
         expect(rt[:meta]).to include("total-pages" => (a_value > 1), :page => 2)
       end
     end
   end
 end
-

--- a/spec/models/resource_type_spec.rb
+++ b/spec/models/resource_type_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ResourceType, type: :model do
+  describe "from new object" do
+    let(:rt) { ResourceType.new({ 'id' => "BookChapter", 'title' => "BookChapter" }) }
+
+    describe "attributes" do
+      it "formats the id attribute correctly" do
+        expect(rt.id).to eq("book-chapter")
+      end
+
+      it "has a correct title attribute" do
+        expect(rt.title).to eq("BookChapter")
+      end
+    end
+  end
+
+  describe "class methods" do
+    describe "#get_data" do
+      it "has expected entries" do
+        expect(ResourceType.get_data()).to include({ "id" => "audiovisual", "title" => "Audiovisual" },
+          { "id" => "book", "title" => "Book" },
+          { "id" => "book-chapter", "title" => "BookChapter" },
+          { "id" => "collection", "title" => "Collection" },
+          { "id" => "computational-notebook", "title" => "ComputationalNotebook" },
+          { "id" => "conference-paper", "title" => "ConferencePaper" },
+          { "id" => "conference-proceeding", "title" => "ConferenceProceeding" },
+          { "id" => "data-paper", "title" => "DataPaper" },
+          { "id" => "dataset", "title" => "Dataset" },
+          { "id" => "dissertation", "title" => "Dissertation" },
+          { "id" => "event", "title" => "Event" },
+          { "id" => "image", "title" => "Image" },
+          { "id" => "interactive-resource", "title" => "InteractiveResource" },
+          { "id" => "journal", "title" => "Journal" },
+          { "id" => "journal-article", "title" => "JournalArticle" },
+          { "id" => "model", "title" => "Model" },
+          { "id" => "output-management-plan", "title" => "OutputManagementPlan" },
+          { "id" => "peer-review", "title" => "PeerReview" },
+          { "id" => "physical-object", "title" => "PhysicalObject" },
+          { "id" => "preprint", "title" => "Preprint" },
+          { "id" => "report", "title" => "Report" },
+          { "id" => "service", "title" => "Service" },
+          { "id" => "software", "title" => "Software" },
+          { "id" => "sound", "title" => "Sound" },
+          { "id" => "standard", "title" => "Standard" },
+          { "id" => "text", "title" => "Text" },
+          { "id" => "workflow", "title" => "Workflow" },
+          { "id" => "other", "title" => "Other" })
+      end
+    end
+
+    describe "#parse_data" do
+      # let(:rt) { ResourceType.parse_data(ResourceType.get_data(), options={ :id => "dissertation" }) }
+      it "finds an item by id" do
+        rt = ResourceType.parse_data(ResourceType.get_data(), options={ :id => "dissertation" })
+        expect(rt[:data]).to be_instance_of ResourceType
+        expect(rt[:data].id).to eq("dissertation")
+        expect(rt[:data].title).to eq("Dissertation")
+      end
+
+      it "returns nil for a non-existent resource type" do
+        rt = ResourceType.parse_data(ResourceType.get_data(), options={ :id => "fake-resource" })
+        expect(rt).to be_nil
+      end
+      
+      it "finds a single item by id query" do
+        rt = ResourceType.parse_data(ResourceType.get_data(), options={ :query => "softw" })
+        expect(rt[:data][0]).to be_instance_of ResourceType
+        expect(rt[:data][0].id).to eq("software")
+        expect(rt[:data][0].title).to eq("Software")
+        expect(rt[:meta]).to eq({ :total => 1, "total-pages" => 1, :page => 1 })
+      end
+
+      it "finds a single item by description query" do
+        rt = ResourceType.parse_data(ResourceType.get_data(), options={ :query => "managementplan" })
+        expect(rt[:data][0]).to be_instance_of ResourceType
+        expect(rt[:data][0].id).to eq("output-management-plan")
+        expect(rt[:data][0].title).to eq("OutputManagementPlan")
+        expect(rt[:meta]).to eq({ :total => 1, "total-pages" => 1, :page => 1 })
+      end
+
+      it "finds all items matching a query" do
+        rt = ResourceType.parse_data(ResourceType.get_data(), options={ :query => "conference" })
+        expect(rt[:data][0]).to be_instance_of ResourceType
+        expect(rt[:data][0].id).to eq("conference-paper")
+        expect(rt[:data][0].title).to eq("ConferencePaper")
+        expect(rt[:data][1]).to be_instance_of ResourceType
+        expect(rt[:data][1].id).to eq("conference-proceeding")
+        expect(rt[:data][1].title).to eq("ConferenceProceeding")
+        expect(rt[:meta]).to eq({ :total => 2, "total-pages" => 1, :page => 1 })
+      end
+
+      it "returns empty results for a non-matching query" do
+        rt = ResourceType.parse_data(ResourceType.get_data(), options={ :query => "fake-resource" })
+        expect(rt[:meta]).to eq({ :total => 0, "total-pages" => 0, :page => 1 })
+      end
+
+      it "returns multiple pages when necessary" do
+        rt = ResourceType.parse_data(ResourceType.get_data(), options={ :query => "a", :page => { :size => 5 } })
+        expect(rt[:meta]).to include("total-pages" => (a_value > 1), :page => 1)
+      end
+
+      it "pages past the first page of results" do
+        rt = ResourceType.parse_data(ResourceType.get_data(), options={ :query => "a", :page => { :size => 5, :number => 2 } })
+        expect(rt[:meta]).to include("total-pages" => (a_value > 1), :page => 2)
+      end
+    end
+  end
+end
+

--- a/spec/requests/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois_spec.rb
@@ -1747,7 +1747,8 @@ describe DataciteDoisController, type: :request, vcr: true do
               "subjects" => [{ "subject" => "80505 Web Technologies (excl. Web Search)",
                                "schemeUri" => "http://www.abs.gov.au/ausstats/abs@.nsf/0/6BB427AB9696C225CA2574180004463E",
                                "subjectScheme" => "FOR",
-                               "lang" => "en" }],
+                               "lang" => "en",
+                               "classificationCode" => "080505" }],
               "contributors" => [{ "contributorType" => "DataManager", "familyName" => "Fenner", "givenName" => "Kurt", "nameIdentifiers" => [{ "nameIdentifier" => "https://orcid.org/0000-0003-1419-2401", "nameIdentifierScheme" => "ORCID", "schemeUri" => "https://orcid.org" }], "name" => "Fenner, Kurt", "nameType" => "Personal" }],
               "dates" => [{ "date" => "2017-02-24", "dateType" => "Issued" }, { "date" => "2015-11-28", "dateType" => "Created" }, { "date" => "2017-02-24", "dateType" => "Updated" }],
               "relatedIdentifiers" => [{ "relatedIdentifier" => "10.5438/55e5-t5c0", "relatedIdentifierType" => "DOI", "relationType" => "References" }],
@@ -1786,7 +1787,8 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(json.dig("data", "attributes", "subjects")).to eq([{ "lang" => "en",
                                                                     "subject" => "80505 Web Technologies (excl. Web Search)",
                                                                     "schemeUri" => "http://www.abs.gov.au/ausstats/abs@.nsf/0/6BB427AB9696C225CA2574180004463E",
-                                                                    "subjectScheme" => "FOR" },
+                                                                    "subjectScheme" => "FOR",
+                                                                    "classificationCode" => "080505" },
                                                                   { "schemeUri" => "http://www.oecd.org/science/inno/38235147.pdf",
                                                                     "subject" => "FOS: Computer and information sciences",
                                                                     "subjectScheme" => "Fields of Science and Technology (FOS)" }
@@ -2150,6 +2152,9 @@ describe DataciteDoisController, type: :request, vcr: true do
         post "/dois", params, headers
 
         expect(last_response.status).to eq(201)
+        expect(json.dig("data", "attributes", "subjects")[2]).to eq("subject" => "metadata",
+                                                                   "classificationCode" => "000")
+
         xml = Maremma.from_xml(Base64.decode64(json.dig("data", "attributes", "xml"))).fetch("resource", {})
 
         expect(xml.dig("subjects", "subject")).to eq(

--- a/spec/requests/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois_spec.rb
@@ -1844,8 +1844,31 @@ describe DataciteDoisController, type: :request, vcr: true do
               "fundingReferences" => [{ "funderIdentifier" => "https://doi.org/10.13039/501100009053", "funderIdentifierType" => "Crossref Funder ID", "funderName" => "The Wellcome Trust DBT India Alliance" }],
               "source" => "test",
               "event" => "publish",
-              "relatedItems" => ["relationType" => "IsPublishedIn", "relatedItemType" => "Journal", "relatedItemIdentifier" => {"relatedItemIdentifier" => "10.5072/john-smiths-1234", "relatedItemIdentifierType" => "DOI", "relatedMetadataScheme" => "citeproc+json", "schemeURI" => "https://github.com/citation-style-language/schema/raw/master/csl-data.json", "schemeType" => "URL"}
-              ]
+              "relatedItems" => [{
+                "contributors" => [{ "name" => "Smithson, James",
+                                     "contributorType" => "ProjectLeader",
+                                     "givenName" => "James",
+                                     "familyName" => "Smithson",
+                                    }],
+                "creators" => [{ "name" => "Smith, John",
+                                 "nameType" => "Personal",
+                                 "givenName" => "John",
+                                 "familyName" => "Smith",
+                                }],
+                "firstPage" => "249",
+                "lastPage" => "264",
+                "publicationYear" => "2018",
+                "relatedItemIdentifier" => { "relatedItemIdentifier" => "10.1016/j.physletb.2017.11.044",
+                                             "relatedItemIdentifierType" => "DOI",
+                                             "relatedMetadataScheme" => "citeproc+json",
+                                             "schemeURI" => "https://github.com/citation-style-language/schema/raw/master/csl-data.json",
+                                             "schemeType" => "URL"
+                                            },
+                "relatedItemType" => "Journal",
+                "relationType" => "IsPublishedIn",
+                "titles" => [{ "title" => "Physics letters / B" }],
+                "volume" => "776"
+              }],
             },
           },
         }
@@ -1873,7 +1896,31 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(json.dig("data", "attributes", "source")).to eq("test")
         expect(json.dig("data", "attributes", "types")).to eq("bibtex" => "article", "citeproc" => "article-journal", "resourceType" => "BlogPosting", "resourceTypeGeneral" => "Text", "ris" => "RPRT", "schemaOrg" => "ScholarlyArticle")
         expect(json.dig("data", "attributes", "state")).to eq("findable")
-        expect(json.dig("data", "attributes", "relatedItems")).to eq(["relationType" => "IsPublishedIn", "relatedItemType" => "Journal", "relatedItemIdentifier" => {"relatedItemIdentifier" => "10.5072/john-smiths-1234", "relatedItemIdentifierType" => "DOI", "relatedMetadataScheme" => "citeproc+json", "schemeURI" => "https://github.com/citation-style-language/schema/raw/master/csl-data.json", "schemeType" => "URL"}])
+        expect(json.dig("data", "attributes", "relatedItems")).to eq(["relationType" => "IsPublishedIn",
+                                                                      "relatedItemType" => "Journal",
+                                                                      "publicationYear" => "2018",
+                                                                      "relatedItemIdentifier" => {
+                                                                                                   "relatedItemIdentifier" => "10.1016/j.physletb.2017.11.044",
+                                                                                                   "relatedItemIdentifierType" => "DOI",
+                                                                                                   "relatedMetadataScheme" => "citeproc+json",
+                                                                                                   "schemeURI" => "https://github.com/citation-style-language/schema/raw/master/csl-data.json",
+                                                                                                   "schemeType" => "URL"
+                                                                                                  },
+                                                                      "contributors" => [{ "name" => "Smithson, James",
+                                                                                           "contributorType" => "ProjectLeader",
+                                                                                           "givenName" => "James",
+                                                                                           "familyName" => "Smithson",
+                                                                                          }],
+                                                                      "creators" => [{ "name" => "Smith, John",
+                                                                                       "nameType" => "Personal",
+                                                                                       "givenName" => "John",
+                                                                                       "familyName" => "Smith",
+                                                                                      }],
+                                                                      "firstPage" => "249",
+                                                                      "lastPage" => "264",
+                                                                      "titles" => [{ "title" => "Physics letters / B" }],
+                                                                      "volume" => "776"
+                                                                      ])
 
         doc = Nokogiri::XML(Base64.decode64(json.dig("data", "attributes", "xml")), nil, "UTF-8", &:noblanks)
         expect(doc.at_css("identifier").content).to eq("10.14454/10703")
@@ -2078,13 +2125,54 @@ describe DataciteDoisController, type: :request, vcr: true do
 
         expect(last_response.status).to eq(201)
 
-        expect(json.dig("data", "attributes", "relatedItems")).to eq(["relationType" => "IsPublishedIn",
+        expect(json.dig("data", "attributes", "relatedItems")).to eq([{ "relationType" => "IsPublishedIn",
                                                                         "relatedItemType" => "Journal",
-                                                                        "relatedItemIdentifier" => {"relatedItemIdentifier" => "10.5072/john-smiths-1234",
+                                                                        "relatedItemIdentifier" => { "relatedItemIdentifier" => "10.5072/john-smiths-1234",
                                                                                                     "relatedItemIdentifierType" => "DOI",
                                                                                                     "relatedMetadataScheme" => "citeproc+json",
                                                                                                     "schemeURI" => "https://github.com/citation-style-language/schema/raw/master/csl-data.json",
-                                                                                                    "schemeType" => "URL"}
+                                                                                                    "schemeType" => "URL" },
+                                                                        "creators" => [
+                                                                          {
+                                                                            "nameType" => "Personal",
+                                                                            "name" => "Smith, John",
+                                                                            "givenName" => "John",
+                                                                            "familyName" => "Smith"
+                                                                          }
+                                                                        ],
+                                                                        "titles" => [
+                                                                            { "title" => "Understanding the fictional John Smith" },
+                                                                            { "titleType" => "Subtitle", "title" => "A detailed look" }
+                                                                        ],
+                                                                        "publicationYear" => "1776",
+                                                                        "volume" => "776",
+                                                                        "issue" => "1",
+                                                                        "number" => "1",
+                                                                        "numberType" => "Chapter",
+                                                                        "firstPage" => "50",
+                                                                        "lastPage" => "60",
+                                                                        "publisher" => "Example Inc",
+                                                                        "edition" => "1",
+                                                                        "contributors" => [
+                                                                            "contributorType" => "ProjectLeader",
+                                                                            "name" => "Hallett, Richard",
+                                                                            "givenName" => "Richard",
+                                                                            "familyName" => "Hallett"
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "contributors" => [],
+                                                                        "creators" => [],
+                                                                        "firstPage" => "249",
+                                                                        "lastPage" => "264",
+                                                                        "publicationYear" => "2018",
+                                                                        "relatedItemIdentifier" => { "relatedItemIdentifier" => "10.1016/j.physletb.2017.11.044",
+                                                                                                     "relatedItemIdentifierType" => "DOI" },
+                                                                        "relatedItemType" => "Journal",
+                                                                        "relationType" => "IsPublishedIn",
+                                                                        "titles" => [{ "title" => "Physics letters / B" } ],
+                                                                        "volume" => "776"
+                                                                      }
                                                                       ])
         xml = Maremma.from_xml(Base64.decode64(json.dig("data", "attributes", "xml"))).fetch("resource", {})
 

--- a/spec/requests/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois_spec.rb
@@ -1849,6 +1849,7 @@ describe DataciteDoisController, type: :request, vcr: true do
                                      "contributorType" => "ProjectLeader",
                                      "givenName" => "James",
                                      "familyName" => "Smithson",
+                                     "nameType" => "Personal"
                                     }],
                 "creators" => [{ "name" => "Smith, John",
                                  "nameType" => "Personal",
@@ -1910,6 +1911,7 @@ describe DataciteDoisController, type: :request, vcr: true do
                                                                                            "contributorType" => "ProjectLeader",
                                                                                            "givenName" => "James",
                                                                                            "familyName" => "Smithson",
+                                                                                           "nameType" => "Personal"
                                                                                           }],
                                                                       "creators" => [{ "name" => "Smith, John",
                                                                                        "nameType" => "Personal",
@@ -2157,7 +2159,8 @@ describe DataciteDoisController, type: :request, vcr: true do
                                                                             "contributorType" => "ProjectLeader",
                                                                             "name" => "Hallett, Richard",
                                                                             "givenName" => "Richard",
-                                                                            "familyName" => "Hallett"
+                                                                            "familyName" => "Hallett",
+                                                                            "nameType" => "Personal"
                                                                         ]
                                                                       },
                                                                       {
@@ -2211,7 +2214,7 @@ describe DataciteDoisController, type: :request, vcr: true do
             "contributors" => {
               "contributor" => {
                 "contributorType" => "ProjectLeader",
-                "contributorName" => "Richard, Hallett",
+                "contributorName" => { "nameType" => "Personal", "__content__" => "Richard, Hallett" },
                 "givenName" => "Richard",
                 "familyName" => "Hallett"
               }

--- a/spec/requests/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois_spec.rb
@@ -1844,6 +1844,8 @@ describe DataciteDoisController, type: :request, vcr: true do
               "fundingReferences" => [{ "funderIdentifier" => "https://doi.org/10.13039/501100009053", "funderIdentifierType" => "Crossref Funder ID", "funderName" => "The Wellcome Trust DBT India Alliance" }],
               "source" => "test",
               "event" => "publish",
+              "relatedItems" => ["relationType" => "IsPublishedIn", "relatedItemType" => "Journal", "relatedItemIdentifier" => {"relatedItemIdentifier" => "10.5072/john-smiths-1234", "relatedItemIdentifierType" => "DOI", "relatedMetadataScheme" => "citeproc+json", "schemeURI" => "https://github.com/citation-style-language/schema/raw/master/csl-data.json", "schemeType" => "URL"}
+              ]
             },
           },
         }
@@ -1871,6 +1873,7 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(json.dig("data", "attributes", "source")).to eq("test")
         expect(json.dig("data", "attributes", "types")).to eq("bibtex" => "article", "citeproc" => "article-journal", "resourceType" => "BlogPosting", "resourceTypeGeneral" => "Text", "ris" => "RPRT", "schemaOrg" => "ScholarlyArticle")
         expect(json.dig("data", "attributes", "state")).to eq("findable")
+        expect(json.dig("data", "attributes", "relatedItems")).to eq(["relationType" => "IsPublishedIn", "relatedItemType" => "Journal", "relatedItemIdentifier" => {"relatedItemIdentifier" => "10.5072/john-smiths-1234", "relatedItemIdentifierType" => "DOI", "relatedMetadataScheme" => "citeproc+json", "schemeURI" => "https://github.com/citation-style-language/schema/raw/master/csl-data.json", "schemeType" => "URL"}])
 
         doc = Nokogiri::XML(Base64.decode64(json.dig("data", "attributes", "xml")), nil, "UTF-8", &:noblanks)
         expect(doc.at_css("identifier").content).to eq("10.14454/10703")
@@ -2074,6 +2077,15 @@ describe DataciteDoisController, type: :request, vcr: true do
         post "/dois", params, headers
 
         expect(last_response.status).to eq(201)
+
+        expect(json.dig("data", "attributes", "relatedItems")).to eq(["relationType" => "IsPublishedIn",
+                                                                        "relatedItemType" => "Journal",
+                                                                        "relatedItemIdentifier" => {"relatedItemIdentifier" => "10.5072/john-smiths-1234",
+                                                                                                    "relatedItemIdentifierType" => "DOI",
+                                                                                                    "relatedMetadataScheme" => "citeproc+json",
+                                                                                                    "schemeURI" => "https://github.com/citation-style-language/schema/raw/master/csl-data.json",
+                                                                                                    "schemeType" => "URL"}
+                                                                      ])
         xml = Maremma.from_xml(Base64.decode64(json.dig("data", "attributes", "xml"))).fetch("resource", {})
 
         expect(xml.dig("relatedItems", "relatedItem")).to eq(


### PR DESCRIPTION
## Purpose
This PR adds support for the remaining Metadata Schema v4.4 changes to the REST API and the GraphQL service

- Support for `classificationCode` sub-property when supplied via JSON
- Support for `relationType` sub-property
- Support for `relatedItems` property and all sub-properties

## Approach
- Tests for ClassificationCode (https://github.com/datacite/datacite/issues/1408)
- Add ClassificationCode to GraphQL (https://github.com/datacite/datacite/issues/1409)
- Allow related items to be passed as JSON as well as in the XML blob (https://github.com/datacite/datacite/issues/1397)
- Serialize related items in the JSON output (https://github.com/datacite/datacite/issues/1399)
- Tests for related items (https://github.com/datacite/datacite/issues/1400)
- Add related items to GraphQL (https://github.com/datacite/datacite/issues/1398)
- Add related items to the XML validator (https://github.com/datacite/lupo/commit/7ead2eb50ff3b13500177c1511cbd04cbebec293)
- Add tests for the Resource Type Model (https://github.com/datacite/datacite/issues/1407)


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
