### PR TITLE
Improve logic for has_next_page for all ElasticSearch based Graphql endpoints

### DIFF
--- a/app/graphql/connections/elasticsearch_model_response_connection.rb
+++ b/app/graphql/connections/elasticsearch_model_response_connection.rb
@@ -137,7 +137,7 @@ class ElasticsearchModelResponseConnection
 
   # @return [Boolean] True if there are more items after this page
   def has_next_page
-    nodes.length < total_count # && !(nodes.length < first.to_i)
+    nodes.length < total_count && (nodes.length == @first_value)
   end
 
   # @return [Boolean] True if there were items before these items


### PR DESCRIPTION
## Purpose
GraphQL endpoints currently have logic that almost always returns true for hasNextPage.
This is an improvement on that logic but is not perfect.

closes: #834

## Approach
If the size of the array of nodes returned from the search is the same as the size specified by the `first` parameter then it is likely that there is another page.

There is a possibility that there won't be a next page if the `total_count.modulo(@first_value) ==0`. and it is the last page of results.  This does not account for  that but it is better than always returning true.

## Learning
This is a difficult problem
https://discuss.elastic.co/t/how-to-check-if-es-has-more-documents-when-paginating-with-search-after-api/151419


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
