### PR TITLE
Addresses error where some author aggs with multiple nameIdentifiers result in array index error

### DIFF
--- a/app/controllers/concerns/facetable.rb
+++ b/app/controllers/concerns/facetable.rb
@@ -411,6 +411,10 @@ module Facetable
       arr.map { |hsh|
         orcid_id = %r{\A(?:(http|https)://(orcid.org)/)(.+)\z}.match?(hsh["key"]) && hsh["key"]
 
+        if orcid_id.nil?
+          next
+        end
+
         # The aggregation query should only return 1 hit, so hence the index
         # into first element
         creators = hsh.dig("authors", "hits", "hits")[0].dig("_source", "creators")

--- a/app/controllers/concerns/facetable.rb
+++ b/app/controllers/concerns/facetable.rb
@@ -409,8 +409,8 @@ module Facetable
 
     def facet_by_authors(arr)
       arr.map { |hsh|
-        orcid_id = hsh["key"]
-        
+        orcid_id = %r{\A(?:(http|https)://(orcid.org)/)(.+)\z}.match?(hsh["key"]) && hsh["key"]
+
         # The aggregation query should only return 1 hit, so hence the index
         # into first element
         creators = hsh.dig("authors", "hits", "hits")[0].dig("_source", "creators")

--- a/app/controllers/concerns/facetable.rb
+++ b/app/controllers/concerns/facetable.rb
@@ -408,9 +408,9 @@ module Facetable
     end
 
     def facet_by_authors(arr)
-      arr.map do |hsh|
+      arr.map { |hsh|
         orcid_id = hsh["key"]
-
+        
         # The aggregation query should only return 1 hit, so hence the index
         # into first element
         creators = hsh.dig("authors", "hits", "hits")[0].dig("_source", "creators")
@@ -418,20 +418,20 @@ module Facetable
         # Filter through creators to find creator that matches the key
         matched_creator = creators.select do |creator|
           if creator.key?("nameIdentifiers")
-            creator["nameIdentifiers"].each do |ni|
-              break ni["nameIdentifier"] == orcid_id
-            end
+            creator["nameIdentifiers"].any? { |ni| ni["nameIdentifier"] == orcid_id }
           end
         end
 
-        title = matched_creator[0]["name"]
+        if matched_creator.any?
+          title = matched_creator[0]["name"]
 
-        {
-          "id" => orcid_id,
-          "title" => title,
-          "count" => hsh["doc_count"],
-        }
-      end
+          {
+            "id" => orcid_id,
+            "title" => title,
+            "count" => hsh["doc_count"],
+          }
+        end
+      }.compact
     end
   end
 end

--- a/app/graphql/types/base_connection.rb
+++ b/app/graphql/types/base_connection.rb
@@ -198,9 +198,13 @@ class BaseConnection < GraphQL::Types::Relay::BaseConnection
   end
 
   def facet_by_authors(arr)
-    arr.map do |hsh|
-      orcid_id = hsh["key"]
+    arr.map { |hsh|
+      orcid_id = %r{\A(?:(http|https)://(orcid.org)/)(.+)\z}.match?(hsh["key"]) && hsh["key"]
 
+      if orcid_id.nil?
+        next
+      end
+      
       # The aggregation query should only return 1 hit, so hence the index
       # into first element
       creators = hsh.dig("authors", "hits", "hits")[0].dig("_source", "creators")
@@ -208,19 +212,19 @@ class BaseConnection < GraphQL::Types::Relay::BaseConnection
       # Filter through creators to find creator that matches the key
       matched_creator = creators.select do |creator|
         if creator.key?("nameIdentifiers")
-          creator["nameIdentifiers"].each do |ni|
-            break ni["nameIdentifier"] == orcid_id
-          end
+          creator["nameIdentifiers"].any? { |ni| ni["nameIdentifier"] == orcid_id }
         end
       end
 
-      title = matched_creator[0]["name"]
+      if matched_creator.any?
+        title = matched_creator[0]["name"]
 
-      {
-        "id" => orcid_id,
-        "title" => title,
-        "count" => hsh["doc_count"],
-      }
-    end
+        {
+          "id" => orcid_id,
+          "title" => title,
+          "count" => hsh["doc_count"],
+        }
+      end
+    }.compact
   end
 end

--- a/app/graphql/types/base_connection.rb
+++ b/app/graphql/types/base_connection.rb
@@ -204,7 +204,7 @@ class BaseConnection < GraphQL::Types::Relay::BaseConnection
       if orcid_id.nil?
         next
       end
-      
+
       # The aggregation query should only return 1 hit, so hence the index
       # into first element
       creators = hsh.dig("authors", "hits", "hits")[0].dig("_source", "creators")

--- a/spec/concerns/facetable_spec.rb
+++ b/spec/concerns/facetable_spec.rb
@@ -48,11 +48,6 @@ describe "Facetable", type: :controller do
             "count" => 4,
         },
         {
-            "id" => "https://osf.io/8kzbu/",
-            "title" => "Gomeseria, Ronald",
-            "count" => 4,
-        },
-        {
             "id" => "https://orcid.org/0000-0002-2149-9897",
             "title" => "A, Subaveerapandiyan",
             "count" => 3,
@@ -62,11 +57,6 @@ describe "Facetable", type: :controller do
             "title" => "Puntiroli, Michael",
             "count" => 3,
         },
-        {
-            "id" => "https://osf.io/cjhmz/",
-            "title" => "Puntiroli, Michael",
-            "count" => 3,
-        }
         ]
       expect(authors).to eq (expected_result)
     end

--- a/spec/concerns/facetable_spec.rb
+++ b/spec/concerns/facetable_spec.rb
@@ -4,11 +4,70 @@ require "rails_helper"
 
 describe "Facetable", type: :controller do
     let(:author_aggs) { JSON.parse(file_fixture("authors_aggs.json").read) }
+    let(:author_aggs_with_multiple_name_identifiers) { JSON.parse(file_fixture("authors_aggs_with_multiple_name_identifiers.json").read) }
     let(:model) { DataciteDoisController.new }
     it "facet by author" do
       authors = model.facet_by_authors(author_aggs)
 
       expected_result = [{ "id" => "https://orcid.org/0000-0003-1419-2405", "title" => "Fenner, Martin", "count" => 244 }, { "id" => "https://orcid.org/0000-0001-9570-8121", "title" => "Lambert, Simon", "count" => 23 }]
+      expect(authors).to eq (expected_result)
+    end
+
+    it "facet by author where author may have multiple nameIdentifiers" do
+      authors = model.facet_by_authors(author_aggs_with_multiple_name_identifiers)
+
+      expected_result = [
+        {
+            "id" => "https://orcid.org/0000-0002-0429-5446",
+            "title" => "Nam, Hyung-song",
+            "count" => 28,
+        },
+        {
+            "id" => "https://orcid.org/0000-0003-4973-3128",
+            "title" => "Casares, Ramón",
+            "count" => 12,
+        },
+        {
+            "id" => "https://orcid.org/0000-0002-3776-4755",
+            "title" => "Gomeseria, Ronald",
+            "count" => 4,
+        },
+        {
+            "id" => "https://orcid.org/0000-0002-6014-2161",
+            "title" => "Kartha, Sivan",
+            "count" => 4,
+        },
+        {
+            "id" => "https://orcid.org/0000-0003-1026-5865",
+            "title" => "Willemen, Louise",
+            "count" => 4,
+        },
+        {
+            "id" => "https://orcid.org/0000-0003-4624-488X",
+            "title" => "Schwarz, Nina",
+            "count" => 4,
+        },
+        {
+            "id" => "https://osf.io/8kzbu/",
+            "title" => "Gomeseria, Ronald",
+            "count" => 4,
+        },
+        {
+            "id" => "https://orcid.org/0000-0002-2149-9897",
+            "title" => "A, Subaveerapandiyan",
+            "count" => 3,
+        },
+        {
+            "id" => "https://orcid.org/0000-0002-4541-7294",
+            "title" => "Puntiroli, Michael",
+            "count" => 3,
+        },
+        {
+            "id" => "https://osf.io/cjhmz/",
+            "title" => "Puntiroli, Michael",
+            "count" => 3,
+        }
+        ]
       expect(authors).to eq (expected_result)
     end
   end

--- a/spec/fixtures/files/authors_aggs_with_multiple_name_identifiers.json
+++ b/spec/fixtures/files/authors_aggs_with_multiple_name_identifiers.json
@@ -1,0 +1,393 @@
+[
+    {
+        "key": "https://orcid.org/0000-0002-0429-5446",
+        "doc_count": 28,
+        "authors": {
+            "hits": {
+                "total": {
+                    "value": 28,
+                    "relation": "eq"
+                },
+                "max_score": 13.617611,
+                "hits": [
+                    {
+                        "_index": "dois_v1",
+                        "_type": "_doc",
+                        "_id": "42248746",
+                        "_score": 13.617611,
+                        "_source": {
+                            "creators": [
+                                {
+                                    "name": "Nam, Hyung-song",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0002-0429-5446"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "Capecchi, Mario"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "key": "https://orcid.org/0000-0003-4973-3128",
+        "doc_count": 12,
+        "authors": {
+            "hits": {
+                "total": {
+                    "value": 12,
+                    "relation": "eq"
+                },
+                "max_score": 27.93923,
+                "hits": [
+                    {
+                        "_index": "dois_v1",
+                        "_type": "_doc",
+                        "_id": "10910532",
+                        "_score": 27.93923,
+                        "_source": {
+                            "creators": [
+                                {
+                                    "name": "Casares, Ramón",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0003-4973-3128"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "key": "https://orcid.org/0000-0002-3776-4755",
+        "doc_count": 4,
+        "authors": {
+            "hits": {
+                "total": {
+                    "value": 4,
+                    "relation": "eq"
+                },
+                "max_score": 35.18596,
+                "hits": [
+                    {
+                        "_index": "dois_v1",
+                        "_type": "_doc",
+                        "_id": "24003460",
+                        "_score": 35.18596,
+                        "_source": {
+                            "creators": [
+                                {
+                                    "name": "Gomeseria, Ronald",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://osf.io/8kzbu/"
+                                        },
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0002-3776-4755"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "key": "https://orcid.org/0000-0002-6014-2161",
+        "doc_count": 4,
+        "authors": {
+            "hits": {
+                "total": {
+                    "value": 4,
+                    "relation": "eq"
+                },
+                "max_score": 21.385294,
+                "hits": [
+                    {
+                        "_index": "dois_v1",
+                        "_type": "_doc",
+                        "_id": "42716009",
+                        "_score": 21.385294,
+                        "_source": {
+                            "creators": [
+                                {
+                                    "name": "Kartha, Sivan",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0002-6014-2161"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "Holz, Christian",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0003-0722-1044"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "Athanasiou, Tom"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "key": "https://orcid.org/0000-0003-1026-5865",
+        "doc_count": 4,
+        "authors": {
+            "hits": {
+                "total": {
+                    "value": 4,
+                    "relation": "eq"
+                },
+                "max_score": 23.381191,
+                "hits": [
+                    {
+                        "_index": "dois_v1",
+                        "_type": "_doc",
+                        "_id": "65907285",
+                        "_score": 23.381191,
+                        "_source": {
+                            "creators": [
+                                {
+                                    "name": "Schwarz, Nina",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0003-4624-488X"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "Martinez, Javier",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0001-9634-3849"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "Willemen, Louise",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0003-1026-5865"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "key": "https://orcid.org/0000-0003-4624-488X",
+        "doc_count": 4,
+        "authors": {
+            "hits": {
+                "total": {
+                    "value": 4,
+                    "relation": "eq"
+                },
+                "max_score": 23.381191,
+                "hits": [
+                    {
+                        "_index": "dois_v1",
+                        "_type": "_doc",
+                        "_id": "65907285",
+                        "_score": 23.381191,
+                        "_source": {
+                            "creators": [
+                                {
+                                    "name": "Schwarz, Nina",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0003-4624-488X"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "Martinez, Javier",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0001-9634-3849"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "Willemen, Louise",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0003-1026-5865"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "key": "https://osf.io/8kzbu/",
+        "doc_count": 4,
+        "authors": {
+            "hits": {
+                "total": {
+                    "value": 4,
+                    "relation": "eq"
+                },
+                "max_score": 35.18596,
+                "hits": [
+                    {
+                        "_index": "dois_v1",
+                        "_type": "_doc",
+                        "_id": "24003460",
+                        "_score": 35.18596,
+                        "_source": {
+                            "creators": [
+                                {
+                                    "name": "Gomeseria, Ronald",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://osf.io/8kzbu/"
+                                        },
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0002-3776-4755"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "key": "https://orcid.org/0000-0002-2149-9897",
+        "doc_count": 3,
+        "authors": {
+            "hits": {
+                "total": {
+                    "value": 3,
+                    "relation": "eq"
+                },
+                "max_score": 27.425684,
+                "hits": [
+                    {
+                        "_index": "dois_v1",
+                        "_type": "_doc",
+                        "_id": "42238927",
+                        "_score": 27.425684,
+                        "_source": {
+                            "creators": [
+                                {
+                                    "name": "A, Subaveerapandiyan",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0002-2149-9897"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "Sinha, Priyanka"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "key": "https://orcid.org/0000-0002-4541-7294",
+        "doc_count": 3,
+        "authors": {
+            "hits": {
+                "total": {
+                    "value": 3,
+                    "relation": "eq"
+                },
+                "max_score": 23.62671,
+                "hits": [
+                    {
+                        "_index": "dois_v1",
+                        "_type": "_doc",
+                        "_id": "41304522",
+                        "_score": 23.62671,
+                        "_source": {
+                            "creators": [
+                                {
+                                    "name": "Puntiroli, Michael",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://osf.io/cjhmz/"
+                                        },
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0002-4541-7294"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "key": "https://osf.io/cjhmz/",
+        "doc_count": 3,
+        "authors": {
+            "hits": {
+                "total": {
+                    "value": 3,
+                    "relation": "eq"
+                },
+                "max_score": 23.62671,
+                "hits": [
+                    {
+                        "_index": "dois_v1",
+                        "_type": "_doc",
+                        "_id": "41304522",
+                        "_score": 23.62671,
+                        "_source": {
+                            "creators": [
+                                {
+                                    "name": "Puntiroli, Michael",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://osf.io/cjhmz/"
+                                        },
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0002-4541-7294"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    }
+]


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Some Commons searches and pages would report an error page due to an issue where ["works", "authors"] was nil. 

closes: 1418 1309 1359

## Approach
<!--- _How does this change address the problem?_ -->

ElasticSearch GQL searches aggregate authors by creators.nameIdentifiers.nameIdentifier, like so: https://github.com/datacite/lupo/blob/bab0c144fcc68489ec8ba6d2287562a3713734cd/app/models/doi.rb#L614

This can result in multiple nameIdentifiers represented in the author aggs for the same person, some of which are not necessarily ORCIDs. These are represented like so:

`{
                                    "name": "Gomeseria, Ronald",
                                    "nameIdentifiers": [
                                        {
                                            "nameIdentifier": "https://osf.io/8kzbu/"
                                        },
                                        {
                                            "nameIdentifier": "https://orcid.org/0000-0002-3776-4755"
                                        }
                                    ]
                                }`

The current code attempts to find the relevant creator by matching the agg key to the creators list. This select would sometimes break before finding the correct id, leaving a blank matched_creator variable and thus an index error at this line:
https://github.com/datacite/lupo/blob/e9d55ad379c568ad55792833a67b23c187bfa960/app/graphql/types/base_connection.rb#L217

The pull request attempts to: 1) rewrite the select behavior to accommodate situations where multiple nameIdentifiers exist for a given creator, 2) filter out identifiers that are not ORCIDs per the tooltip explanation of the facet functionality in Commons, and 3) make the facet_by_authors function a bit safer. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

It's unclear if this line is a "best practice" approach to filtering ORCIDs: https://github.com/datacite/lupo/blob/8f309b83c225156e6f9d12c2b744e467afe49a1f/app/controllers/concerns/facetable.rb#L412

Borrows regex from here:
https://github.com/datacite/lupo/blob/dd116fb95ce417ff53fc05773d509333aa34ab6d/app/graphql/types/base_connection.rb#L66

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
