### PR TITLE
support queries for data management plans

### DIFF
--- a/app/graphql/types/funder_type.rb
+++ b/app/graphql/types/funder_type.rb
@@ -201,8 +201,7 @@ class FunderType < BaseObject
   end
 
   def data_management_plans(**args)
-    args[:resource_type_id] = "Text"
-    args[:resource_type] = "Data Management Plan"
+    args[:resource_type_id] = "OutputManagementPlan"
     ElasticsearchModelResponseConnection.new(
       response(args),
       context: context, first: args[:first], after: args[:after],

--- a/app/graphql/types/member_type.rb
+++ b/app/graphql/types/member_type.rb
@@ -250,8 +250,7 @@ class MemberType < BaseObject
   end
 
   def data_management_plans(**args)
-    args[:resource_type_id] = "Text"
-    args[:resource_type] = "Data Management Plan"
+    args[:resource_type_id] = "OutputManagementPlan"
     ElasticsearchModelResponseConnection.new(
       response(args),
       context: context, first: args[:first], after: args[:after],

--- a/app/graphql/types/organization_type.rb
+++ b/app/graphql/types/organization_type.rb
@@ -293,8 +293,8 @@ class OrganizationType < BaseObject
   end
 
   def data_management_plans(**args)
-    args[:resource_type_id] = "Text"
-    args[:resource_type] = "Data Management Plan"
+    args[:resource_type_id] = "OutputManagementPlan"
+
     ElasticsearchModelResponseConnection.new(
       response(args),
       context: context, first: args[:first], after: args[:after],

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -874,8 +874,7 @@ class QueryType < BaseObject
   end
 
   def data_management_plans(**args)
-    args[:resource_type_id] = "Text"
-    args[:resource_type] = "Data Management Plan"
+    args[:resource_type_id] = "OutputManagementPlan"
     ElasticsearchModelResponseConnection.new(response(args), context: context, first: args[:first], after: args[:after])
   end
 

--- a/app/graphql/types/repository_type.rb
+++ b/app/graphql/types/repository_type.rb
@@ -243,8 +243,8 @@ class RepositoryType < BaseObject
   end
 
   def data_management_plans(**args)
-    args[:resource_type_id] = "Text"
-    args[:resource_type] = "Data Management Plan"
+    args[:resource_type_id] = "OutputManagementPlan"
+
     ElasticsearchModelResponseConnection.new(
       response(args),
       context: context, first: args[:first], after: args[:after],

--- a/spec/graphql/types/data_management_plan_type_spec.rb
+++ b/spec/graphql/types/data_management_plan_type_spec.rb
@@ -198,6 +198,7 @@ describe DataManagementPlanType do
           "types",
         ),
       ).to eq(
+        "resourceType"=>nil,
         "resourceTypeGeneral" => "OutputManagementPlan",
         "schemaOrg" => "CreativeWork",
       )
@@ -330,6 +331,7 @@ describe DataManagementPlanType do
           "types",
         ),
       ).to eq(
+        "resourceType"=>nil,
         "resourceTypeGeneral" => "OutputManagementPlan",
         "schemaOrg" => "CreativeWork",
       )

--- a/spec/graphql/types/data_management_plan_type_spec.rb
+++ b/spec/graphql/types/data_management_plan_type_spec.rb
@@ -91,7 +91,7 @@ describe DataManagementPlanType do
         :doi,
         2,
         types: {
-          "resourceTypeGeneral" => "OutputManagementPlan",
+          "resourceTypeGeneral" => "OutputManagementPlan"
         },
         language: "de",
         aasm_state: "findable",
@@ -199,7 +199,7 @@ describe DataManagementPlanType do
         ),
       ).to eq(
         "resourceTypeGeneral" => "OutputManagementPlan",
-        "schemaOrg" => "ScholarlyArticle",
+        "schemaOrg" => "CreativeWork",
       )
     end
   end
@@ -331,7 +331,7 @@ describe DataManagementPlanType do
         ),
       ).to eq(
         "resourceTypeGeneral" => "OutputManagementPlan",
-        "schemaOrg" => "ScholarlyArticle",
+        "schemaOrg" => "CreativeWork",
       )
       expect(
         response.dig(

--- a/spec/graphql/types/data_management_plan_type_spec.rb
+++ b/spec/graphql/types/data_management_plan_type_spec.rb
@@ -198,7 +198,7 @@ describe DataManagementPlanType do
           "types",
         ),
       ).to eq(
-        "resourceType"=>nil,
+        "resourceType" => nil,
         "resourceTypeGeneral" => "OutputManagementPlan",
         "schemaOrg" => "CreativeWork",
       )
@@ -331,7 +331,7 @@ describe DataManagementPlanType do
           "types",
         ),
       ).to eq(
-        "resourceType"=>nil,
+        "resourceType" => nil,
         "resourceTypeGeneral" => "OutputManagementPlan",
         "schemaOrg" => "CreativeWork",
       )

--- a/spec/graphql/types/data_management_plan_type_spec.rb
+++ b/spec/graphql/types/data_management_plan_type_spec.rb
@@ -16,8 +16,7 @@ describe DataManagementPlanType do
         :doi,
         2,
         types: {
-          "resourceTypeGeneral" => "Text",
-          "resourceType" => "Data Management Plan",
+          "resourceTypeGeneral" => "OutputManagementPlan",
         },
         language: "de",
         aasm_state: "findable",
@@ -92,8 +91,7 @@ describe DataManagementPlanType do
         :doi,
         2,
         types: {
-          "resourceTypeGeneral" => "Text",
-          "resourceType" => "Data Management Plan",
+          "resourceTypeGeneral" => "OutputManagementPlan",
         },
         language: "de",
         aasm_state: "findable",
@@ -200,8 +198,7 @@ describe DataManagementPlanType do
           "types",
         ),
       ).to eq(
-        "resourceType" => "Data Management Plan",
-        "resourceTypeGeneral" => "Text",
+        "resourceTypeGeneral" => "OutputManagementPlan",
         "schemaOrg" => "ScholarlyArticle",
       )
     end
@@ -214,8 +211,7 @@ describe DataManagementPlanType do
         :doi,
         2,
         types: {
-          "resourceTypeGeneral" => "Text",
-          "resourceType" => "Data Management Plan",
+          "resourceTypeGeneral" => "OutputManagementPlan",
         },
         language: "de",
         aasm_state: "findable",
@@ -334,8 +330,7 @@ describe DataManagementPlanType do
           "types",
         ),
       ).to eq(
-        "resourceType" => "Data Management Plan",
-        "resourceTypeGeneral" => "Text",
+        "resourceTypeGeneral" => "OutputManagementPlan",
         "schemaOrg" => "ScholarlyArticle",
       )
       expect(
@@ -365,8 +360,7 @@ describe DataManagementPlanType do
         :doi,
         2,
         types: {
-          "resourceTypeGeneral" => "Text",
-          "resourceType" => "Data Management Plan",
+          "resourceTypeGeneral" => "OutputManagementPlan",
         },
         language: "de",
         aasm_state: "findable",
@@ -461,8 +455,7 @@ describe DataManagementPlanType do
         :doi,
         2,
         types: {
-          "resourceTypeGeneral" => "Text",
-          "resourceType" => "Data Management Plan",
+          "resourceTypeGeneral" => "OutputManagementPlan",
         },
         language: "de",
         aasm_state: "findable",
@@ -545,8 +538,7 @@ describe DataManagementPlanType do
         :doi,
         3,
         types: {
-          "resourceTypeGeneral" => "Text",
-          "resourceType" => "Data Management Plan",
+          "resourceTypeGeneral" => "OutputManagementPlan",
         },
         aasm_state: "findable",
       )
@@ -555,8 +547,7 @@ describe DataManagementPlanType do
       create(
         :doi,
         types: {
-          "resourceTypeGeneral" => "Text",
-          "resourceType" => "Data Management Plan",
+          "resourceTypeGeneral" => "OutputManagementPlan",
         },
         aasm_state: "findable",
         creators: [
@@ -619,8 +610,7 @@ describe DataManagementPlanType do
         :doi,
         client: client,
         types: {
-          "resourceTypeGeneral" => "Text",
-          "resourceType" => "Data Management Plan",
+          "resourceTypeGeneral" => "OutputManagementPlan",
         },
         aasm_state: "findable",
       )


### PR DESCRIPTION

## Purpose

```
Feature: GraphQl query support

        Scenario: A user request DMPs in a query
            Given that user makes a query for DataManagementPlan in Graphql
             When the API is requesting DOIs 
             Then the query should use the filter with the new resourceTypeGeneral

```
addresses: [Metadata Schema 4.4 implementation](https://docs.google.com/document/d/1wQUH9_owPp4faBpZm04Z0oqvKhkf1nRAxk6vTzB8j1w/edit#)

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
