### PR TITLE
Pagination fix

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -56,7 +56,7 @@ class ActivitiesController < ApplicationController
         options[:links] = {
           self: request.original_url,
           next:
-            if results.size < page[:size] || page[:size] == 0
+            if results.size < page[:size] || page[:size] == 0 || page[:number] == total_pages
               nil
             else
               request.base_url + "/activities?" +

--- a/app/controllers/client_prefixes_controller.rb
+++ b/app/controllers/client_prefixes_controller.rb
@@ -74,7 +74,7 @@ class ClientPrefixesController < ApplicationController
       options[:links] = {
         self: request.original_url,
         next:
-          if client_prefixes.blank?
+          if client_prefixes.blank? || page[:number] == total_pages
             nil
           else
             request.base_url + "/client-prefixes?" +

--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -96,7 +96,7 @@ class ClientsController < ApplicationController
       options[:links] = {
         self: request.original_url,
         next:
-          if @clients.blank?
+          if @clients.blank? || page[:number] == total_pages
             nil
           else
             request.base_url + "/clients?" +

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -65,7 +65,7 @@ class ContactsController < ApplicationController
           options[:links] = {
             self: request.original_url,
             next:
-              if @contacts.blank?
+              if @contacts.blank? || page[:number] == total_pages
                 nil
               else
                 request.base_url + "/contacts?" +

--- a/app/controllers/data_centers_controller.rb
+++ b/app/controllers/data_centers_controller.rb
@@ -67,7 +67,7 @@ class DataCentersController < ApplicationController
       options[:links] = {
         self: request.original_url,
         next:
-          if @clients.blank?
+          if @clients.blank? || page[:number] == total_pages
             nil
           else
             request.base_url + "/data-centers?" +

--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -300,7 +300,7 @@ class DataciteDoisController < ApplicationController
             options[:links] = {
               self: request.original_url,
               next:
-                if results.size < page[:size] || page[:size] == 0
+                if results.size < page[:size] || page[:size] == 0 || page[:number] == total_pages
                   nil
                 else
                   request.base_url + "/dois?" +

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -233,7 +233,7 @@ class EventsController < ApplicationController
       options[:links] = {
         self: request.original_url,
         next:
-          if results.size < page[:size] || page[:size] == 0
+          if results.size < page[:size] || page[:size] == 0 || page[:number] == total_pages
             nil
           else
             request.base_url + "/events?" +

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -35,7 +35,7 @@ class MediaController < ApplicationController
     options[:links] = {
       self: request.original_url,
       next:
-        if @media.blank?
+        if @media.blank? || page[:number] == total_pages
           nil
         else
           request.base_url + "/media?" +

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -77,7 +77,7 @@ class MembersController < ApplicationController
       options[:links] = {
         self: request.original_url,
         next:
-          if @members.blank?
+          if @members.blank?  || page[:number] == total_pages
             nil
           else
             request.base_url + "/members?" +

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -77,7 +77,7 @@ class MembersController < ApplicationController
       options[:links] = {
         self: request.original_url,
         next:
-          if @members.blank?  || page[:number] == total_pages
+          if @members.blank? || page[:number] == total_pages
             nil
           else
             request.base_url + "/members?" +

--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -39,7 +39,7 @@ class MetadataController < ApplicationController
     options[:links] = {
       self: request.original_url,
       next:
-        if @metadata.blank?
+        if @metadata.blank? || page[:number] == total_pages
           nil
         else
           request.base_url + "/media?" +

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -88,7 +88,7 @@ class OrganizationsController < ApplicationController
           options[:links] = {
             self: request.original_url,
             next:
-              if @providers.blank?
+              if @providers.blank? || page[:number] == total_pages
                 nil
               else
                 request.base_url + "/providers?" +

--- a/app/controllers/prefixes_controller.rb
+++ b/app/controllers/prefixes_controller.rb
@@ -79,7 +79,7 @@ class PrefixesController < ApplicationController
       options[:links] = {
         self: request.original_url,
         next:
-          if prefixes.blank?
+          if prefixes.blank? || page[:number] == total_pages
             nil
           else
             request.base_url + "/prefixes?" +

--- a/app/controllers/provider_prefixes_controller.rb
+++ b/app/controllers/provider_prefixes_controller.rb
@@ -72,7 +72,7 @@ class ProviderPrefixesController < ApplicationController
       options[:links] = {
         self: request.original_url,
         next:
-          if provider_prefixes.blank?
+          if provider_prefixes.blank? || page[:number] == total_pages
             nil
           else
             request.base_url + "/provider-prefixes?" +

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -110,7 +110,7 @@ class ProvidersController < ApplicationController
           options[:links] = {
             self: request.original_url,
             next:
-              if @providers.blank?
+              if @providers.blank? || page[:number] == total_pages
                 nil
               else
                 request.base_url + "/providers?" +

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -99,7 +99,7 @@ class RepositoriesController < ApplicationController
           options[:links] = {
             self: request.original_url,
             next:
-              if response.results.blank?
+              if response.results.blank? || page[:number] == total_pages
                 nil
               else
                 request.base_url + "/repositories?" +

--- a/app/controllers/repository_prefixes_controller.rb
+++ b/app/controllers/repository_prefixes_controller.rb
@@ -72,7 +72,7 @@ class RepositoryPrefixesController < ApplicationController
       options[:links] = {
         self: request.original_url,
         next:
-          if repository_prefixes.blank?
+          if repository_prefixes.blank? || page[:number] == total_pages
             nil
           else
             request.base_url + "/repository-prefixes?" +

--- a/spec/requests/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois_spec.rb
@@ -88,6 +88,34 @@ describe DataciteDoisController, type: :request, vcr: true do
       expect(json.dig("links", "next")).to be_nil
     end
 
+    it "returns correct page links when results is exactly divisible by page size" do
+      get "/dois?page[number]=1&page[size]=5", nil, headers
+
+      expect(last_response.status).to eq(200)
+      expect(json["data"].size).to eq(5)
+      expect(json.dig("meta", "total")).to eq(10)
+      next_link_absolute = Addressable::URI.parse(json.dig("links", "next"))
+      next_link = next_link_absolute.path + "?" + next_link_absolute.query
+      expect(next_link).to eq("/dois?page%5Bnumber%5D=2&page%5Bsize%5D=5")
+
+      get next_link, nil, headers
+
+      expect(last_response.status).to eq(200)
+      expect(json["data"].size).to eq(5)
+      expect(json.dig("meta", "total")).to eq(10)
+      expect(json.dig("links", "next")).to be_nil
+    end
+
+    it "returns a blank resultset when page is above max page" do
+      get "/dois?page[number]=3&page[size]=5", nil, headers
+
+      expect(last_response.status).to eq(200)
+      expect(json["data"].size).to eq(0)
+      expect(json.dig("meta", "totalPages")).to eq(2)
+      expect(json.dig("meta", "page")).to eq(3)
+      expect(json.dig("links", "next")).to be_nil
+    end
+
     it "returns dois with cursor" do
       get "/dois?page[cursor]&page[size]=4", nil, headers
 

--- a/spec/requests/provider_prefixes_spec.rb
+++ b/spec/requests/provider_prefixes_spec.rb
@@ -117,10 +117,7 @@ describe ProviderPrefixesController, type: :request, elasticsearch: true do
       get "/provider-prefixes", nil, headers
       self_link_absolute = Addressable::URI.parse(json.dig("links", "self"))
       expect(self_link_absolute.path).to eq("/provider-prefixes")
-
-      next_link_absolute = Addressable::URI.parse(json.dig("links", "next"))
-      next_link = next_link_absolute.path + "?" + next_link_absolute.query
-      expect(next_link).to eq("/provider-prefixes?page%5Bnumber%5D=2&page%5Bsize%5D=25")
+      expect(json.dig("links", "next")).to be_nil
     end
   end
 


### PR DESCRIPTION
## Purpose
Fixes invalid `next` links being returned when using page-based pagination. This was caused by three different patterns:

1. Removing `next` when the result set is empty - meaning that the last page of results will still have a `next`, and it will only be removed on page(max + 1)
2. Removing next when the size of the results on that page is < `page_size` - this works only when the number of results is not equally divisible by the page size (e.g it works ok for 10 results in pages of 4, because page 3 will have only 2 results and so pass the `if results.size < page[:size]` check, but it will fail for 10 results in pages of 5, because page 2 will have 5 results and so fail that check)
3. When number of results is >10k, pagination calculation would always indicate another page was available, even though it was then clamped by `page[:number].to_i > 0 ? [page[:number].to_i, max_number].min : 1`

closes: #828 

## Approach
Fixed by adding an extra test to all controllers that return paginated results, `page[:number] == total_pages`, meaning `next` is not added when the final page of results are hit, regardless of page size or number of results.

Two new tests have been also added to the datacite_dois_spec file to test that `next` links are correctly removed. These complement the existing test above which tests the functionality in (2) above

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
