### PR TITLE
Ensures clear ES indices in tests. (issue 859)

### DIFF
--- a/bin/rspec
+++ b/bin/rspec
@@ -1,5 +1,10 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 
 begin
   load File.expand_path("spring", __dir__)

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,9 +1,10 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 begin
-  load File.expand_path('../spring', __FILE__)
+  load File.expand_path("../spring", __FILE__)
 rescue LoadError => e
-  raise unless e.message.include?('spring')
+  raise unless e.message.include?("spring")
 end
 
 begin

--- a/bin/spring
+++ b/bin/spring
@@ -1,17 +1,18 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # This file loads Spring without using Bundler, in order to be fast.
 # It gets overwritten when you run the `spring binstub` command.
 
 unless defined?(Spring)
-  require 'rubygems'
-  require 'bundler'
+  require "rubygems"
+  require "bundler"
 
   lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
-  spring = lockfile.specs.detect { |spec| spec.name == 'spring' }
+  spring = lockfile.specs.detect { |spec| spec.name == "spring" }
   if spring
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
-    gem 'spring', spring.version
-    require 'spring/binstub'
+    gem "spring", spring.version
+    require "spring/binstub"
   end
 end

--- a/bin/spring
+++ b/bin/spring
@@ -1,16 +1,17 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
 
-if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
-  gem "bundler"
-  require "bundler"
+# This file loads Spring without using Bundler, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
 
-  # Load Spring without loading other gems in the Gemfile, for speed.
-  Bundler.locked_gems&.specs&.find { |spec| spec.name == "spring" }&.tap do |spring|
+unless defined?(Spring)
+  require 'rubygems'
+  require 'bundler'
+
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  spring = lockfile.specs.detect { |spec| spec.name == 'spring' }
+  if spring
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
-    gem "spring", spring.version
-    require "spring/binstub"
-  rescue Gem::LoadError
-    # Ignore when Spring is not installed.
+    gem 'spring', spring.version
+    require 'spring/binstub'
   end
 end

--- a/spec/concerns/authenticable_spec.rb
+++ b/spec/concerns/authenticable_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe User, type: :model do
+describe User, type: :model, elasticsearch: true do
   let(:token) { User.generate_token }
   subject { User.new(token) }
 

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe Doi, type: :model, vcr: true do
+describe Doi, type: :model, vcr: true, elasticsearch: true do
   it_behaves_like "an STI class"
 
   describe "validations" do

--- a/spec/models/reference_repository_spec.rb
+++ b/spec/models/reference_repository_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ReferenceRepository, type: :model , elasticsearch: true do
+RSpec.describe ReferenceRepository, type: :model, elasticsearch: true do
   describe "Validations" do
     it { should validate_uniqueness_of(:re3doi).case_insensitive }
   end

--- a/spec/models/reference_repository_spec.rb
+++ b/spec/models/reference_repository_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ReferenceRepository, type: :model do
+RSpec.describe ReferenceRepository, type: :model , elasticsearch: true do
   describe "Validations" do
     it { should validate_uniqueness_of(:re3doi).case_insensitive }
   end
@@ -73,16 +73,6 @@ RSpec.describe ReferenceRepository, type: :model do
   end
 
   describe "Deletes" do
-    before :all do
-      Client.import(force: true)
-      ReferenceRepository.import(force: true)
-    end
-
-    after :all do
-      Client.delete_index
-      ReferenceRepository.delete_index
-    end
-
     it "propegate from clients" do
       Rails.logger.level = :fatal
       client = create(:client)

--- a/spec/support/elasticsearch_helper.rb
+++ b/spec/support/elasticsearch_helper.rb
@@ -30,7 +30,6 @@ RSpec.configure do |config|
         index: esc.index_name,
         body: { settings: esc.settings.to_hash, mappings: esc.mappings.to_hash }
       )
-
     end
   end
 

--- a/spec/support/elasticsearch_helper.rb
+++ b/spec/support/elasticsearch_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-## https://github.com/elastic/elasticsearch-ruby/issues/462
 SEARCHABLE_MODELS = [
   Client,
   Provider,
@@ -17,32 +16,33 @@ SEARCHABLE_MODELS = [
 ].freeze
 
 RSpec.configure do |config|
-  config.around :example, elasticsearch: true do |example|
-    SEARCHABLE_MODELS.each do |model|
-      if model.name == "DataciteDoi" || model.name == "OtherDoi"
-        model.create_template
+  config.before :all do
+    SEARCHABLE_MODELS.each do |esc|
+      if esc.name == "DataciteDoi" || esc.name == "OtherDoi"
+        esc.create_template
       end
 
-      if Elasticsearch::Model.client.indices.exists? index:
-                                                     "#{model.index_name}_v1"
-        Elasticsearch::Model.client.indices.delete index:
-                                                     "#{model.index_name}_v1"
-      end
-      if Elasticsearch::Model.client.indices.exists? index:
-                                                     "#{model.index_name}_v2"
-        Elasticsearch::Model.client.indices.delete index:
-                                                     "#{model.index_name}_v2"
+      if Elasticsearch::Model.client.indices.exists?(index: esc.index_name)
+        esc.__elasticsearch__.client.indices.delete index: esc.index_name
       end
 
-      model.__elasticsearch__.create_index! force: true
+      esc.__elasticsearch__.client.indices.create(
+        index: esc.index_name,
+        body: { settings: esc.settings.to_hash, mappings: esc.mappings.to_hash }
+      )
+
     end
+  end
 
-    example.run
-
-    SEARCHABLE_MODELS.each do |model|
-      if Elasticsearch::Model.client.indices.exists? index: model.index_name
-        Elasticsearch::Model.client.indices.delete index: model.index_name
+  config.after :all do
+    SEARCHABLE_MODELS.each do |esc|
+      if Elasticsearch::Model.client.indices.exists?(index: esc.index_name)
+        esc.__elasticsearch__.client.indices.delete index: esc.index_name
       end
     end
+  end
+
+  config.before(:each, elasticsearch: true) do
+    SEARCHABLE_MODELS.each { |esc| esc.import(refresh: true, force: true) }
   end
 end


### PR DESCRIPTION
## Purpose
Enforce ES indices before each top level rspec example group  and Clears them (delete and repost) if already present.
Makes sure that  ES indices are clean.

closes: #859

## Approach
Updates the rspec elasticsearch_helper.  Each top level example group ensures that all ES indices are present and clear.

If a given block includes `elasticsearch: true` it will clear and reindex all models in currently in the DB.
If applied at a top level, it will do so for each `it` spec within the block.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
