### PR TITLE
Doi-enrichment Redo

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -187,6 +187,16 @@ type Audiovisual implements DoiItem {
   fieldsOfScience: [FieldOfScience!]
 
   """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
+
+  """
   Technical format of the resource
   """
   formats: [String!]
@@ -496,6 +506,16 @@ type Book implements DoiItem {
   fieldsOfScience: [FieldOfScience!]
 
   """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
+
+  """
   Technical format of the resource
   """
   formats: [String!]
@@ -758,6 +778,16 @@ type BookChapter implements DoiItem {
   OECD Fields of Science of the resource
   """
   fieldsOfScience: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
 
   """
   Technical format of the resource
@@ -1154,6 +1184,16 @@ type Collection implements DoiItem {
   fieldsOfScience: [FieldOfScience!]
 
   """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
+
+  """
   Technical format of the resource
   """
   formats: [String!]
@@ -1460,6 +1500,16 @@ type ConferencePaper implements DoiItem {
   OECD Fields of Science of the resource
   """
   fieldsOfScience: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
 
   """
   Technical format of the resource
@@ -2063,6 +2113,16 @@ type DataManagementPlan implements DoiItem {
   fieldsOfScience: [FieldOfScience!]
 
   """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
+
+  """
   Technical format of the resource
   """
   formats: [String!]
@@ -2372,6 +2432,16 @@ type DataPaper implements DoiItem {
   fieldsOfScience: [FieldOfScience!]
 
   """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
+
+  """
   Technical format of the resource
   """
   formats: [String!]
@@ -2678,6 +2748,16 @@ type Dataset implements DoiItem {
   OECD Fields of Science of the resource
   """
   fieldsOfScience: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
 
   """
   Technical format of the resource
@@ -3107,6 +3187,16 @@ type Dissertation implements DoiItem {
   fieldsOfScience: [FieldOfScience!]
 
   """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
+
+  """
   Technical format of the resource
   """
   formats: [String!]
@@ -3417,6 +3507,16 @@ interface DoiItem {
   OECD Fields of Science of the resource
   """
   fieldsOfScience: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
 
   """
   Technical format of the resource
@@ -3733,6 +3833,16 @@ type Event implements DoiItem {
   fieldsOfScience: [FieldOfScience!]
 
   """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
+
+  """
   Technical format of the resource
   """
   formats: [String!]
@@ -4024,6 +4134,16 @@ type EventData implements DoiItem {
   OECD Fields of Science of the resource
   """
   fieldsOfScience: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
 
   """
   Technical format of the resource
@@ -4615,6 +4735,16 @@ type Image implements DoiItem {
   fieldsOfScience: [FieldOfScience!]
 
   """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
+
+  """
   Technical format of the resource
   """
   formats: [String!]
@@ -4922,6 +5052,16 @@ type Instrument implements DoiItem {
   fieldsOfScience: [FieldOfScience!]
 
   """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
+
+  """
   Technical format of the resource
   """
   formats: [String!]
@@ -5227,6 +5367,16 @@ type InteractiveResource implements DoiItem {
   OECD Fields of Science of the resource
   """
   fieldsOfScience: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
 
   """
   Technical format of the resource
@@ -5540,6 +5690,16 @@ type JournalArticle implements DoiItem {
   OECD Fields of Science of the resource
   """
   fieldsOfScience: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
 
   """
   Technical format of the resource
@@ -6146,6 +6306,16 @@ type Model implements DoiItem {
   fieldsOfScience: [FieldOfScience!]
 
   """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
+
+  """
   Technical format of the resource
   """
   formats: [String!]
@@ -6626,6 +6796,16 @@ type Other implements DoiItem {
   fieldsOfScience: [FieldOfScience!]
 
   """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
+
+  """
   Technical format of the resource
   """
   formats: [String!]
@@ -6957,6 +7137,16 @@ type PeerReview implements DoiItem {
   OECD Fields of Science of the resource
   """
   fieldsOfScience: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
 
   """
   Technical format of the resource
@@ -7404,6 +7594,16 @@ type PhysicalObject implements DoiItem {
   fieldsOfScience: [FieldOfScience!]
 
   """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
+
+  """
   Technical format of the resource
   """
   formats: [String!]
@@ -7765,6 +7965,16 @@ type Preprint implements DoiItem {
   fieldsOfScience: [FieldOfScience!]
 
   """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
+
+  """
   Technical format of the resource
   """
   formats: [String!]
@@ -8071,6 +8281,16 @@ type Publication implements DoiItem {
   OECD Fields of Science of the resource
   """
   fieldsOfScience: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
 
   """
   Technical format of the resource
@@ -9026,6 +9246,16 @@ type Service implements DoiItem {
   fieldsOfScience: [FieldOfScience!]
 
   """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
+
+  """
   Technical format of the resource
   """
   formats: [String!]
@@ -9333,6 +9563,16 @@ type Software implements DoiItem {
   OECD Fields of Science of the resource
   """
   fieldsOfScience: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
 
   """
   Technical format of the resource
@@ -9672,6 +9912,16 @@ type Sound implements DoiItem {
   OECD Fields of Science of the resource
   """
   fieldsOfScience: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
 
   """
   Technical format of the resource
@@ -10193,6 +10443,16 @@ type Work implements DoiItem {
   fieldsOfScience: [FieldOfScience!]
 
   """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
+
+  """
   Technical format of the resource
   """
   formats: [String!]
@@ -10391,6 +10651,8 @@ type WorkConnectionWithTotal {
   """
   edges: [WorkEdge]
   fieldsOfScience: [Facet!]
+  fieldsOfScienceCombined: [Facet!]
+  fieldsOfScienceRepository: [Facet!]
   languages: [Facet!]
   licenses: [Facet!]
 
@@ -10505,6 +10767,16 @@ type Workflow implements DoiItem {
   OECD Fields of Science of the resource
   """
   fieldsOfScience: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the resource and containing repository
+  """
+  fieldsOfScienceCombined: [FieldOfScience!]
+
+  """
+  OECD Fields of Science of the containing repository
+  """
+  fieldsOfScienceRepository: [FieldOfScience!]
 
   """
   Technical format of the resource

--- a/app/graphql/types/doi_item.rb
+++ b/app/graphql/types/doi_item.rb
@@ -66,6 +66,15 @@ module DoiItem
   field :fields_of_science,
         [FieldOfScienceType],
         null: true, description: "OECD Fields of Science of the resource"
+
+  field :fields_of_science_combined,
+        [FieldOfScienceType],
+        null: true, description: "OECD Fields of Science of the resource and containing repository"
+
+  field :fields_of_science_repository,
+        [FieldOfScienceType],
+        null: true, description: "OECD Fields of Science of the containing repository"
+
   field :dates,
         [DateType],
         null: true, description: "Different dates relevant to the work"
@@ -418,13 +427,32 @@ module DoiItem
     { id: object.agency, name: REGISTRATION_AGENCIES[object.agency] }.compact
   end
 
-  def fields_of_science
+  def _fos_to_facet(fos_list)
+    Array.wrap(fos_list).map do |name|
+      { "id" => name.parameterize(separator: "_"), "name" => name }
+    end.uniq
+  end
+
+  def fields_of_science_repository
+    if object.client.blank?
+      return []
+    end
+    _fos_to_facet(object.fields_of_science_repository)
+  end
+
+  def fields_of_science_combined
+    _fos_to_facet(object.fields_of_science_combined)
+  end
+
+  def _fos_temp
     Array.wrap(object.subjects).select do |s|
       s["subjectScheme"] == "Fields of Science and Technology (FOS)"
     end.map do |s|
-      name = s["subject"].gsub("FOS: ", "")
-      { "id" => name.parameterize(separator: "_"), "name" => name }
+      s["subject"].gsub("FOS: ", "")
     end.uniq
+  end
+  def fields_of_science
+    _fos_to_facet(_fos_temp)
   end
 
   def creators(**args)

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -277,7 +277,12 @@ class QueryType < BaseObject
   end
 
   def works(**args)
-    ElasticsearchModelResponseConnection.new(response(args), context: context, first: args[:first], after: args[:after])
+    ElasticsearchModelResponseConnection.new(
+      response(args), {
+      context: context,
+      first: args[:first],
+      after: args[:after]
+    })
   end
 
   field :work, WorkType, null: false do
@@ -1253,7 +1258,37 @@ class QueryType < BaseObject
   end
 
   def response(**args)
-    Doi.gql_query(args[:query], ids: args[:ids], user_id: args[:user_id], client_id: args[:repository_id], provider_id: args[:member_id], resource_type_id: args[:resource_type_id], resource_type: args[:resource_type], published: args[:published], agency: args[:registration_agency], language: args[:language], license: args[:license], has_person: args[:has_person], has_funder: args[:has_funder], has_organization: args[:has_organization], has_affiliation: args[:has_affiliation], has_member: args[:has_member], has_citations: args[:has_citations], has_parts: args[:has_parts], has_versions: args[:has_versions], has_views: args[:has_views], has_downloads: args[:has_downloads], field_of_science: args[:field_of_science], facet_count: args[:facet_count], pid_entity: args[:pid_entity], state: "findable", page: { cursor: args[:after].present? ? Base64.urlsafe_decode64(args[:after]) : [], size: args[:first] })
+    Doi.gql_query(
+      args[:query],
+      ids: args[:ids],
+      user_id: args[:user_id],
+      client_id: args[:repository_id],
+      provider_id: args[:member_id],
+      resource_type_id: args[:resource_type_id],
+      resource_type: args[:resource_type],
+      published: args[:published],
+      agency: args[:registration_agency],
+      language: args[:language],
+      license: args[:license],
+      has_person: args[:has_person],
+      has_funder: args[:has_funder],
+      has_organization: args[:has_organization],
+      has_affiliation: args[:has_affiliation],
+      has_member: args[:has_member],
+      has_citations: args[:has_citations],
+      has_parts: args[:has_parts],
+      has_versions: args[:has_versions],
+      has_views: args[:has_views],
+      has_downloads: args[:has_downloads],
+      field_of_science: args[:field_of_science],
+      facet_count: args[:facet_count],
+      pid_entity: args[:pid_entity],
+      state: "findable",
+      page: {
+        cursor: args[:after].present? ? Base64.urlsafe_decode64(args[:after]) : [],
+        size: args[:first]
+      }
+    )
   end
 
   def set_doi(id)

--- a/app/graphql/types/work_connection_with_total_type.rb
+++ b/app/graphql/types/work_connection_with_total_type.rb
@@ -17,6 +17,8 @@ class WorkConnectionWithTotalType < BaseConnection
   field :affiliations, [FacetType], null: true, cache: true
   field :authors, [FacetType], null: true, cache: true
   field :fields_of_science, [FacetType], null: true, cache: true
+  field :fields_of_science_combined, [FacetType], null: true, cache: true
+  field :fields_of_science_repository, [FacetType], null: true, cache: true
   field :licenses, [FacetType], null: true, cache: true
   field :languages, [FacetType], null: true, cache: true
 
@@ -101,6 +103,22 @@ class WorkConnectionWithTotalType < BaseConnection
   def fields_of_science
     if object.aggregations.fields_of_science
       facet_by_fos(object.aggregations.fields_of_science.subject.buckets)
+    else
+      []
+    end
+  end
+
+  def fields_of_science_combined
+    if object.aggregations.fields_of_science_combined
+      facet_by_fos(object.aggregations.fields_of_science_combined.buckets)
+    else
+      []
+    end
+  end
+
+  def fields_of_science_repository
+    if object.aggregations.fields_of_science_repository
+      facet_by_fos(object.aggregations.fields_of_science_repository.buckets)
     else
       []
     end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -52,6 +52,7 @@ class Client < ApplicationRecord
   attr_accessor :password_input, :target_id
   attr_reader :from_salesforce
 
+  validate :subjects_only_for_disciplinary_repos
   validates :subjects, if: :subjects?,
             json: {
               message: ->(errors) { errors },
@@ -96,6 +97,7 @@ class Client < ApplicationRecord
   has_many :activities, as: :auditable, dependent: :destroy
 
   before_validation :set_defaults
+  before_validation :convert_subject_hashes_to_camelcase
   before_create { self.created = Time.zone.now.utc.iso8601 }
   before_save { self.updated = Time.zone.now.utc.iso8601 }
   after_create :assign_prefix
@@ -396,6 +398,7 @@ class Client < ApplicationRecord
         end,
       "analytics_dashboard_url" => analytics_dashboard_url,
       "analytics_tracking_id" => analytics_tracking_id,
+      "subjects" => Array.wrap(subjects),
     }
   end
 
@@ -504,7 +507,7 @@ class Client < ApplicationRecord
   end
 
   def subjects=(value)
-    write_attribute(:subjects, Array.wrap(value))
+    write_attribute(:subjects, Array.wrap(value).uniq)
   end
 
   def opendoar=(value)
@@ -910,6 +913,15 @@ class Client < ApplicationRecord
       errors.add(:symbol, "cannot be changed") if symbol_changed?
     end
 
+    def subjects_only_for_disciplinary_repos
+      if Array.wrap(subjects).any? && Array.wrap(repository_type).exclude?("disciplinary")
+        errors.add(
+          :subjects,
+          "Subjects are only allowed for disciplinary repositories.  This repository_type is: #{repository_type}",
+        )
+      end
+    end
+
     def check_id
       if symbol && symbol.split(".").first != provider.symbol
         errors.add(
@@ -955,7 +967,7 @@ class Client < ApplicationRecord
         ClientPrefix.create(
           client_id: symbol,
           provider_prefix_id: provider_prefix.uid,
-          prefix_id: provider_prefix.prefix.uid,
+          prefix_id: provider_prefix.prefix.uid
         )
       end
     end
@@ -978,6 +990,18 @@ class Client < ApplicationRecord
       self.role_name = "ROLE_DATACENTRE" if role_name.blank?
       self.doi_quota_used = 0 unless doi_quota_used.to_i > 0
       self.doi_quota_allowed = -1 unless doi_quota_allowed.to_i > 0
+    end
+
+    def convert_subject_hashes_to_camelcase
+      if self.subjects?
+        self.subjects = Array.wrap(self.subjects).map { |subject|
+          subject.transform_keys! do |key|
+            key.to_s.camelcase(:lower)
+          end
+        }
+      else
+        []
+      end
     end
 
     def create_reference_repository

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -104,7 +104,7 @@ class Client < ApplicationRecord
   after_create_commit :create_reference_repository
   after_update_commit :update_reference_repository
   after_destroy_commit :destroy_reference_repository
-  after_commit on: %i[create update] do
+  after_commit on: %i[update] do
     ::Client.import_dois(self.symbol)
   end
 

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -104,6 +104,9 @@ class Client < ApplicationRecord
   after_create_commit :create_reference_repository
   after_update_commit :update_reference_repository
   after_destroy_commit :destroy_reference_repository
+  after_commit on: %i[create update] do
+    ::Client.import_dois(self.symbol)
+  end
 
   # use different index for testing
   if Rails.env.test?

--- a/app/models/datacite_doi.rb
+++ b/app/models/datacite_doi.rb
@@ -39,12 +39,13 @@ class DataciteDoi < Doi
           DataciteDoi.where(type: "DataciteDoi").maximum(:id)
       ).
         to_i
+    batch_size = options[:batch_size] || 50
     count = 0
 
     # TODO remove query for type once STI is enabled
     # SQS message size limit is 256 kB, up to 2 GB with S3
     DataciteDoi.where(type: "DataciteDoi").where(id: from_id..until_id).
-      find_in_batches(batch_size: 50) do |dois|
+      find_in_batches(batch_size: batch_size) do |dois|
       ids = dois.pluck(:id)
       DataciteDoiImportInBulkJob.perform_later(ids, index: index)
       count += ids.length

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -141,6 +141,8 @@ class Doi < ApplicationRecord
   before_save :set_defaults, :save_metadata
   before_create { self.created = Time.zone.now.utc.iso8601 }
 
+  FIELD_OF_SCIENCE_SCHEME = "Fields of Science and Technology (FOS)"
+
   scope :q, ->(query) { where("dataset.doi = ?", query) }
 
   # use different index for testing
@@ -408,6 +410,14 @@ class Doi < ApplicationRecord
         updated: { type: :date },
         deleted_at: { type: :date },
         cumulative_years: { type: :integer, index: "false" },
+        subjects: { type: :object, properties: {
+          subjectScheme: { type: :keyword },
+          subject: { type: :keyword },
+          schemeUri: { type: :keyword },
+          valueUri: { type: :keyword },
+          lang: { type: :keyword },
+          classificationCode: { type: :keyword },
+        } }
       }
       indexes :provider, type: :object, properties: {
         id: { type: :keyword },
@@ -512,6 +522,9 @@ class Doi < ApplicationRecord
         titleType: { type: :keyword },
         lang: { type: :keyword },
       }
+      indexes :fields_of_science, type: :keyword
+      indexes :fields_of_science_combined, type: :keyword
+      indexes :fields_of_science_repository, type: :keyword
     end
   end
 
@@ -567,6 +580,9 @@ class Doi < ApplicationRecord
       "sizes" => Array.wrap(sizes),
       "language" => language,
       "subjects" => Array.wrap(subjects),
+      "fields_of_science" => fields_of_science,
+      "fields_of_science_repository" => fields_of_science_repository,
+      "fields_of_science_combined" => fields_of_science_combined,
       "xml" => xml,
       "is_active" => is_active,
       "landing_page" => landing_page,
@@ -1699,6 +1715,26 @@ class Doi < ApplicationRecord
 
   def client_id
     client.symbol.downcase if client.present?
+  end
+
+  def _fos_filter(subject_array)
+    Array.wrap(subject_array).select { |sub|
+      sub.dig("subjectScheme") == FIELD_OF_SCIENCE_SCHEME
+    }.map do |fos|
+      fos["subject"].gsub("FOS: ", "")
+    end
+  end
+
+  def fields_of_science
+    _fos_filter(subjects).uniq
+  end
+
+  def fields_of_science_repository
+    _fos_filter(client&.subjects).uniq
+  end
+
+  def fields_of_science_combined
+    fields_of_science | fields_of_science_repository
   end
 
   def client_id_and_name

--- a/app/models/schemas/client/subjects.json
+++ b/app/models/schemas/client/subjects.json
@@ -5,34 +5,18 @@
   "items": {
       "type": "object",
       "properties": {
-        "classification_code": { "type": "string" },
         "classificationCode":  { "type": "string" },
-        "scheme_uri":          { "type": "string" },
         "schemeUri":           { "type": "string" },
-        "value_uri":           { "type": "string" },
         "valueUri":            { "type": "string" },
         "lang":                { "type": "string" },
         "subject":             { "type": "string" },
-        "subject_scheme":      { "type": "string" },
         "subjectScheme":       { "type": "string" }
       },
-      "oneOf": [
-        {
-          "required": [
-            "classification_code",
-            "scheme_uri",
-            "subject",
-            "subject_scheme"
-          ]
-        },
-        {
-          "required": [
-            "classificationCode",
-            "schemeUri",
-            "subject",
-            "subjectScheme"
-          ]
-        }
+      "required": [
+        "classificationCode",
+        "schemeUri",
+        "subject",
+        "subjectScheme"
       ],
       "additionalProperties": false
   }

--- a/db/seeds/development/base.seeds.rb
+++ b/db/seeds/development/base.seeds.rb
@@ -24,11 +24,19 @@ provider =
 client =
   Client.where(symbol: "DATACITE.TEST").first ||
   FactoryBot.create(
-    :client,
+    :client_with_fos,
     provider: provider,
     symbol: ENV["MDS_USERNAME"],
     password_input: ENV["MDS_PASSWORD"],
   )
+if Prefix.where(uid: "10.14454").blank?
+  prefix = FactoryBot.create(:prefix, uid: "10.14454")
+  ### This creates both the client_prefix and the provider association
+  FactoryBot.create(
+    :client_prefix,
+    client_id: client.symbol, prefix_id: prefix.uid,
+  )
+end
 dois = FactoryBot.create_list(:doi, 10, client: client, state: "findable")
 FactoryBot.create_list(:event_for_datacite_related, 3, obj_id: dois.first.doi)
 FactoryBot.create_list(:event_for_datacite_usage, 2, obj_id: dois.first.doi)

--- a/lib/tasks/datacite_doi.rake
+++ b/lib/tasks/datacite_doi.rake
@@ -65,8 +65,14 @@ namespace :datacite_doi do
   task import: :environment do
     from_id = (ENV["FROM_ID"] || DataciteDoi.minimum(:id)).to_i
     until_id = (ENV["UNTIL_ID"] || DataciteDoi.maximum(:id)).to_i
+    batch_size = ENV["BATCH_SIZE"].nil? ? 50 : ENV["BATCH_SIZE"].to_i
 
-    DataciteDoi.import_by_ids(from_id: from_id, until_id: until_id, index: ENV["INDEX"] || DataciteDoi.inactive_index)
+    DataciteDoi.import_by_ids(
+      from_id: from_id,
+      until_id: until_id,
+      batch_size: batch_size,
+      index: ENV["INDEX"] || DataciteDoi.inactive_index
+    )
   end
 
   desc "Import one datacite DOI"

--- a/lib/tasks/enrich.rake
+++ b/lib/tasks/enrich.rake
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+namespace :enrich do
+  desc "Enrich Clients with Subjects from re3data and converted to Field Of Science subjectScheme"
+  task client_subjects: :environment do
+    def all_clients_from_query(query: nil)
+      # Loop through all clients
+      page = { size: 1_000, number: 1 }
+      response = Client.query(query, page: page)
+      clients = response.records.to_a
+
+      total = response.records.total
+      total_pages = page[:size] > 0 ? (total.to_f / page[:size]).ceil : 0
+
+      # keep going for all pages
+      page_num = 2
+      while page_num <= total_pages
+        page = { size: 1_000, number: page_num }
+        response = self.query(query, page: page)
+        clients = clients + response.records.to_a
+        page_num += 1
+      end
+      clients
+    end
+
+    def enrich_client(client)
+      re3data = DataCatalog.find_by_id(client.re3data_id).fetch(:data, []).first
+      if re3data
+        subs = re3data.subjects
+        dfg_ids = subs.select { |subject|
+          subject.scheme == "DFG"
+        }.map { |subject|
+          subject.text.split.first
+        }
+        fos_subjects = Bolognese::Utils.dfg_ids_to_fos(dfg_ids)
+        client.subjects = fos_subjects.uniq
+        client.save
+      end
+    end
+
+    puts "Searching for disciplinary repositories with re3data_ids without subjects"
+    clients = all_clients_from_query(query: "re3data_id:* AND -subjects:* AND -deleted_at:* AND repository_type:disciplinary")
+    puts "Found #{clients.count} repostitories."
+    if clients.count > 0
+      puts "Enriching now..."
+      clients.each do |c|
+        enrich_client(c)
+      end
+      puts "Enrichment complete"
+    else
+      puts "Skipping enrichment"
+    end
+  end
+end

--- a/spec/factories/client.rb
+++ b/spec/factories/client.rb
@@ -19,6 +19,21 @@ FactoryBot.define do
     password_input { "12345" }
     is_active { true }
 
+    factory :client_with_fos do
+      repository_type { "disciplinary" }
+      subjects do
+        [
+          {
+            subject: "Physical sciences",
+            valueUri: "",
+            schemeUri: "http://www.oecd.org/science/inno/38235147.pdf",
+            subjectScheme: "Fields of Science and Technology (FOS)",
+            classificationCode: "1001",
+          },
+        ]
+      end
+    end
+
     initialize_with { Client.where(symbol: symbol).first_or_initialize }
   end
 end

--- a/spec/graphql/types/doi_item_spec.rb
+++ b/spec/graphql/types/doi_item_spec.rb
@@ -13,6 +13,9 @@ describe DoiItem do
     it { is_expected.to have_field(:publicationYear).of_type("Int") }
     it { is_expected.to have_field(:publisher).of_type("String") }
     it { is_expected.to have_field(:subjects).of_type("[Subject!]") }
+    it { is_expected.to have_field(:fieldsOfScience).of_type("[FieldOfScience!]") }
+    it { is_expected.to have_field(:fieldsOfScienceRepository).of_type("[FieldOfScience!]") }
+    it { is_expected.to have_field(:fieldsOfScienceCombined).of_type("[FieldOfScience!]") }
     it { is_expected.to have_field(:dates).of_type("[Date!]") }
     it { is_expected.to have_field(:registered).of_type("ISO8601DateTime") }
     it { is_expected.to have_field(:language).of_type("Language") }

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -15,7 +15,11 @@ describe Client, type: :model do
   end
 
   describe "subjects" do
-    let(:client) { build(:client, provider: provider) }
+    let(:client) { build(:client,
+                         provider: provider,
+                         repository_type: "disciplinary"
+                        )
+    }
     let(:valid_subjects) do
       {
        classificationCode: "6.1",
@@ -23,6 +27,12 @@ describe Client, type: :model do
        subject: "History and archaeology",
        subjectScheme: "Fields of Science and Technology (FOS)",
       }
+    end
+
+    it "are invalid if the repository_type is not disciplinary" do
+      client.repository_type = nil
+      client.subjects = [valid_subjects]
+      expect(client).to_not be_valid
     end
 
     it "valid hash" do

--- a/spec/requests/repositories_spec.rb
+++ b/spec/requests/repositories_spec.rb
@@ -413,6 +413,7 @@ describe RepositoriesController, type: :request, elasticsearch: true do
             "type" => "repositories",
             "attributes" => {
               "subjects" => subjects,
+              "repositoryType" => "disciplinary",
             },
           },
         }


### PR DESCRIPTION
## Purpose
Re-implements Doi Enrichment Part 3: Indexing dois with subject information from
their containing repositories/clients.

## Approach
Copy in code from the branch doi-enrichment-retract but leave out sections that
try to use the newly indexed fields in facets _and subsequently throwing errors._


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.

## Commits
- Index repository subjects in DOIs and specifically Field of Science subjects
- Index Client subjects.  Tighten up schema fields
- Add client specs for requiring disciplinary type
- Expose FOS fields through Doi Graphql endpoint
- Add new FOS facets/fields to Works
- Update development seeds
- Update REST repositories spec to include disciplinary repository type
- Make DOI query/params more readable
- Update Graphql Schema file
- Updating a Client will now trigger the reindex of its DOIs
- Creating a Client shouldn't trigger a DOI reindex
- Add rake task to back-fill disciplinary clients/repositories that have re3data subjects.
- Allow variable batch_size for rake datacite_doi imports
