### PR TITLE
Issue #1431 - Update lupo scripts for managing prefixes/dois.

### DIFF
--- a/app/jobs/hide_job.rb
+++ b/app/jobs/hide_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class HideJob < ApplicationJob
+  queue_as :lupo_background
+
+  def perform(doi_id, _options = {})
+    doi = Doi.where(doi: doi_id).first
+
+    if doi.present?
+      doi.hide
+      doi.save
+      Rails.logger.error "DOI hidden" + doi_id + "."
+    else
+      Rails.logger.error "Error hiding DOI " + doi_id + ": not found"
+    end
+  end
+end

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -1939,7 +1939,11 @@ class Doi < ApplicationRecord
     "DOI #{doi} will be deleted"
   end
 
-  # to be used after DOIs were transferred to another DOI RA
+  def self.hide_by_doi(doi, options = {})
+    HideJob.perform_later(doi)
+    "DOI #{doi} will be hidden (change state from findable => registered)."
+  end
+
   def self.delete_dois_by_prefix(prefix, options = {})
     if prefix.blank?
       Rails.logger.error "[Error] No prefix provided."
@@ -1965,6 +1969,40 @@ class Doi < ApplicationRecord
 
         response.results.results.each do |d|
           DeleteJob.perform_later(d.doi)
+        end
+      end
+    end
+
+    response.results.total
+  end
+
+  # To be used after DOIs were transferred to another DOI RA
+  # 'Hide' dois by moving state from findable to registered.
+  def self.hide_dois_by_prefix(prefix, options = {})
+    if prefix.blank?
+      Rails.logger.error "[Error] No prefix provided."
+      return nil
+    end
+
+    # query = options[:query] || "*"
+    size = (options[:size] || 1000).to_i
+
+    response = Doi.query(nil, prefix: prefix, page: { size: 1, cursor: [] })
+    Rails.logger.info "#{response.results.total} DOIs found for prefix #{prefix}."
+
+    if prefix && response.results.total > 0
+      # walk through results using cursor
+      cursor = []
+
+      while !response.results.results.empty?
+        response = Doi.query(nil, prefix: prefix, page: { size: size, cursor: cursor })
+        break if response.results.results.empty?
+
+        Rails.logger.info "Hiding#{response.results.results.length} DOIs starting with _id #{response.results.to_a.first[:_id]}."
+        cursor = response.results.to_a.last[:sort]
+
+        response.results.results.each do |d|
+          HideJob.perform_later(d.doi)
         end
       end
     end

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -1985,7 +1985,8 @@ class Doi < ApplicationRecord
     end
 
     # query = options[:query] || "*"
-    size = (options[:size] || 1000).to_i
+    # size = (options[:size] || 1000).to_i
+    size = (options[:size] || 2).to_i
 
     response = Doi.query(nil, prefix: prefix, page: { size: 1, cursor: [] })
     Rails.logger.info "#{response.results.total} DOIs found for prefix #{prefix}."
@@ -1998,7 +1999,7 @@ class Doi < ApplicationRecord
         response = Doi.query(nil, prefix: prefix, page: { size: size, cursor: cursor })
         break if response.results.results.empty?
 
-        Rails.logger.info "Hiding#{response.results.results.length} DOIs starting with _id #{response.results.to_a.first[:_id]}."
+        Rails.logger.info "Hiding #{response.results.results.length} DOIs starting with _id #{response.results.to_a.first[:_id]}."
         cursor = response.results.to_a.last[:sort]
 
         response.results.results.each do |d|

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -1986,7 +1986,7 @@ class Doi < ApplicationRecord
 
     # query = options[:query] || "*"
     # size = (options[:size] || 1000).to_i
-    size = (options[:size] || 2).to_i
+    size = (options[:size] || 1000).to_i
 
     response = Doi.query(nil, prefix: prefix, page: { size: 1, cursor: [] })
     Rails.logger.info "#{response.results.total} DOIs found for prefix #{prefix}."

--- a/lib/tasks/doi.rake
+++ b/lib/tasks/doi.rake
@@ -281,6 +281,19 @@ namespace :doi do
     puts "#{count} DOIs with prefix #{ENV['PREFIX']} deleted."
   end
 
+  desc "HIDE dois by a prefix"
+  task hide_by_prefix: :environment do
+    if ENV["PREFIX"].nil?
+      puts "ENV['PREFIX'] is required."
+      exit
+    end
+
+    puts "Note: This does not delete any associated prefix."
+
+    count = Doi.hide_dois_by_prefix(ENV["PREFIX"])
+    puts "#{count} DOIs with prefix #{ENV['PREFIX']} hidden."
+  end
+
   desc "Delete doi by a doi"
   task delete_by_doi: :environment do
     if ENV["DOI"].nil?
@@ -290,6 +303,17 @@ namespace :doi do
 
     Doi.delete_by_doi(ENV["DOI"])
     puts "DOI #{ENV['DOI']} will be deleted."
+  end
+
+  desc "HIDE doi by a doi"
+  task hide_by_doi: :environment do
+    if ENV["DOI"].nil?
+      puts "ENV['DOI'] is required."
+      exit
+    end
+
+    Doi.hide_by_doi(ENV["DOI"])
+    puts "DOI #{ENV['DOI']} will be hidden (state changed from findable=>registered)."
   end
 
   desc "Add type information to dois based on id range"

--- a/lib/tasks/prefix.rake
+++ b/lib/tasks/prefix.rake
@@ -111,8 +111,8 @@ namespace :prefix do
     puts "#{count} DOIs with prefix #{ENV['PREFIX']} deleted."
   end
 
-  desc "Delete prefix and hide associated DOIs"
-  task delete_and_hide_dois: :environment do
+  desc "Delete prefix and hide associated DOIs (by changing state from 'findable' to 'registered'"
+  task delete: :environment do
     # These prefixes are used by multiple prefixes and can't be deleted
     prefixes_to_keep = %w(10.4124 10.4225 10.4226 10.4227)
 

--- a/lib/tasks/prefix.rake
+++ b/lib/tasks/prefix.rake
@@ -76,7 +76,7 @@ namespace :prefix do
     puts Prefix.get_registration_agency
   end
 
-  desc "Delete prefix and associated DOIs"
+  desc "Delete prefix and hide associated DOIs (by changing state from 'findable' to 'registered')"
   task delete: :environment do
     # These prefixes are used by multiple prefixes and can't be deleted
     prefixes_to_keep = %w(10.4124 10.4225 10.4226 10.4227)
@@ -96,53 +96,18 @@ namespace :prefix do
       puts "Prefix #{ENV['PREFIX']} not found."
       exit
     end
-
-    ClientPrefix.where("prefix_id = ?", prefix.id).destroy_all
-    puts "Client prefix deleted."
-
-    ProviderPrefix.where("prefix_id = ?", prefix.id).destroy_all
-    puts "Provider prefix deleted."
-
-    prefix.destroy
-    puts "Prefix #{ENV['PREFIX']} deleted."
-
-    # delete DOIs
-    count = Doi.delete_dois_by_prefix(ENV["PREFIX"])
-    puts "#{count} DOIs with prefix #{ENV['PREFIX']} deleted."
-  end
-
-  desc "Delete prefix and hide associated DOIs (by changing state from 'findable' to 'registered'"
-  task delete: :environment do
-    # These prefixes are used by multiple prefixes and can't be deleted
-    prefixes_to_keep = %w(10.4124 10.4225 10.4226 10.4227)
-
-    if ENV["PREFIX"].nil?
-      puts "ENV['PREFIX'] is required."
-      exit
-    end
-
-    if prefixes_to_keep.include?(ENV["PREFIX"])
-      puts "Prefix #{ENV['PREFIX']} can't be deleted."
-      exit
-    end
-
-    prefix = Prefix.where(uid: ENV["PREFIX"]).first
-    if prefix.nil?
-      puts "Prefix #{ENV['PREFIX']} not found."
-      exit
-    end
-
-    ClientPrefix.where("prefix_id = ?", prefix.id).destroy_all
-    puts "Client prefix deleted."
-
-    ProviderPrefix.where("prefix_id = ?", prefix.id).destroy_all
-    puts "Provider prefix deleted."
-
-    prefix.destroy
-    puts "Prefix #{ENV['PREFIX']} deleted."
 
     # hide DOIs
     count = Doi.hide_dois_by_prefix(ENV["PREFIX"])
     puts "#{count} DOIs with prefix #{ENV['PREFIX']} hidden."
+
+    ClientPrefix.where("prefix_id = ?", prefix.id).destroy_all
+    puts "Client prefix deleted."
+
+    ProviderPrefix.where("prefix_id = ?", prefix.id).destroy_all
+    puts "Provider prefix deleted."
+
+    prefix.destroy
+    puts "Prefix #{ENV['PREFIX']} deleted."
   end
 end


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: datacite/datacite#1431

## Approach
<!--- _How does this change address the problem?_ -->
Add rake tasks and code structured similarly to that used for deleting dois, but that changes the doi aasm state from 'findable' to 'registered' instead of deleting the dois.

Modified the 'prefix:delete' task to hide the dois by changing their aasm state from 'findable'  to 'registered' instead of deleting them.  Changed the order of ops in that task to delete the prefix after the dois have changed state.  

Task invocation is still:

```
PREFIX=10.14454 bundle exec rake prefix:delete
```
If we need to delete dois there is a doi:delete_dois_by_prefix task.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->
- [ ] Is just changing the state sufficient? Are there other things that need to be done when the state is reverted in this way?

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [X] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
