### PR TITLE
Adds title sort by first title functionality to the /dois endpoint

### DIFF
--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -44,9 +44,25 @@ class DataciteDoisController < ApplicationController
       when "-citation-count"
         { citation_count: { order: "desc" } }
       when "title"
-        { "titles.title.keyword": { order: "asc" } }
+        { "_script": {
+            "type": "string",
+            "script": {
+                "lang": "painless",
+                "inline": "if (params._source.titles.length > 0) { return params._source.titles[0].title } else { return '' }"
+            },
+            "order": "asc"
+          }
+        }
       when "-title"
-        { "titles.title.keyword": { order: "desc" } }
+        { "_script": {
+            "type": "string",
+            "script": {
+                "lang": "painless",
+                "inline": "if (params._source.titles.length > 0) { return params._source.titles[0].title } else { return '' }"
+            },
+            "order": "desc"
+          }
+        }
       when "relevance"
         { "_score": { "order": "desc" } }
       else

--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -43,6 +43,10 @@ class DataciteDoisController < ApplicationController
         { citation_count: { order: "asc" } }
       when "-citation-count"
         { citation_count: { order: "desc" } }
+      when "title"
+        { "titles.title.keyword": { order: "asc" } }
+      when "-title"
+        { "titles.title.keyword": { order: "desc" } }
       when "relevance"
         { "_score": { "order": "desc" } }
       else

--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -44,25 +44,9 @@ class DataciteDoisController < ApplicationController
       when "-citation-count"
         { citation_count: { order: "desc" } }
       when "title"
-        { "_script": {
-            "type": "string",
-            "script": {
-                "lang": "painless",
-                "inline": "if (params._source.titles.length > 0) { return params._source.titles[0].title } else { return '' }"
-            },
-            "order": "asc"
-          }
-        }
+        { "primary_title.title.keyword": { order: "asc" } }
       when "-title"
-        { "_script": {
-            "type": "string",
-            "script": {
-                "lang": "painless",
-                "inline": "if (params._source.titles.length > 0) { return params._source.titles[0].title } else { return '' }"
-            },
-            "order": "desc"
-          }
-        }
+        { "primary_title.title.keyword": { order: "desc" } }
       when "relevance"
         { "_score": { "order": "desc" } }
       else

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -503,6 +503,11 @@ class Doi < ApplicationRecord
       indexes :version_of_ids, type: :keyword
       indexes :reference_ids, type: :keyword
       indexes :citation_ids, type: :keyword
+      indexes :primary_title, type: :object, properties: {
+        title: { type: :text, fields: { keyword: { type: "keyword" } } },
+        titleType: { type: :keyword },
+        lang: { type: :keyword },
+      }
     end
   end
 
@@ -582,6 +587,7 @@ class Doi < ApplicationRecord
       "part_of_ids" => part_of_ids,
       "version_ids" => version_ids,
       "version_of_ids" => version_of_ids,
+      "primary_title" => Array.wrap(primary_title),
     }
   end
 
@@ -1825,6 +1831,10 @@ class Doi < ApplicationRecord
   def cache_key
     timestamp = updated || Time.zone.now
     "dois/#{uid}-#{timestamp.iso8601}"
+  end
+
+  def primary_title
+    Array.wrap(Array.wrap(titles).first)
   end
 
   def event=(value)

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -1307,4 +1307,28 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
       expect(doi.as_indexed_json["media_ids"].count).to eq(12)
     end
   end
+
+  describe "primary_title" do
+    let(:doi) { create(:doi) }
+    titles = [{ "title" => "New title", "titleType" => "AlternativeTitle" }, { "title" => "Second title" }]
+
+    it "is first title" do
+      expect(doi.primary_title).to eq(Array.wrap(doi.titles.first))
+      expect(doi.as_indexed_json.dig("primary_title")).to eq(Array.wrap(doi.titles.first))
+    end
+
+    it "is first title after update" do
+      doi.titles = titles
+
+      expect(doi.primary_title).to eq(Array.wrap(titles.first))
+      expect(doi.as_indexed_json.dig("primary_title")).to eq(Array.wrap(titles.first))
+    end
+
+    it "is empty array if titles is nil" do
+      doi.titles = nil
+
+      expect(doi.primary_title).to eq([])
+      expect(doi.as_indexed_json.dig("primary_title")).to eq([])
+    end
+  end
 end

--- a/spec/requests/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois_spec.rb
@@ -369,10 +369,10 @@ describe DataciteDoisController, type: :request, vcr: true do
   describe "GET /dois with sort", elasticsearch: true do
     let!(:dois) {
       [
-        create(:doi, titles: [{ "title": "Brad" }]),
-        create(:doi, titles: [{ "title": "Zack" }]),
-        create(:doi, titles: [{ "title": "Alphonso" }, { "title": "Zorro", "titleType": "AlternativeTitle"}]),
-        create(:doi, titles: [{ "title": "Corey" }]),
+        create(:doi, titles: [{ "title" => "Brad" }]),
+        create(:doi, titles: [{ "title" => "Zack" }]),
+        create(:doi, titles: [{ "title" => "Alphonso" }, { "title" => "Zorro", "titleType" => "AlternativeTitle" }]),
+        create(:doi, titles: [{ "title" => "Corey" }]),
         create(:doi, titles: nil),
         create(:doi, titles: []),
       ]

--- a/spec/requests/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois_spec.rb
@@ -371,14 +371,11 @@ describe DataciteDoisController, type: :request, vcr: true do
       [
         create(:doi, titles: [{ "title": "Brad" }]),
         create(:doi, titles: [{ "title": "Zack" }]),
-        create(:doi, titles: [{ "title": "Alphonso" }, { "title": "Zorro"}]),
+        create(:doi, titles: [{ "title": "Alphonso" }, { "title": "Zorro", "titleType": "AlternativeTitle"}]),
         create(:doi, titles: [{ "title": "Corey" }]),
-        create(:doi, titles: nil)
+        create(:doi, titles: nil),
+        create(:doi, titles: []),
       ]
-    }
-
-    let!(:dois_2) {
-      create_list(:doi, 200, aasm_state: "findable")
     }
 
     before do
@@ -391,8 +388,8 @@ describe DataciteDoisController, type: :request, vcr: true do
 
       result = json.dig("data")
 
-      expect(result.dig(0, "attributes", "titles")).to eq([])
-      expect(result.dig(1, "attributes", "titles")).to eq(dois[2].titles)
+      expect(result.dig(0, "attributes", "titles")).to eq(dois[2].titles)
+      expect(result.dig(1, "attributes", "titles")).to eq(dois[0].titles)
     end
 
     it "returns dois in descending title sort order" do
@@ -401,6 +398,7 @@ describe DataciteDoisController, type: :request, vcr: true do
       result = json.dig("data")
 
       expect(result.dig(0, "attributes", "titles")).to eq(dois[1].titles)
+      expect(result.dig(1, "attributes", "titles")).to eq(dois[3].titles)
     end
   end
 

--- a/spec/requests/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois_spec.rb
@@ -372,8 +372,13 @@ describe DataciteDoisController, type: :request, vcr: true do
         create(:doi, titles: [{ "title": "Brad" }]),
         create(:doi, titles: [{ "title": "Zack" }]),
         create(:doi, titles: [{ "title": "Alphonso" }, { "title": "Zorro"}]),
-        create(:doi, titles: [{ "title": "Corey" }])
+        create(:doi, titles: [{ "title": "Corey" }]),
+        create(:doi, titles: nil)
       ]
+    }
+
+    let!(:dois_2) {
+      create_list(:doi, 200, aasm_state: "findable")
     }
 
     before do
@@ -386,9 +391,8 @@ describe DataciteDoisController, type: :request, vcr: true do
 
       result = json.dig("data")
 
-      expect(result.size).to eq(4)
-      expect(result.dig(0, "attributes", "titles")).to eq(dois[2].titles)
-      expect(result.dig(3, "attributes", "titles")).to eq(dois[1].titles)
+      expect(result.dig(0, "attributes", "titles")).to eq([])
+      expect(result.dig(1, "attributes", "titles")).to eq(dois[2].titles)
     end
 
     it "returns dois in descending title sort order" do
@@ -396,9 +400,7 @@ describe DataciteDoisController, type: :request, vcr: true do
 
       result = json.dig("data")
 
-      expect(result.size).to eq(4)
       expect(result.dig(0, "attributes", "titles")).to eq(dois[1].titles)
-      expect(result.dig(3, "attributes", "titles")).to eq(dois[2].titles)
     end
   end
 

--- a/spec/requests/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois_spec.rb
@@ -366,6 +366,42 @@ describe DataciteDoisController, type: :request, vcr: true do
     end
   end
 
+  describe "GET /dois with sort", elasticsearch: true do
+    let!(:dois) {
+      [
+        create(:doi, titles: [{ "title": "Brad" }]),
+        create(:doi, titles: [{ "title": "Zack" }]),
+        create(:doi, titles: [{ "title": "Alphonso" }, { "title": "Zorro"}]),
+        create(:doi, titles: [{ "title": "Corey" }])
+      ]
+    }
+
+    before do
+      DataciteDoi.import
+      sleep 2
+    end
+
+    it "returns dois in ascending title sort order" do
+      get "/dois?sort=title", nil, headers
+
+      result = json.dig("data")
+
+      expect(result.size).to eq(4)
+      expect(result.dig(0, "attributes", "titles")).to eq(dois[2].titles)
+      expect(result.dig(3, "attributes", "titles")).to eq(dois[1].titles)
+    end
+
+    it "returns dois in descending title sort order" do
+      get "/dois?sort=-title", nil, headers
+
+      result = json.dig("data")
+
+      expect(result.size).to eq(4)
+      expect(result.dig(0, "attributes", "titles")).to eq(dois[1].titles)
+      expect(result.dig(3, "attributes", "titles")).to eq(dois[2].titles)
+    end
+  end
+
   describe "GET /dois/:id", elasticsearch: true do
     let!(:doi) { create(:doi, client: client) }
 


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Adds title sort by first title functionality to the /dois endpoint to fulfill datacite/datacite#1518

## Approach
<!--- _How does this change address the problem?_ -->

The spec called for title sorting by the DOI's first title. Because Elasticsearch has no sense of order in object/non-nested fields, we were unable to select the first value of an array in a sort using the expected sort method:

``` 
        { "titles.title.keyword": { order: "asc" } }
```

We attempted to use a Painless script to sort by first title, but the response time and unpredictable system load made this option appear untenable: 

```
        { "_script": {
            "type": "string",
            "script": {
                "lang": "painless",
                "inline": "if (params._source.titles.length > 0) { return params._source.titles[0].title } else { return '' }"
            },
            "order": "asc"
          }
        } 
```

Instead, I created a new attribute in the Doi model `primary_title` that selects the first title from the Doi's `titles`. This is wrapped in an array for interoperability with other applications that expect titles to be in an array. The `primary_title` attribute is added to the indexed JSON and is sortable using the implemented sort. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

- [x] For the `primary_title` attribute to be mapped added in ES and the sort to be implemented, DataCite DOIs will need to be re-indexed.  

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->

We tested the first, non-cached load of the /dois endpoint locally using multiple ES title sort methods. The [Elasticsearch guide on "Scripts, caching, and search speed"](https://www.elastic.co/guide/en/elasticsearch/reference/current/scripts-and-search-speed.html) indicated that the only ways to improve search speed for a larger index with script sorts is to create an ingest pipeline with script processor and reindex. Rather than manage the additional suggested attribute with a script processor in ES, it seems better to consolidate the attribute logic in the Doi mode. 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
