### PR TITLE
Repository uid: use only lowercase letters and numbers

### DIFF
--- a/app/models/reference_repository.rb
+++ b/app/models/reference_repository.rb
@@ -5,6 +5,8 @@ class ReferenceRepository < ApplicationRecord
   include Elasticsearch::Model
   include Elasticsearch::Model::Callbacks
   include Hashid::Rails
+  hashid_config alphabet: "abcdefghijklmnopqrstuvwxyz" \
+    "1234567890"
 
   before_save :downcase_fields
   before_save :force_index


### PR DESCRIPTION
## Purpose
Bring repository uid in line with clientId and re3dataDoi.
Fix potential issues with elastic_search case insensitivity for text.


## Approach
Restrict the alphabet used in hashids to lowecase characters and numbers.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
