### PR TITLE
Skip double-encoding diacritics

### DIFF
--- a/app/models/data_catalog.rb
+++ b/app/models/data_catalog.rb
@@ -41,7 +41,7 @@ class DataCatalog
 
     url = "https://api.datacite.org/re3data?" + URI.encode_www_form(params)
 
-    response = Maremma.get(url, host: true)
+    response = Maremma.get(url, host: true, skip_encoding: true)
 
     return [] if response.status != 200
 


### PR DESCRIPTION
## Purpose
Diacritics were double encoded resulting in "??" all over the place when searching re3data.  Including when warming the cache for indexing reference repositories.  This skips that process.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
