### PR TITLE
Fix provider tests broken due to casing

### DIFF
--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -301,7 +301,7 @@ describe ProvidersController, type: :request, elasticsearch: true do
         )
         expect(
           json.dig("data", "relationships", "consortium", "data", "id"),
-        ).to eq(consortium.symbol.downcase)
+        ).to eq(consortium.symbol)
       end
     end
 
@@ -447,7 +447,7 @@ describe ProvidersController, type: :request, elasticsearch: true do
         )
         expect(
           json.dig("data", "relationships", "consortium", "data", "id"),
-        ).to eq(consortium.symbol.downcase)
+        ).to eq(consortium.symbol)
 
         sleep 1
 
@@ -965,7 +965,7 @@ describe ProvidersController, type: :request, elasticsearch: true do
         )
         expect(
           json.dig("data", "relationships", "consortium", "data", "id"),
-        ).to eq(consortium.symbol.downcase)
+        ).to eq(consortium.symbol)
       end
     end
 
@@ -1017,7 +1017,7 @@ describe ProvidersController, type: :request, elasticsearch: true do
         )
         expect(
           json.dig("data", "relationships", "consortium", "data", "id"),
-        ).to eq(consortium.symbol.downcase)
+        ).to eq(consortium.symbol)
       end
     end
 


### PR DESCRIPTION
## Purpose
Fixes some spec tests that break when Rails is upgraded to 6. It seems like there is an undocumented (as far as we could find) change in how ActiveRecord handles storing the keys for `belongs_to`. In R5 string value FKs were stored as provided, and the lookup was done with case-insensitivity (i.e a record with id XYZ could be linked from another record by being stored in the key column as XYZ, xyz, xYz, XYz, etc). In R6, the supplied value is looked up case-insensitively, and then transformed to match the key of the other record (i.e to link to XYZ, you can supply xyz, xYz, xyZ, etc to the constructor, but the actual data that goes into the DB column will be XYZ)

An example of the mixed-casing in R5: https://gist.github.com/digitaldogsbody/58ccda01930510337a7485c394adbc4c

In R6:
submitted data: `"relationships"=>{"consortium"=>{"data"=>{"type"=>"providers", "id"=>"tEsTa"}}}`
object created by ActiveRecord: `consortium_id: "TESTA"`

As far as we can tell, the underlying functionality remains the same, and doesn't break anything other than these two tests.

Various places that use the `x.consortium_id` field (rather than `x.consortium.uid` or `x.consortium.symbol`) either explicitly uppercase the data anyway (e.g the CSV export) or use case-insensitive comparison (e.g the ability.rb file that handles users permissions)

The other usage is in the JSON API, where the `relationships` section can be used to construct URLs to access the related objects, but here casing does not matter, as ActiveRecord seems to match case insensitively already anyway, so the URL will still be valid (i.e you can use https://api.datacite.org/providers/datacite, https://api.datacite.org/providers/DATACITE and https://api.datacite.org/providers/DataCite and you will get the same response back).

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->
The only potential trip up we could think of is if a third-party is consuming this field and expecting it to always be lowercase. We should have a quick call to talk through this before merge, just to be on the safe side.

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
