### PR TITLE
Removes validation of media_type in Media model that affected Doi indexing

### DIFF
--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -14,7 +14,6 @@ class Media < ApplicationRecord
   validates_format_of :url,
                       with: %r{\A(ftp|http|https|gs|s3|dos)://\S+},
                       if: :url?
-  validates_format_of :media_type, with: %r{\S+/\S+}, if: :media_type?
   validates_associated :doi
 
   belongs_to :doi, foreign_key: :dataset, inverse_of: :media

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -1261,4 +1261,43 @@ describe Doi, type: :model, vcr: true do
       expect(response.aggregations.created.buckets).to eq([])
     end
   end
+
+  context "formats" do
+    let(:doi) { create(:doi, 
+      formats: [
+        "text/csv",
+        "ndjson",
+        "avro",
+        "parquet",
+        "sas7bdat",
+        "dat",
+        "sav"
+      ]
+      ) }
+
+    it "add content_url and update media" do
+      doi.content_url = [
+        "https://redivis.com/datasets/rt7m-4ndqm48zf/tables/1dgp-0rkbx6ahe?v=1.2",
+        "https://redivis.com/datasets/rt7m-4ndqm48zf/tables/7a4a-2zxc46nwb?v=1.2",
+        "https://redivis.com/datasets/rt7m-4ndqm48zf/tables/jjaq-bj4qtkmhj?v=1.2",
+        "https://redivis.com/datasets/rt7m-4ndqm48zf/tables/xgx0-b76w60psz?v=1.2",
+        "https://redivis.com/datasets/rt7m-4ndqm48zf/tables/9sje-1mp1m3yzp?v=1.2",
+        "https://redivis.com/datasets/rt7m-4ndqm48zf/tables/mz8t-6z7c5r3cd?v=1.2",
+        "https://redivis.com/datasets/rt7m-4ndqm48zf/tables/1dgp-0rkbx6ahe?v=1.2",
+        "https://redivis.com/datasets/rt7m-4ndqm48zf/tables/7a4a-2zxc46nwb?v=1.2",
+        "https://redivis.com/datasets/rt7m-4ndqm48zf/tables/jjaq-bj4qtkmhj?v=1.2",
+        "https://redivis.com/datasets/rt7m-4ndqm48zf/tables/xgx0-b76w60psz?v=1.2",
+        "https://redivis.com/datasets/rt7m-4ndqm48zf/tables/9sje-1mp1m3yzp?v=1.2",
+        "https://redivis.com/datasets/rt7m-4ndqm48zf/tables/mz8t-6z7c5r3cd?v=1.2"
+      ]
+
+      doi.update_media
+
+      expect(doi.media.count).to eq(12)
+      expect(doi.media[-1].uid).to eq("0000-0000-0000-000c")
+      expect(doi.media_ids.count).to eq(12)
+      expect(doi.media_ids[-1]).to eq("0000-0000-0000-000c")
+      expect(doi.as_indexed_json["media_ids"].count).to eq(12)
+    end
+  end
 end

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -1263,7 +1263,7 @@ describe Doi, type: :model, vcr: true do
   end
 
   context "formats" do
-    let(:doi) { create(:doi, 
+    let(:doi) { create(:doi,
       formats: [
         "text/csv",
         "ndjson",

--- a/spec/models/media_spec.rb
+++ b/spec/models/media_spec.rb
@@ -47,15 +47,15 @@ context "validations" do
     expect(subject.url).to eq("mailto:info@example.org")
   end
 
-  it "Media type valid" do
+  it "MIME type media type valid" do
     subject = build(:media, media_type: "text/plain")
     expect(subject).to be_valid
     expect(subject.media_type).to eq("text/plain")
   end
 
-  it "Media type invalid" do
+  it "Free text media type valid" do
     subject = build(:media, media_type: "text")
-    expect(subject).to_not be_valid
+    expect(subject).to be_valid
     expect(subject.media_type).to eq("text")
   end
 

--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -149,39 +149,6 @@ describe MediaController,
         expect(json.dig("data", "attributes", "url")).to eq(url)
       end
     end
-
-    context "when the media_type is not valid" do
-      let(:media_type) { "text" }
-      let(:valid_attributes) do
-        {
-          "data" => {
-            "type" => "media",
-            "attributes" => { "mediaType" => media_type, "url" => url },
-            "relationships" => {
-              "doi" => {
-                "data" => { "type" => "dois", "id" => datacite_doi.doi },
-              },
-            },
-          },
-        }
-      end
-
-      it "returns status code 422" do
-        post "/dois/#{datacite_doi.doi}/media",
-             valid_attributes, headers
-
-        expect(last_response.status).to eq(422)
-      end
-
-      it "returns a validation failure message" do
-        post "/dois/#{datacite_doi.doi}/media",
-             valid_attributes, headers
-
-        expect(json["errors"]).to eq(
-          [{ "source" => "media_type", "title" => "Is invalid" }],
-        )
-      end
-    end
   end
 
   describe "PATCH /dois/DOI/media/:id" do


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

The `Media` model `media_type` attribute required an undocumented `\S+/\S+` validation. When `content_url` and `formats` values were both present, this could cause nil objects to be stored in the `Doi` `media` attribute, resulting in errors in the `update_media` and `media_ids` methods. This sometimes caused errors with DOI indexing and returned 500 errors to users upon DOI metadata updates.

closes: #848

## Approach
<!--- _How does this change address the problem?_ -->

Removes validation of `Media` model `media_type` attribute. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
