### PR TITLE
Adjusts validation of Doi language attribute to allow non-ISO 639-1 values

### DIFF
--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -1938,8 +1938,7 @@ class Doi < ApplicationRecord
   end
 
   def check_language
-    entry = ISO_639.find_by_code(language) || ISO_639.find_by_english_name(language.upcase_first)
-    errors.add(:language, "Language #{language} not found.") if entry.blank?
+    errors.add(:language, "Language #{language} not found.") if !language.match?(/^[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*$/)
   end
 
   # To be used for isolated clean up of errored individual DOIs
@@ -2216,9 +2215,12 @@ class Doi < ApplicationRecord
   def update_language
     lang = language.to_s.split("-").first
     entry = ISO_639.find_by_code(lang) || ISO_639.find_by_english_name(lang.upcase_first)
-    self.language = if entry.present? && entry.alpha2.present?
-      entry.alpha2
-    end
+    self.language = 
+      if entry.present? && entry.alpha2.present?
+        entry.alpha2
+      elsif language.match?(/^[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*$/)
+        language
+      end
   end
 
   def update_field_of_science

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -124,6 +124,7 @@ class Doi < ApplicationRecord
   validate :check_related_items, if: :related_items?
   validate :check_funding_references, if: :funding_references?
   validate :check_geo_locations, if: :geo_locations?
+  validate :check_language, if: :language?
 
   after_commit :update_url, on: %i[create update]
   after_commit :update_media, on: %i[create update]
@@ -131,6 +132,7 @@ class Doi < ApplicationRecord
   before_validation :update_xml, if: :regenerate
   before_validation :update_agency
   before_validation :update_field_of_science
+  before_validation :update_language, if: :language?
   before_validation :update_rights_list, if: :rights_list?
   before_validation :update_identifiers
   before_validation :update_types
@@ -1683,16 +1685,6 @@ class Doi < ApplicationRecord
     write_attribute(:types, value || {})
   end
 
-  def language=(value)
-    lang = value.to_s.split("-").first
-    entry = ISO_639.find_by_code(lang) || ISO_639.find_by_english_name(lang.upcase_first) if lang
-    if entry.present? && entry.alpha2.present?
-      write_attribute(:language, entry.alpha2 || nil)
-    else
-      write_attribute(:language, value || nil)
-    end
-  end
-
   def landing_page=(value)
     write_attribute(:landing_page, value || {})
   end
@@ -1943,6 +1935,11 @@ class Doi < ApplicationRecord
 
   def check_container
     errors.add(:container, "Container '#{container}' should be an object instead of a string.") unless container.is_a?(Hash)
+  end
+
+  def check_language
+    entry = ISO_639.find_by_code(language) || ISO_639.find_by_english_name(language.upcase_first)
+    errors.add(:language, "Language #{language} not found.") if entry.blank?
   end
 
   # To be used for isolated clean up of errored individual DOIs
@@ -2213,6 +2210,14 @@ class Doi < ApplicationRecord
     else
       self.agency = "datacite"
       self.type = "DataciteDoi"
+    end
+  end
+
+  def update_language
+    lang = language.to_s.split("-").first
+    entry = ISO_639.find_by_code(lang) || ISO_639.find_by_english_name(lang.upcase_first)
+    self.language = if entry.present? && entry.alpha2.present?
+      entry.alpha2
     end
   end
 

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -2215,7 +2215,7 @@ class Doi < ApplicationRecord
   def update_language
     lang = language.to_s.split("-").first
     entry = ISO_639.find_by_code(lang) || ISO_639.find_by_english_name(lang.upcase_first)
-    self.language = 
+    self.language =
       if entry.present? && entry.alpha2.present?
         entry.alpha2
       elsif language.match?(/^[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*$/)

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -1938,7 +1938,7 @@ class Doi < ApplicationRecord
   end
 
   def check_language
-    errors.add(:language, "Language #{language} not found.") if !language.match?(/^[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*$/)
+    errors.add(:language, "Language #{language} is in an invalid format.") if !language.match?(/^[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*$/)
   end
 
   # To be used for isolated clean up of errored individual DOIs

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -298,18 +298,17 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
       expect(doi.language).to eq("fr")
     end
 
-    it "non-iso 639-1" do
+    it "error" do
       doi.language = "hhh"
       expect(doi.save).to be true
       expect(doi.errors.details).to be_empty
-      expect(doi.language).to eq("hhh")
+      expect(doi.language).to be_nil
     end
 
     it "nil" do
       doi.language = nil
       expect(doi.save).to be true
       expect(doi.errors.details).to be_empty
-      expect(doi.language).to be_nil
     end
   end
 

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -298,8 +298,29 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
       expect(doi.language).to eq("fr")
     end
 
-    it "error" do
+    it "human longer than 8 characters" do
+      doi.language = "Indonesian"
+      expect(doi.save).to be true
+      expect(doi.errors.details).to be_empty
+      expect(doi.language).to eq("id")
+    end
+
+    it "non-iso 639-1" do
       doi.language = "hhh"
+      expect(doi.save).to be true
+      expect(doi.errors.details).to be_empty
+      expect(doi.language).to eq("hhh")
+    end
+
+    it "non-iso 639-1 with country code" do
+      doi.language = "prq-PE"
+      expect(doi.save).to be true
+      expect(doi.errors.details).to be_empty
+      expect(doi.language).to eq("prq-PE")
+    end
+
+    it "fails xs:language regex" do
+      doi.language = "Borgesian"
       expect(doi.save).to be true
       expect(doi.errors.details).to be_empty
       expect(doi.language).to be_nil

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -298,17 +298,18 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
       expect(doi.language).to eq("fr")
     end
 
-    it "error" do
+    it "non-iso 639-1" do
       doi.language = "hhh"
       expect(doi.save).to be true
       expect(doi.errors.details).to be_empty
-      expect(doi.language).to be_nil
+      expect(doi.language).to eq("hhh")
     end
 
     it "nil" do
       doi.language = nil
       expect(doi.save).to be true
       expect(doi.errors.details).to be_empty
+      expect(doi.language).to be_nil
     end
   end
 


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Removes validation of the Doi model's language attribute to allow non-ISO 639-1 free-text values. Allows for free-text entry in the Language property per datacite/datacite#1590

## Approach
<!--- _How does this change address the problem?_ -->

I removed the language attribute validations in the Doi model and moved the logic to a computed attribute. ISO 639-1 codes and ISO 639-1 "name" values (like "English") are still normalized to a ISO 639-1 code. Free-text values that are neither ISO 639-1 codes or ISO 639-1 "name" values are saved as submitted. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

- [ ] The XSD uses a `xs:language` type for the language property. Registered/findable metadata can produce the following errors if the language attribute contains commas, dashes, and/or other special characters. Permitting any text may cause unexpected validation errors because the attribute text had been previously normalized to a ISO 639-1 code or `nil`.

```{
    "source": "language",
    "uid": "10.14454/z5bs-0327",
    "title": "DOI 10.14454/z5bs-0327: 'Borgesian, Spanish' is not a valid value of the atomic type 'xs:language'. at line 15, column 0"
}
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
