### PR TITLE
Cites/IsCitedBy fix

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1029,23 +1029,6 @@ class Event < ApplicationRecord
       self.source_relation_type_id = "parts"
       self.target_relation_type_id = "part_of"
     end
-
-    ## If the two DOI's involved are Cody and Mike's intro blog posts
-    ## _AND_ is a cites/is-cited-by, then switch for testing
-    if (subj_id == "https://doi.org/10.5438/sjx9-hb16" && obj_id == "https://doi.org/10.5438/cq8g-b226") || (obj_id == "https://doi.org/10.5438/sjx9-hb16" && subj_id == "https://doi.org/10.5438/cq8g-b226")
-      if relation_type_id == "is-cited-by"
-        self.source_doi = uppercase_doi_from_url(obj_id)
-        self.target_doi = uppercase_doi_from_url(subj_id)
-        self.source_relation_type_id = "references"
-        self.target_relation_type_id = "citations"
-      elsif relation_type_id == "cites"
-        self.source_doi = uppercase_doi_from_url(subj_id)
-        self.target_doi = uppercase_doi_from_url(obj_id)
-        self.source_relation_type_id = "references"
-        self.target_relation_type_id = "citations"
-      end
-    end
-    ## END TEST ##
   end
 
   def set_defaults

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -86,10 +86,10 @@ class Event < ApplicationRecord
   ].freeze
 
   # renamed to make it clearer that these relation types are grouped together as references
-  REFERENCE_RELATION_TYPES = %w[is-cited-by is-supplement-to references].freeze
+  REFERENCE_RELATION_TYPES = %w[cites is-supplement-to references].freeze
 
   # renamed to make it clearer that these relation types are grouped together as citations
-  CITATION_RELATION_TYPES = %w[cites is-supplemented-by is-referenced-by].freeze
+  CITATION_RELATION_TYPES = %w[is-cited-by is-supplemented-by is-referenced-by].freeze
 
   RELATIONS_RELATION_TYPES = %w[
     compiles


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
This PR reverses the incorrect assignment of the Cites and IsCitedBy relationship types when processed by the Events service

closes: #752, https://github.com/datacite/datacite/issues/1416
## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
