### PR TITLE
Enable manual deployment of non-main branch to staging environment

### DIFF
--- a/.github/workflows/branch_to_staging.yml
+++ b/.github/workflows/branch_to_staging.yml
@@ -1,0 +1,26 @@
+name: Build/Deploy Branch to Staging
+on:
+  workflow_dispatch:
+env:
+  IMAGE_TAG: ${{ github.ref_name }}
+  DEPLOYMENT_ENV: staging
+jobs:
+  lint:
+    uses: ./.github/workflows/rubocop.yml
+  test:
+    uses: ./.github/workflows/parallel_ci.yml
+    secrets: inherit
+  call_build_and_push:
+    needs: test
+    uses: ./.github/workflows/build.yml
+    with:
+      image_name: ${{ github.repository }}
+      image_tag: ${{ env.IMAGE_TAG }}
+    secrets: inherit
+  deploy:
+    needs: [test, call_build_and_push]
+    uses: ./.github/workflows/_update_terraform.yml
+    with:
+      image_tag: ${{ env.IMAGE_TAG }}
+      deployment_environment: ${{ env.DEPLOYMENT_ENV }}
+    secrets: inherit

--- a/.github/workflows/branch_to_staging.yml
+++ b/.github/workflows/branch_to_staging.yml
@@ -1,9 +1,6 @@
 name: Build/Deploy Branch to Staging
 on:
   workflow_dispatch:
-env:
-  IMAGE_TAG: ${{ github.ref_name }}
-  DEPLOYMENT_ENV: staging
 jobs:
   lint:
     uses: ./.github/workflows/rubocop.yml
@@ -15,12 +12,12 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       image_name: ${{ github.repository }}
-      image_tag: ${{ env.IMAGE_TAG }}
+      image_tag: ${{ github.ref_name }}
     secrets: inherit
   deploy:
     needs: [test, call_build_and_push]
     uses: ./.github/workflows/_update_terraform.yml
     with:
-      image_tag: ${{ env.IMAGE_TAG }}
-      deployment_environment: ${{ env.DEPLOYMENT_ENV }}
+      image_tag: ${{ github.ref_name }}
+      deployment_environment: staging
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Staging
+name: Deploy Main to Staging
 on:
   push:
     branches:

--- a/.github/workflows/parallel_ci.yml
+++ b/.github/workflows/parallel_ci.yml
@@ -92,7 +92,7 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
           bundle exec rails db:setup RAILS_ENV=test
-      - name: Lint and Test
+      - name: Test
         env:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
           ES_HOST: localhost:${{ job.services.elasticsearch.ports[9200] }}

--- a/.github/workflows/reset_staging.yml
+++ b/.github/workflows/reset_staging.yml
@@ -1,14 +1,11 @@
 name: Reset Staging to Main Branch
 on:
   workflow_dispatch:
-env:
-  IMAGE_TAG: main
-  DEPLOYMENT_ENV: staging
 jobs:
   deploy:
     needs: [test, call_build_and_push]
     uses: ./.github/workflows/_update_terraform.yml
     with:
-      image_tag: ${{ env.IMAGE_TAG }}
-      deployment_environment: ${{ env.DEPLOYMENT_ENV }}
+      image_tag: main
+      deployment_environment: staging
     secrets: inherit

--- a/.github/workflows/reset_staging.yml
+++ b/.github/workflows/reset_staging.yml
@@ -1,0 +1,14 @@
+name: Reset Staging to Main Branch
+on:
+  workflow_dispatch:
+env:
+  IMAGE_TAG: main
+  DEPLOYMENT_ENV: staging
+jobs:
+  deploy:
+    needs: [test, call_build_and_push]
+    uses: ./.github/workflows/_update_terraform.yml
+    with:
+      image_tag: ${{ env.IMAGE_TAG }}
+      deployment_environment: ${{ env.DEPLOYMENT_ENV }}
+    secrets: inherit


### PR DESCRIPTION
## Purpose
Deploying non-main/master branch to the staging environment.

closes: #928 

## Approach
Creates two manual Github actions:

- The first action lets you select a branch which will be built into a docker image, tagged (with the branch name), and updates the terraform configuration for staging to point to the tagged image.
- The second action resets the terraform configuration for staging to point to the image tagged with `main`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
