### PR TITLE
Fix gzipped request test

### DIFF
--- a/spec/requests/datacite_dois_gzip_spec.rb
+++ b/spec/requests/datacite_dois_gzip_spec.rb
@@ -37,7 +37,7 @@ describe DataciteDoisController, type: :request, vcr: true do
       let(:headers) do
         {
           "CONTENT_TYPE" => "application/gzip",
-          "HTTP_ACCEPT" => "gzip",
+          "HTTP_ACCEPT" => "application/vnd.api+json",
           "HTTP_AUTHORIZATION" => "Bearer " + bearer,
           "HTTP_CONTENT_ENCODING" => "gzip",
         }


### PR DESCRIPTION
## Purpose
Changes the gzip request spec test to request a valid response type. The correct type as written would have been `application/gzip`, but our API doesn't actually ever return that, so instead I updated it to request the standard JSON response.

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->
This whole approach should be revisited - I think there was some confusion around the guidance for use when it was introduced, between transport-level compression (which would be handled entirely by Passenger) and sending a compressed file (with or without transport-level compression), which would be used here.

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
