### PR TITLE
Add some optional batch_size to rake import

### DIFF
--- a/lib/tasks/client.rake
+++ b/lib/tasks/client.rake
@@ -53,7 +53,9 @@ namespace :client do
 
   desc "Import all clients"
   task import: :environment do
-    Client.import(index: Client.inactive_index)
+    batch_size = ENV["BATCH_SIZE"].nil? ? 10 : ENV["BATCH_SIZE"].to_i
+
+    Client.import(index: Client.inactive_index, batch_size: batch_size)
   end
 
   desc "Delete from index by query"

--- a/lib/tasks/prefix.rake
+++ b/lib/tasks/prefix.rake
@@ -43,7 +43,9 @@ namespace :prefix do
 
   desc "Import all prefixes"
   task import: :environment do
-    Prefix.import(index: ENV["INDEX"] || Prefix.inactive_index, batch_size: (ENV["BATCH_SIZE"] || 100).to_i)
+    batch_size = ENV["BATCH_SIZE"].nil? ? 100 : ENV["BATCH_SIZE"].to_i
+
+    Prefix.import(index: ENV["INDEX"] || Prefix.inactive_index, batch_size: batch_size)
   end
 
   desc "Create alias for prefixes"

--- a/lib/tasks/provider.rake
+++ b/lib/tasks/provider.rake
@@ -53,7 +53,9 @@ namespace :provider do
 
   desc "Import all providers"
   task import: :environment do
-    Provider.import(index: Provider.inactive_index)
+    batch_size = ENV["BATCH_SIZE"].nil? ? 10 : ENV["BATCH_SIZE"].to_i
+
+    Provider.import(index: Provider.inactive_index, batch_size: batch_size)
   end
 
   desc "Export all providers to Salesforce"

--- a/lib/tasks/provider_prefix.rake
+++ b/lib/tasks/provider_prefix.rake
@@ -43,7 +43,9 @@ namespace :provider_prefix do
 
   desc "Import all provider_prefixes"
   task import: :environment do
-    ProviderPrefix.import(index: ENV["INDEX"] || ProviderPrefix.inactive_index, batch_size: (ENV["BATCH_SIZE"] || 100).to_i)
+    batch_size = ENV["BATCH_SIZE"].nil? ? 100 : ENV["BATCH_SIZE"].to_i
+
+    ProviderPrefix.import(index: ENV["INDEX"] || ProviderPrefix.inactive_index, batch_size: batch_size)
   end
 
   desc "Create alias for provider_prefixes"


### PR DESCRIPTION
## Purpose
Client imports on staging fail due to elasticsearch document size being different.
While you can run in rails console, this makes defaults and optional overrides as necessary on rake tasks.

## Approach
N/A

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
Talking about it.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
