### PR TITLE
Updating client trigger reference_repository update.  Respects uniqueness of re3dois

### DIFF
--- a/app/models/reference_repository.rb
+++ b/app/models/reference_repository.rb
@@ -52,6 +52,9 @@ class ReferenceRepository < ApplicationRecord
     rr = ReferenceRepository.find_or_create_by(client_id: client.uid)
     if client.re3data_id && (not rr.re3doi)
       rr.re3doi = client.re3data_id
+      if !rr.validate
+        ReferenceRepository.find_by(re3doi: client.re3data_id, client_id: nil).try(:destroy)
+      end
       rr.save
     else
       rr.touch

--- a/spec/models/reference_repository_spec.rb
+++ b/spec/models/reference_repository_spec.rb
@@ -2,6 +2,96 @@
 
 require "rails_helper"
 
-RSpec.describe "ReferenceRepository", type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe ReferenceRepository, type: :model do
+  describe "Validations" do
+    it { should validate_uniqueness_of(:re3doi).case_insensitive }
+  end
+
+  describe "Creation from client" do
+    it "when a client is created" do
+      client = create(:client)
+      expect(
+        ReferenceRepository.find_by(client_id: client.uid)
+      ).not_to be_nil
+    end
+
+    it "gets assigned client_id from client" do
+      client = create(:client)
+      repository = ReferenceRepository.find_by(client_id: client.uid)
+      expect(repository.client_id).to eq(client.uid)
+    end
+
+    it "gets assigned re3data_id from client" do
+      client = create(:client, re3data_id: "10.17616/r3989r")
+      repository = ReferenceRepository.find_by(client_id: client.uid)
+      expect(repository.re3doi).not_to be_nil
+      expect(repository.re3doi).to eq(client.re3data_id)
+    end
+
+    it "get nil re3data_id from client if client does not have re3data_id" do
+      client = create(:client)
+      repository = ReferenceRepository.find_by(client_id: client.uid)
+      expect(repository.re3doi).to be_nil
+    end
+  end
+
+  describe "Updates" do
+    it "propegate from clients" do
+      doi = "10.17616/r3989r"
+      client = create(:client)
+
+      expect(client.re3data_id).to be_nil
+      repository = ReferenceRepository.find_by(client_id: client.uid)
+      expect(repository.re3doi).to be_nil
+
+      client.re3data = "https://doi.org/" + doi
+      expect(client.save).to be true
+      expect(client.re3data_id).to eq(doi)
+
+      repository = ReferenceRepository.find_by(client_id: client.uid)
+      expect(repository.re3doi).to eq(doi)
+    end
+
+    it "propegate from clients but re3data_id  exists" do
+      doi = "10.17616/r3989r"
+      create(:reference_repository, re3doi: doi)
+
+      client = create(:client)
+      expect(client.re3data_id).to be_nil
+
+      repository_client = ReferenceRepository.find_by(client_id: client.uid)
+      expect(repository_client.re3doi).to be_nil
+
+      client.re3data = "https://doi.org/" + doi
+      expect(client.save).to be true
+      expect(client.re3data_id).to eq(doi)
+
+      repository_client2 = ReferenceRepository.find_by(client_id: client.uid)
+      expect(repository_client2.re3doi).to eq(doi)
+    end
+  end
+
+  describe "Deletes" do
+    before :all do
+      Client.import(force: true)
+      ReferenceRepository.import(force: true)
+    end
+
+    after :all do
+      Client.delete_index
+      ReferenceRepository.delete_index
+    end
+
+    it "propegate from clients" do
+      Rails.logger.level = :fatal
+      client = create(:client)
+      expect(
+        ReferenceRepository.find_by(client_id: client.uid)
+      ).not_to be_nil
+      client.destroy!
+      expect(
+        ReferenceRepository.find_by(client_id: client.uid)
+      ).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Add tests for reference_repository creation/updates/delete

## Approach
On `update_from_client` checks for validation (uniqueness of re3dois)
If this fails, then delete the duplicate reference_repository
Extra check to make sure that duplicate does not already have a client_id associated with it.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
