### PR TITLE
Add fields to pagination

### DIFF
--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -111,6 +111,7 @@ class ClientsController < ApplicationController
                 "page[number]" => page[:number] + 1,
                 "page[size]" => page[:size],
                 sort: params[:sort],
+                fields: fields_hash_from_params(params)
               }.compact.
               to_query
           end,

--- a/app/controllers/concerns/fieldable.rb
+++ b/app/controllers/concerns/fieldable.rb
@@ -11,5 +11,13 @@ module Fieldable
       fields.each { |k, v| fields[k] = v.to_s.split(",") }
       fields
     end
+
+    def fields_hash_from_params(params)
+      fields = params.to_unsafe_h.dig(:fields)
+      return nil unless fields.is_a?(Hash)
+
+      fields.each { |k, v| fields[k] = v }
+      fields
+    end
   end
 end

--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -340,6 +340,7 @@ class DataciteDoisController < ApplicationController
                           page[:number] + 1
                         end,
                       "page[size]" => page[:size],
+                      fields: fields_hash_from_params(params)
                     }.compact.
                     to_query
                 end,

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -102,6 +102,7 @@ class OrganizationsController < ApplicationController
                     "page[number]" => page[:number] + 1,
                     "page[size]" => page[:size],
                     sort: sort,
+                    fields: fields_hash_from_params(params)
                   }.compact.
                   to_query
               end,

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -125,6 +125,7 @@ class ProvidersController < ApplicationController
                     "page[number]" => page[:number] + 1,
                     "page[size]" => page[:size],
                     sort: sort,
+                    fields: fields_hash_from_params(params)
                   }.compact.
                   to_query
               end,

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -114,6 +114,7 @@ class RepositoriesController < ApplicationController
                     "page[number]" => page[:number] + 1,
                     "page[size]" => page[:size],
                     sort: params[:sort],
+                    fields: fields_hash_from_params(params)
                   }.compact.
                   to_query
               end,

--- a/spec/concerns/fieldable_spec.rb
+++ b/spec/concerns/fieldable_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Dois", type: :controller do
+  subject { DataciteDoisController.new }
+
+  it "no params" do
+    params = ActionController::Parameters.new
+    expect(subject.fields_from_params(params)).to be_nil
+    expect(subject.fields_hash_from_params(params)).to be_nil
+  end
+
+  it "single value" do
+    params = ActionController::Parameters.new(fields: { dois: "id" })
+    expect(subject.fields_from_params(params)).to eq({ dois: ["id"] }.with_indifferent_access)
+    expect(subject.fields_hash_from_params(params)).to eq({ dois: "id" }.with_indifferent_access)
+  end
+
+  it "multiple values" do
+    params = ActionController::Parameters.new(fields: { dois: "id,subjects" })
+    expect(subject.fields_from_params(params)).to eq({ dois: ["id", "subjects"] }.with_indifferent_access)
+    expect(subject.fields_hash_from_params(params)).to eq({ dois: "id,subjects" }.with_indifferent_access)
+  end
+end


### PR DESCRIPTION
## Purpose
When requesting a limited fieldset (e.g to save data transfer when the user just wants IDs or some other field for each result in a large query), the `fields` parameter can be added. This was not being included in the pagination links and so lost beyond the first page of results.

closes: #829 

## Approach
Adds a new function to the Fieldable concern to return the data in a format that can be added to a querystring hash and includes it for all controllers that can use `fields` parameter. Added RSpec tests to the `/dois` request suite, and a new suite for the concern (previously without any tests at all)

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
For the tests, the fact that one hash came from serialized data and one constructed meant the keys did not match as they were strings not symbols. Resolved by using [HashWithIndifferentAccess](https://apidock.com/rails/ActiveSupport/HashWithIndifferentAccess)


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
