### PR TITLE
Serializer: Replace related_items with [] if it doesn't exist

### DIFF
--- a/app/serializers/datacite_doi_serializer.rb
+++ b/app/serializers/datacite_doi_serializer.rb
@@ -192,7 +192,11 @@ class DataciteDoiSerializer
   end
 
   attribute :related_items do |object|
-    Array.wrap(object.related_items)
+    if object.related_items?
+      Array.wrap(object.related_items)
+    else
+      []
+    end
   end
 
   attribute :geo_locations,


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
This stops the DataciteDoiSerializer from erroring out if `related_items` is missing (because the DOI came from the `dois-other` index

Tested locally by manipulating a genuine ES response to delete the related items key:
From rails console inside the container:
```ruby
q = DataciteDoi.query("")
r = q.results[0]
r._source.delete("related_items")
s = DataciteDoiSerializer.new(r, {})
s.serialized_json
```

If you run this without this PR, you should get an error:
`NoMethodError (undefined method 'related_items' for #<Elasticsearch::Model::Response::Result:0x00007f0a215ca760>)`

With the PR, you should get a JSON string with the `related_items` property being an empty array `[]`

closes: #874 

## Approach
<!--- _How does this change address the problem?_ -->
Implements a workaround in the serializer that tests for the truthiness of the `related_items` attribute in the serializer (since it's actually a method due to how the `FastJsonapi::ObjectSerializer` works), so it's not enough to check for the presence, as this will also cause a `NoMethodError` and returns an empty list if it fails.

In the longer term, we should address the underlying issue which is the ES indexes missing keys in their structures.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->
- [ ] Why is the query function reading from the ES alias which includes the `dois-other` index? This is a long-term discussion!

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
