### PR TITLE
Revert "Updating a Client will trigger the reindex of its DOIs"

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -102,9 +102,6 @@ class Client < ApplicationRecord
   after_create_commit :create_reference_repository
   after_update_commit :update_reference_repository
   after_destroy_commit :destroy_reference_repository
-  after_commit on: %i[update] do
-    ::Client.import_dois(self.symbol)
-  end
 
   # use different index for testing
   if Rails.env.test?


### PR DESCRIPTION
Reverting this change because the following operations either hang or appear to be unusually expensive:

https://github.com/datacite/lupo/blob/6dc44d0b02196bde871f5bbfd6871c8f2dee0c47/app/models/datacite_doi.rb#L70-L77

Reverts datacite/lupo#939