### PR TITLE
Rails6 duplicate errors

### DIFF
--- a/spec/requests/clients_spec.rb
+++ b/spec/requests/clients_spec.rb
@@ -191,8 +191,11 @@ describe ClientsController, type: :request, elasticsearch: true do
 
         expect(json["errors"]).to eq(
           [
-            { "source" => "system_email", "title" => "Can't be blank", "uid" => provider.uid + ".imperial" },
-            { "source" => "system_email", "title" => "Is invalid", "uid" => provider.uid + ".imperial" },
+            {
+              "source" => "system_email",
+              "title" => "Can't be blank",
+              "uid" => provider.uid + ".imperial"
+            },
           ],
         )
       end

--- a/spec/requests/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois_spec.rb
@@ -2930,7 +2930,9 @@ describe DataciteDoisController, type: :request, vcr: true do
         post "/dois", valid_attributes, headers
 
         expect(last_response.status).to eq(422)
-        expect(json.dig("errors")).to eq([{ "source" => "metadata", "title" => "Is invalid", "uid" => "10.14454/10703" }, { "source" => "metadata", "title" => "Is invalid", "uid" => "10.14454/10703" }])
+        expect(json.dig("errors")).to eq([
+          { "source" => "metadata", "title" => "Is invalid", "uid" => "10.14454/10703" }
+        ])
       end
     end
 

--- a/spec/requests/repositories_spec.rb
+++ b/spec/requests/repositories_spec.rb
@@ -306,7 +306,6 @@ describe RepositoriesController, type: :request, elasticsearch: true do
         expect(json["errors"]).to eq(
           [
             { "source" => "system_email", "title" => "Can't be blank", "uid" => "#{provider.uid}.imperial" },
-            { "source" => "system_email", "title" => "Is invalid", "uid" => "#{provider.uid}.imperial" },
           ],
         )
       end


### PR DESCRIPTION
## Purpose
After upgrading to rails 6, some of the error messages were a bit different.
Specifically, some of the error messages that previously included duplicate errors are only returning one copy since the upgrade.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
