### PR TITLE
Fix ES index definition to match the JSON data structure

### DIFF
--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -283,7 +283,7 @@ class Doi < ApplicationRecord
         edition: { type: :keyword },
         contributors: { type: :object, properties: {
           contributorType: { type: :text },
-          contributorName: { type: :text },
+          name: { type: :text },
           nameType: { type: :text },
           givenName: { type: :text },
           familyName: { type: :text },
@@ -301,6 +301,7 @@ class Doi < ApplicationRecord
         funderName: { type: :keyword },
         funderIdentifier: { type: :keyword, normalizer: "keyword_lowercase" },
         funderIdentifierType: { type: :keyword },
+        schemeUri: {type: :keyword}
         awardNumber: { type: :keyword },
         awardUri: { type: :keyword },
         awardTitle: { type: :keyword },
@@ -308,6 +309,7 @@ class Doi < ApplicationRecord
       indexes :dates, type: :object, properties: {
         date: { type: :text },
         dateType: { type: :keyword },
+        dateInformation: {type: :keyword},
       }
       indexes :geo_locations, type: :object, properties: {
         geoLocationPoint: { type: :object },


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
Fixes various inconsistencies between the ES index mapping and the way the JSON data that populates it is generated by Bolognese

closes: #849, #906, #907 

## Approach
<!--- _How does this change address the problem?_ -->
Update the mappings in the DOI model

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->
Post-merge & deploy - this will require a re-templating of the `dois` index in ES to generate a new mapping, and not just a reindex.

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
