### PR TITLE
Restrict "anonymous" role_id users to findable DOIs at /dois endpoint

### DIFF
--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -67,8 +67,8 @@ class DataciteDoisController < ApplicationController
         "types.resourceTypeGeneral"
       end
 
-    # only show findable DOIs to anonymous users and role user
-    if current_user.nil? || current_user.role_id == "user"
+    # only show findable DOIs to no user, role user, and role anonymous
+    if current_user.nil? || current_user.role_id == "user" || current_user.role_id == "anonymous"
       params[:state] = "findable"
     end
 

--- a/spec/requests/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois_spec.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+include Passwordable
 
 describe DataciteDoisController, type: :request, vcr: true do
   let(:admin) { create(:provider, symbol: "ADMIN") }
   let(:admin_bearer) { Client.generate_token(role_id: "staff_admin", uid: admin.symbol, password: admin.password) }
   let(:admin_headers) { { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => "Bearer " + admin_bearer } }
 
-  let(:provider) { create(:provider, symbol: "DATACITE") }
-  let(:client) { create(:client, provider: provider, symbol: ENV["MDS_USERNAME"], password: ENV["MDS_PASSWORD"], re3data_id: "10.17616/r3xs37") }
+  let(:provider) { create(:provider, symbol: "DATACITE", password: encrypt_password_sha256(ENV["MDS_PASSWORD"])) }
+  let(:client) { create(:client, provider: provider, symbol: ENV["MDS_USERNAME"], password: encrypt_password_sha256(ENV["MDS_PASSWORD"]), re3data_id: "10.17616/r3xs37") }
   let!(:prefix) { create(:prefix, uid: "10.14454") }
   let!(:client_prefix) { create(:client_prefix, client: client, prefix: prefix) }
 
@@ -434,6 +435,65 @@ describe DataciteDoisController, type: :request, vcr: true do
       expect(result.dig(0, "attributes", "titles")).to eq(dois[6].titles)
       expect(result.dig(1, "attributes", "titles")).to eq(dois[1].titles)
       expect(result.dig(2, "attributes", "titles")).to eq(dois[3].titles)
+    end
+  end
+
+  describe "GET /dois with authorization headers", elasticsearch: true do
+    let!(:dois) { create_list(:doi, 10, client: client, aasm_state: "findable") }
+    let!(:doi_draft) { create(:doi, client: client, aasm_state: "draft") }
+    let!(:doi_registered) { create(:doi, client: client, aasm_state: "registered") }
+    let(:anonymous_basic_auth_headers) { { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(client.symbol, "") } }
+    let(:client_basic_auth_headers) { { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(client.symbol, ENV["MDS_PASSWORD"]) } }
+    let(:provider_basic_auth_headers) { { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(provider.symbol, ENV["MDS_PASSWORD"]) } }
+
+    before do
+      DataciteDoi.import
+      sleep 2
+    end
+
+    it "return only findable dois with no authorization" do
+      get "/dois"
+
+      expect(json.dig("meta", "total")).to eq(10)
+      expect(json.dig("meta", "states", 0, "count")).to eq(10)
+      expect(json.dig("meta", "states", 1)).to eq(nil)
+      expect(json.dig("meta", "states", 2)).to eq(nil)
+    end
+
+    it "return only findable dois with anonymous user" do
+      get "/dois", nil, anonymous_basic_auth_headers
+
+      expect(json.dig("meta", "total")).to eq(10)
+      expect(json.dig("meta", "states", 0, "count")).to eq(10)
+      expect(json.dig("meta", "states", 1)).to eq(nil)
+      expect(json.dig("meta", "states", 2)).to eq(nil)
+    end
+
+    it "return dois in all states with authenticated client user" do
+      get "/dois", nil, client_basic_auth_headers
+
+      expect(json.dig("meta", "total")).to eq(12)
+      expect(json.dig("meta", "states", 0, "count")).to eq(10)
+      expect(json.dig("meta", "states", 1, "count")).to eq(1)
+      expect(json.dig("meta", "states", 2, "count")).to eq(1)
+    end
+
+    it "return dois in all states with authenticated provider user" do
+      get "/dois", nil, provider_basic_auth_headers
+
+      expect(json.dig("meta", "total")).to eq(12)
+      expect(json.dig("meta", "states", 0, "count")).to eq(10)
+      expect(json.dig("meta", "states", 1, "count")).to eq(1)
+      expect(json.dig("meta", "states", 2, "count")).to eq(1)
+    end
+
+    it "return dois in all states with authenticated admin user" do
+      get "/dois", nil, admin_headers
+
+      expect(json.dig("meta", "total")).to eq(12)
+      expect(json.dig("meta", "states", 0, "count")).to eq(10)
+      expect(json.dig("meta", "states", 1, "count")).to eq(1)
+      expect(json.dig("meta", "states", 2, "count")).to eq(1)
     end
   end
 


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Restricts users with an "anonymous" role_id to findable DOIs at the /dois endpoint. 

## Approach
<!--- _How does this change address the problem?_ -->

Adds a condition for "anonymous" users in addition to no user and "user" users.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
