### PR TITLE
Issue #794 - ES - DOIs Deposited in the Wrong Index

### DIFF
--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -1219,6 +1219,8 @@ module Indexable
               break
             end
           end
+          # If it gets here, just return the first.
+          ret = h.keys.first
         end
       end
 

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -1201,20 +1201,36 @@ module Indexable
     end
 
     # Return the active index, i.e. the index that is aliased
+    # Don't rely on the first index being the correct one.
     def active_index
       alias_name = index_name
       client = Elasticsearch::Model.client
-      client.indices.get_alias(name: alias_name).keys.first
+
+      ret = nil
+      h = client.indices.get_alias(name: alias_name)
+
+      if h && !h.key?(:error)
+        if h.size == 1
+          ret = h.keys.first
+        else
+          h.each do |key, value|
+            if value.dig(:aliases, :dois, :is_write_index)
+              ret = key
+              break
+            end
+          end
+        end
+      end
+
+      ret
     end
 
     # Return the inactive index, i.e. the index that is not aliased
     def inactive_index
-      alias_name = index_name
+      active_index = self.active_index
       index_name = self.index_name + "_v1"
       alternate_index_name = self.index_name + "_v2"
 
-      client = Elasticsearch::Model.client
-      active_index = client.indices.get_alias(name: alias_name).keys.first
       active_index.end_with?("v1") ? alternate_index_name : index_name
     end
 


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Reindexing dois in repository caused some dois to be added to the wrong ElasticSearch index.

closes: Issue #794 

related to: datacite/datecite#1458 

## Approach
<!--- _How does this change address the problem?_ -->

Slight modification to active_index and inactive_index methods in indexable.rb concern.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

Post-deployment TO DOs:
* Re-index univie.univie repo dois so that they all go into the correct ES index (dois_v1, not dois-other_v1).  This involves removing their index entries from the indices and then re-importing.
* Remove duplicate doi index entries for crui.inaf repo from of dois-other_v1.  They are already correctly indexed in dois_v1 and are causing duplicates to show up in Fabrica.  This problem can be observed in Fabrica by listing all of the DOIs in this repository, sorted by doi.  Duplicates can be seen in Fabrica.  When this is fixed, the duplicates will go away.
* Fix the ES 'dois' index aliases.  This needs discussion before anything is done.

The last 2 items can be accomplished by the following:

* Remove the 'dois' alias from 'dois-other_v1'.
* Add the 'dois' alias to dois-other_v2.

which can be done with the following  API request in elasticvue.  This has been tested in local development.

```
POST /_aliases

{
  "actions": [
    {
      "remove": {
        "index": "dois-other_v1",
        "alias": "dois"
      }
    },
    {
      "add": {
        "index": "dois-other_v2",
        "alias": "dois"
      }
    }
  ]
}
```

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
