### PR TITLE
Add env check on whether to disable queue workers.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,3 +69,6 @@ HS_SECKEY=password
 # Set to 0 if the test handle server has a self-signed or otherwise invalid SSL
 # certificate
 HS_SSL_VERIFY=0
+
+# Enable or disable queue worker
+DISABLE_QUEUE_WORKER=true

--- a/vendor/docker/shoryuken.sh
+++ b/vendor/docker/shoryuken.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 cd /home/app/webapp
 exec 2>&1
-if [ "$AWS_REGION" ]; then
+# If AWS_REGION is set and not explicitly disabled with DISABLE_QUEUE_WORKER, start shoryuken
+if [ -n "$AWS_REGION" ] && [ -z "$DISABLE_QUEUE_WORKER" ]; then
   exec /sbin/setuser app bundle exec shoryuken -R -C config/shoryuken.yml
 fi


### PR DESCRIPTION
## Purpose
As per the linked issue, this is just a simple env check whether to start the shorokun queue worker or not.
Basically my idea would be that we then can launch specific containers that do and do not do queue processing.

re: datacite/datacite#1848

## Approach
If the DISABLE_QUEUE_WORKER is not set (or empty) then it will run the shorokun worker in the container.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
