### PR TITLE
Fix Repository facets

### DIFF
--- a/app/graphql/types/base_connection.rb
+++ b/app/graphql/types/base_connection.rb
@@ -89,6 +89,16 @@ class BaseConnection < GraphQL::Types::Relay::BaseConnection
     end
   end
 
+  def facet_by_key_raw(arr)
+    arr.map do |hsh|
+      {
+        "id" => hsh["key"],
+        "title" => hsh["key"],
+        "count" => hsh["doc_count"],
+      }
+    end
+  end
+
   def facet_by_bool(arr)
     arr.map do |hsh|
       id = hsh["key"] == 1 ? "true" : "false"

--- a/app/graphql/types/base_connection.rb
+++ b/app/graphql/types/base_connection.rb
@@ -79,21 +79,12 @@ class BaseConnection < GraphQL::Types::Relay::BaseConnection
     end
   end
 
-  def facet_by_key(arr)
+  def facet_by_key(arr, title_case: true)
     arr.map do |hsh|
+      title = title_case ? hsh["key"].titleize : hsh["key"]
       {
         "id" => hsh["key"],
-        "title" => hsh["key"].titleize,
-        "count" => hsh["doc_count"],
-      }
-    end
-  end
-
-  def facet_by_key_raw(arr)
-    arr.map do |hsh|
-      {
-        "id" => hsh["key"],
-        "title" => hsh["key"],
+        "title" => title,
         "count" => hsh["doc_count"],
       }
     end

--- a/app/graphql/types/repository_connection_with_total_type.rb
+++ b/app/graphql/types/repository_connection_with_total_type.rb
@@ -28,7 +28,7 @@ class RepositoryConnectionWithTotalType < BaseConnection
   end
 
   def certificates
-    facet_by_key(object.aggregations.certificates.buckets)
+    facet_by_key_raw(object.aggregations.certificates.buckets)
   end
 
   def members

--- a/app/graphql/types/repository_connection_with_total_type.rb
+++ b/app/graphql/types/repository_connection_with_total_type.rb
@@ -28,7 +28,7 @@ class RepositoryConnectionWithTotalType < BaseConnection
   end
 
   def certificates
-    facet_by_key_raw(object.aggregations.certificates.buckets)
+    facet_by_key(object.aggregations.certificates.buckets, title_case: false)
   end
 
   def members

--- a/spec/graphql/types/repository_type_spec.rb
+++ b/spec/graphql/types/repository_type_spec.rb
@@ -159,9 +159,9 @@ describe RepositoryType do
       expect(
         response.dig("data", "repositories", "certificates"),
       ).to eq([
-        { "count" => 4, "id" => "CoreTrustSeal", "title" => "Core Trust Seal" },
-        { "count" => 1, "id" => "DINI Certificate", "title" => "Dini Certificate" },
-        { "count" => 1, "id" => "DSA", "title" => "Dsa" }
+        { "count" => 4, "id" => "CoreTrustSeal", "title" => "CoreTrustSeal" },
+        { "count" => 1, "id" => "DINI Certificate", "title" => "DINI Certificate" },
+        { "count" => 1, "id" => "DSA", "title" => "DSA" }
       ])
     end
 
@@ -203,7 +203,7 @@ describe RepositoryType do
     it "filters based on software" do
       response = LupoSchema.execute(
         search_query,
-        variables: { software: "DataVerse" }
+        variables: { software: "dataverse" }
       ).as_json
       expect(response.dig("data", "repositories", "totalCount")).to eq(2)
     end


### PR DESCRIPTION
## Purpose
Repository Graphql Software and Certificate facets were having filtering and display issues respectively.


## Approach
Added a couple of more auto-generated fields for software, one used for displaying the facet, the other used for searching the facets.  For the certificate facet, we now skip running the string through a title-case filter before sending it out through the graphql endpoint. 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
