### PR TITLE
Bracco issue #541 - consortium org list doesn't show service contacts.

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -90,7 +90,7 @@ class ProvidersController < ApplicationController
           )
         end
 
-      @providers = response.results
+      @providers = response.records
       respond_to do |format|
         format.json do
           options = {}


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: datacite/bracco#541

## Approach
<!--- _How does this change address the problem?_ -->
Abilitiy.rb did not correctly evaluate authorization for consortium_admin access to contacts in consortium orgs because it was being given elasticsearch objects instead of provider objects.  

This caused lupo not to return contact information for the the list of consortium orgs for a consortium when the requesting user was a consortium_admin.  Consequently bracco could not display the service contact for orgs in the consortium org list.

This may fix more than one bug.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
