### PR TITLE
Add missing method for subject assignment used by the RepositoriesController

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -499,6 +499,10 @@ class Client < ApplicationRecord
     write_attribute(:re3data_id, attr)
   end
 
+  def subjects=(value)
+    write_attribute(:subjects, Array.wrap(value))
+  end
+
   def opendoar=(value)
     attr = value.present? ? value[38..-1] : nil
     write_attribute(:opendoar_id, attr)


### PR DESCRIPTION
## Purpose
Sentry reports an error when trying to assign a subject to a repository

closes: #898 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
