### PR TITLE
Makes /dois endpoint title sort case insensitive

### DIFF
--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -44,9 +44,9 @@ class DataciteDoisController < ApplicationController
       when "-citation-count"
         { citation_count: { order: "desc" } }
       when "title"
-        { "primary_title.title.keyword": { order: "asc" } }
+        { "primary_title.title.raw": { order: "asc" } }
       when "-title"
-        { "primary_title.title.keyword": { order: "desc" } }
+        { "primary_title.title.raw": { order: "desc" } }
       when "relevance"
         { "_score": { "order": "desc" } }
       else

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -504,7 +504,7 @@ class Doi < ApplicationRecord
       indexes :reference_ids, type: :keyword
       indexes :citation_ids, type: :keyword
       indexes :primary_title, type: :object, properties: {
-        title: { type: :text, fields: { keyword: { type: "keyword" } } },
+        title: { type: :text, fields: { keyword: { type: "keyword" }, raw: { type: "text", analyzer: "string_lowercase", "fielddata": true } } },
         titleType: { type: :keyword },
         lang: { type: :keyword },
       }

--- a/spec/requests/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois_spec.rb
@@ -373,8 +373,12 @@ describe DataciteDoisController, type: :request, vcr: true do
         create(:doi, titles: [{ "title" => "Zack" }]),
         create(:doi, titles: [{ "title" => "Alphonso" }, { "title" => "Zorro", "titleType" => "AlternativeTitle" }]),
         create(:doi, titles: [{ "title" => "Corey" }]),
+        create(:doi, titles: [{ "title" => "Adorno" }]),
+        create(:doi, titles: [{ "title" => "acorn" }]),
+        create(:doi, titles: [{ "title" => "zoey" }]),
         create(:doi, titles: nil),
         create(:doi, titles: []),
+        create(:doi, titles: [{ "title" => "" }]),
       ]
     }
 
@@ -388,8 +392,10 @@ describe DataciteDoisController, type: :request, vcr: true do
 
       result = json.dig("data")
 
-      expect(result.dig(0, "attributes", "titles")).to eq(dois[2].titles)
-      expect(result.dig(1, "attributes", "titles")).to eq(dois[0].titles)
+      expect(result.dig(0, "attributes", "titles")).to eq(dois[9].titles)
+      expect(result.dig(1, "attributes", "titles")).to eq(dois[5].titles)
+      expect(result.dig(2, "attributes", "titles")).to eq(dois[4].titles)
+      expect(result.dig(3, "attributes", "titles")).to eq(dois[2].titles)
     end
 
     it "returns dois in descending title sort order" do
@@ -397,8 +403,9 @@ describe DataciteDoisController, type: :request, vcr: true do
 
       result = json.dig("data")
 
-      expect(result.dig(0, "attributes", "titles")).to eq(dois[1].titles)
-      expect(result.dig(1, "attributes", "titles")).to eq(dois[3].titles)
+      expect(result.dig(0, "attributes", "titles")).to eq(dois[6].titles)
+      expect(result.dig(1, "attributes", "titles")).to eq(dois[1].titles)
+      expect(result.dig(2, "attributes", "titles")).to eq(dois[3].titles)
     end
   end
 


### PR DESCRIPTION
Fixes #890

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Changes the mapping for Doi `primary_title.title` to allow for case insensitive sorting. 

closes: #890 

## Approach
<!--- _How does this change address the problem?_ -->

Mirrors other mappings like that for the `name` field, which use the `string_lowercase` analyzer for case insensitivity. 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
