### PR TITLE
Changes to support Fabrica Improvements feature 10

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -110,6 +110,7 @@ class Provider < ApplicationRecord
                            professionalSociety
                            publisher
                            serviceProvider
+                           internationalOrganization
                            other
                          ],
                          message:

--- a/app/serializers/repository_serializer.rb
+++ b/app/serializers/repository_serializer.rb
@@ -23,6 +23,7 @@ class RepositorySerializer
              :domains,
              :issn,
              :url,
+             :software,
              :salesforce_id,
              :from_salesforce,
              :created,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -184,9 +184,11 @@ paths:
               - invenio
               - islandora
               - nesstar
-              - open_journal_systems_ojs
+              - open journal systems (ojs)
               - opus
               - samvera
+              - pubman
+              - mycore
               - other
               - unknown
         - in: query
@@ -883,15 +885,13 @@ paths:
             type: string
             enum:
               - academicInstitution
-              - academicLibrary
               - governmentAgency
               - nationalInstitution
-              - nationalLibrary
               - publisher
               - professionalSociety
               - researchInstitution
               - serviceProvider
-              - vendor
+              - internationalOrganization
               - other
         - in: query
           name: focus-area

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -872,6 +872,48 @@ describe ProvidersController, type: :request, elasticsearch: true do
       end
     end
 
+    context "create provider with internationalOrganization organization type" do
+      provider_symbol = "FG"
+      let(:params) do
+        {
+          "data" => {
+            "type" => "providers",
+            "attributes" => {
+              "symbol" => provider_symbol,
+              "name" => "Figshare",
+              "displayName" => "Figshare",
+              "region" => "EMEA",
+              "systemEmail" => "doe@joe.joe",
+              "website" => "https://www.bl.uk",
+              "memberType" => "direct_member",
+              "organizationType" => "internationalOrganization",
+              "country" => "GB",
+            },
+          },
+        }
+      end
+
+      it "creates a provider" do
+        post "/providers", params, admin_headers
+
+        expect(last_response.status).to eq(200)
+        expect(json.dig("data", "attributes", "organizationType")).to eq(
+          "internationalOrganization",
+        )
+
+        sleep 1
+
+        get "/providers/#{
+              provider_symbol
+            }",
+            nil, headers
+        
+        expect(json.dig("data", "attributes", "organizationType")).to eq(
+          "internationalOrganization",
+        )
+      end
+    end
+
     context "when the request is missing a required attribute" do
       let(:params) do
         {
@@ -937,6 +979,7 @@ describe ProvidersController, type: :request, elasticsearch: true do
               "globusUuid" => "9908a164-1e4f-4c17-ae1b-cc318839d6c8",
               "displayName" => "British Library",
               "memberType" => "consortium_organization",
+              "organizationType" => "internationalOrganization",
               "website" => "https://www.bl.uk",
               "region" => "Americas",
               "systemEmail" => "Pepe@mdm.cod",
@@ -966,6 +1009,9 @@ describe ProvidersController, type: :request, elasticsearch: true do
         expect(
           json.dig("data", "relationships", "consortium", "data", "id"),
         ).to eq(consortium.symbol.downcase)
+        expect(json.dig("data", "attributes", "organizationType")).to eq(
+          "internationalOrganization",
+        )
       end
     end
 

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -907,7 +907,7 @@ describe ProvidersController, type: :request, elasticsearch: true do
               provider_symbol
             }",
             nil, headers
-        
+
         expect(json.dig("data", "attributes", "organizationType")).to eq(
           "internationalOrganization",
         )

--- a/spec/requests/repositories_spec.rb
+++ b/spec/requests/repositories_spec.rb
@@ -36,6 +36,7 @@ describe RepositoriesController, type: :request, elasticsearch: true do
           "name" => "Imperial College",
           "systemEmail" => "bob@example.com",
           "salesforceId" => "abc012345678901234",
+          "software" => "MyCoRe",
           "fromSalesforce" => true,
           "clientType" => "repository",
           "certificate" => %w[CoreTrustSeal],
@@ -125,6 +126,7 @@ describe RepositoriesController, type: :request, elasticsearch: true do
         expect(json.dig("data", "attributes", "globusUuid")).to eq(
           "bc7d0274-3472-4a79-b631-e4c7baccc667",
         )
+        expect(json.dig("data", "attributes", "software")).to eq(client.software)
         expect(json["meta"]).to eq("doiCount" => 0, "prefixCount" => 0)
       end
     end
@@ -240,6 +242,7 @@ describe RepositoriesController, type: :request, elasticsearch: true do
         expect(attributes["name"]).to eq("Imperial College")
         expect(attributes["systemEmail"]).to eq("bob@example.com")
         expect(attributes["certificate"]).to eq(%w[CoreTrustSeal])
+        expect(attributes["software"]).to eq("MyCoRe")
         expect(attributes["salesforceId"]).to eq("abc012345678901234")
 
         relationships = json.dig("data", "relationships")
@@ -322,6 +325,7 @@ describe RepositoriesController, type: :request, elasticsearch: true do
               "name" => "Imperial College 2",
               "clientType" => "periodical",
               "globusUuid" => "9908a164-1e4f-4c17-ae1b-cc318839d6c8",
+              "software" => "OPUS"
             },
           },
         }
@@ -336,6 +340,9 @@ describe RepositoriesController, type: :request, elasticsearch: true do
         )
         expect(json.dig("data", "attributes", "globusUuid")).to eq(
           "9908a164-1e4f-4c17-ae1b-cc318839d6c8",
+        )
+        expect(json.dig("data", "attributes", "software")).to eq(
+          "OPUS",
         )
         expect(json.dig("data", "attributes", "name")).not_to eq(client.name)
         expect(json.dig("data", "attributes", "clientType")).to eq("periodical")


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Adds `internationalOrganization` to the `organization_type` validation in the Provider model to support a new "International Organization" option in Fabrica. Exposes the `software` attribute in the RepositorySerializer so the software field is displayed properly in Fabrica.

Part of datacite/datacite#1521

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

- [ ] Unrelated to this PR, but should `software` also be exposed in the ClientSerializer? It is not currently.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
