### PR TITLE
Downcase re3data_id in ReferenceRepository.update_from_client

### DIFF
--- a/app/models/reference_repository.rb
+++ b/app/models/reference_repository.rb
@@ -50,10 +50,10 @@ class ReferenceRepository < ApplicationRecord
 
   def self.update_from_client(client)
     rr = ReferenceRepository.find_or_create_by(client_id: client.uid)
-    if client.re3data_id && (not rr.re3doi)
+    if client.re3data_id && (rr.re3doi.blank?)
       rr.re3doi = client.re3data_id
-      if !rr.validate
-        ReferenceRepository.find_by(re3doi: client.re3data_id, client_id: nil).try(:destroy)
+      if !rr.valid?
+        ReferenceRepository.find_by(re3doi: client.re3data_id.downcase, client_id: nil).try(:destroy)
       end
       rr.save
     else

--- a/spec/models/reference_repository_spec.rb
+++ b/spec/models/reference_repository_spec.rb
@@ -53,21 +53,22 @@ RSpec.describe ReferenceRepository, type: :model do
     end
 
     it "propegate from clients but re3data_id  exists" do
-      doi = "10.17616/r3989r"
+      Rails.logger.level = :fatal
+      doi = "10.17616/R3P01C"
       create(:reference_repository, re3doi: doi)
 
       client = create(:client)
       expect(client.re3data_id).to be_nil
-
       repository_client = ReferenceRepository.find_by(client_id: client.uid)
       expect(repository_client.re3doi).to be_nil
 
-      client.re3data = "https://doi.org/" + doi
-      expect(client.save).to be true
+      expect(
+        client.update({ re3data: "https://doi.org/" + doi })
+      ).to be true
       expect(client.re3data_id).to eq(doi)
 
       repository_client2 = ReferenceRepository.find_by(client_id: client.uid)
-      expect(repository_client2.re3doi).to eq(doi)
+      expect(repository_client2.re3doi).to eq(doi.downcase)
     end
   end
 


### PR DESCRIPTION
## Purpose
Fix bug in `ReferenceRepository.update_from_client` where it wasn't finding the RR because the case for the Client.re3data_id and the ReferenceRepository.re3doi were different.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
