### PR TITLE
Repository cursor

### DIFF
--- a/app/models/reference_repository_denormalizer.rb
+++ b/app/models/reference_repository_denormalizer.rb
@@ -58,14 +58,6 @@ class ReferenceRepositoryDenormalizer
     @repository.re3doi
   end
 
-  def created_at
-    @repository.created_at
-  end
-
-  def updated_at
-    @repository.updated_at
-  end
-
   def name
     @repository.client_repo&.name || @repository.re3_repo&.name
   end

--- a/spec/graphql/types/repository_type_spec.rb
+++ b/spec/graphql/types/repository_type_spec.rb
@@ -74,9 +74,10 @@ describe RepositoryType do
             $hasPid: String
             $subject: String
             $subjectId: String
+            $cursor: String
           ){
           repositories(
-              first: 10,
+              first: 4,
               query: $query,
               certificate: $certificate,
               software: $software,
@@ -86,7 +87,8 @@ describe RepositoryType do
               isDisciplinary: $isDisciplinary,
               isCertified: $isCertified,
               hasPid: $hasPid,
-              repositoryType: $repositoryType
+              repositoryType: $repositoryType,
+              after: $cursor
             ) {
             nodes {
               uid
@@ -278,6 +280,33 @@ describe RepositoryType do
           }
       ).as_json
       expect(response.dig("data", "repositories", "totalCount")).to eq(4)
+    end
+
+    it "uses the cursor to continue searching" do
+      response = LupoSchema.execute(
+        search_query,
+          variables: {
+          }
+      ).as_json
+      expect(response.dig("data",
+                           "repositories",
+                           "pageInfo",
+                           "hasNextPage")).to eq(true)
+      end_cursor = response.dig("data",
+                                "repositories",
+                                "pageInfo",
+                                "endCursor")
+      second_response = LupoSchema.execute(
+        search_query,
+          variables: {
+            cursor: end_cursor
+          }
+      ).as_json
+      expect(second_response.dig("data",
+                                 "repositories",
+                                 "nodes",
+                                 0,
+                                 "re3dataDoi")).to eq("10.17616/r3bw5r")
     end
   end
 


### PR DESCRIPTION
## Purpose
Fix error when users submitted a cursor for pagination with repository queries in graphql

## Approach
Sets up better sort parameters for repository search and processes the (resumption) cursor passed in through graphql

## Learning
Some great youtube videos on pagination and sort parameters

[Youtube: ElasticSearch Pagination](https://www.youtube.com/watch?v=8noSYHuTeSM)
[Youtube: ElasticSearch Sort](https://www.youtube.com/watch?v=qt5qpfr5s4o)

Previous aproaches to processing the cursors for the resulting ES query have done work to explicitly convert the string returned from the Base64 urlEncoded `cursor` parameter into the appropriate types based on the sort parameters.  It turns out that ES can infer the type from the sort parameters and then coerce the values in the search_after array into the appropriate type.  

To read more about it you can view the source code for [SearchAfterBuilder.java](https://github.com/elastic/elasticsearch/blob/00b3721108d749dcaf88ee187a61e66b21006060/server/src/main/java/org/elasticsearch/search/searchafter/SearchAfterBuilder.java#L154)

This means that we do not have to explicitly convert `to_i` or `to_d` in our processing of the array returned from the cursor.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
