### PR TITLE
Updating a Client will trigger the reindex of its DOIs

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -102,7 +102,7 @@ class Client < ApplicationRecord
   after_create_commit :create_reference_repository
   after_update_commit :update_reference_repository
   after_destroy_commit :destroy_reference_repository
-  after_commit on: %i[create update] do
+  after_commit on: %i[update] do
     ::Client.import_dois(self.symbol)
   end
 

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -102,6 +102,9 @@ class Client < ApplicationRecord
   after_create_commit :create_reference_repository
   after_update_commit :update_reference_repository
   after_destroy_commit :destroy_reference_repository
+  after_commit on: %i[create update] do
+    ::Client.import_dois(self.symbol)
+  end
 
   # use different index for testing
   if Rails.env.test?


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Updating a Client will trigger the reindex of its DOIs. Previously, ES DOI records would contain stale Client metadata if the DOI's Client was changed. 

## Approach
<!--- _How does this change address the problem?_ -->

Imports the Client's DOIs after an update. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
