### PR TITLE
Explicitly set the is_write_index key on every switch_index option

### DIFF
--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -1099,6 +1099,7 @@ module Indexable
               add: {
                 index: index_name,
                 alias: alias_name,
+                is_write_index: is_write_index,
               },
             },
           ],


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
Currently when running the `datacite_doi:switch_index` task and _only_ when moving from `dois_v2` to `dois_v1`, the `is_write_index` flag is not set due to faulty logic in the Indexable concern. This prevents ES from indexing any new DOIs, causing significant errors with REST API functionality.

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->
Explicitly sets `is_write_index` in both branches of the `switch_index` rake task logic.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
