### PR TITLE
Changed deleted account email preheader text to reflect the intent of…

### DIFF
--- a/app/views/users/delete.html.erb
+++ b/app/views/users/delete.html.erb
@@ -1,4 +1,4 @@
-<span class="preheader">Use this link to generate a password. The link is only valid for 24 hours.</span>
+<span class="preheader">The <%= @title %> account named <%= @name %> has been deleted.</span>
 <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0">
       <tr>
         <td align="center">


### PR DESCRIPTION
… the email

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Changes the email preheader text of the "deleted account" notification email from a string about password generation to a string about account deletion.

closes: #821 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
