### PR TITLE
Create available prefix before creating a client in seeds

### DIFF
--- a/db/seeds/development/consortium_transfer.seeds.rb
+++ b/db/seeds/development/consortium_transfer.seeds.rb
@@ -7,6 +7,9 @@ if Rails.env.production?
 end
 
 after "development:base" do
+  if Prefix.where(uid: "10.14459").blank?
+    prefix = FactoryBot.create(:prefix, uid: "10.14459")
+  end
   provider =
     Provider.where(symbol: "QUECHUA").first ||
     FactoryBot.create(:provider, symbol: "QUECHUA")
@@ -18,21 +21,6 @@ after "development:base" do
       symbol: "QUECHUA.TEXT",
       password: ENV["MDS_PASSWORD"],
     )
-  if Prefix.where(uid: "10.14459").blank?
-    prefix = FactoryBot.create(:prefix, uid: "10.14459")
-    ## one needs to create the provider first so the assignation is made
-    provider_prefix_id =
-      FactoryBot.create(
-        :provider_prefix,
-        provider_id: provider.symbol, prefix_id: prefix.uid,
-      )
-    FactoryBot.create(
-      :client_prefix,
-      client_id: client.symbol,
-      prefix_id: prefix.uid,
-      provider_prefix_id: provider_prefix_id.uid,
-    )
-  end
   dois = FactoryBot.create_list(:doi, 10, client: client, state: "findable")
   FactoryBot.create_list(:event_for_datacite_related, 3, obj_id: dois.first.doi)
   FactoryBot.create_list(:event_for_datacite_usage, 2, obj_id: dois.first.doi)

--- a/db/seeds/development/consortium_transfer.seeds.rb
+++ b/db/seeds/development/consortium_transfer.seeds.rb
@@ -8,7 +8,7 @@ end
 
 after "development:base" do
   if Prefix.where(uid: "10.14459").blank?
-    prefix = FactoryBot.create(:prefix, uid: "10.14459")
+    FactoryBot.create(:prefix, uid: "10.14459")
   end
   provider =
     Provider.where(symbol: "QUECHUA").first ||


### PR DESCRIPTION
## Purpose
Fix error with development database seed step

## Approach
Prefixes now auto-assign when a client is created.
_but_ the prefix must be created before you create client

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
