### PR TITLE
Set ENV in github action config, not at the shell

### DIFF
--- a/.github/workflows/_update_terraform.yml
+++ b/.github/workflows/_update_terraform.yml
@@ -17,6 +17,9 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    env:
+      GIT_SHA: ${{ github.sha }}
+      GIT_TAG: ${{ inputs.image_tag }}
     steps:
       - name: Checkout terraform config repo
         uses: actions/checkout@v3
@@ -26,8 +29,6 @@ jobs:
           persist-credentials: false
       - name: Setup dokerize and template parameters
         run: |
-          export GIT_SHA=${{ github.sha }}
-          export GIT_TAG=${{ inputs.image_tag }}
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           wget https://github.com/jwilder/dockerize/releases/download/v0.6.0/dockerize-linux-amd64-v0.6.0.tar.gz


### PR DESCRIPTION
## Purpose
Fixes error in action config that resulted in mastino variables not being set.
Steps with multiple run statements only share ENV variables if set in github job, not through the shell

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
