### PR TITLE
Fixes GraphQL errors when returning queries where DOI metadata creator/contributor nameIdentifiers properties are stored as hashes

### DIFF
--- a/app/controllers/concerns/facetable.rb
+++ b/app/controllers/concerns/facetable.rb
@@ -474,7 +474,7 @@ module Facetable
         # Filter through creators to find creator that matches the key
         matched_creator = creators.select do |creator|
           if creator.key?("nameIdentifiers")
-            creator["nameIdentifiers"].any? { |ni| ni["nameIdentifier"] == orcid_id }
+            Array.wrap(creator["nameIdentifiers"]).any? { |ni| ni["nameIdentifier"] == orcid_id }
           end
         end
 

--- a/app/graphql/types/doi_item.rb
+++ b/app/graphql/types/doi_item.rb
@@ -468,7 +468,7 @@ module DoiItem
     Array.wrap(object.creators)[0...args[:first]].map do |c|
       Hashie::Mash.new(
         "id" =>
-          c.fetch("nameIdentifiers", []).detect do |n|
+          Array.wrap(c.fetch("nameIdentifiers", [])).detect do |n|
             %w[ORCID ROR].include?(n.fetch("nameIdentifierScheme", nil))
           end.to_h.
             fetch("nameIdentifier", nil),
@@ -493,7 +493,7 @@ module DoiItem
     contrib.map do |c|
       Hashie::Mash.new(
         "id" =>
-          c.fetch("nameIdentifiers", []).detect do |n|
+          Array.wrap(c.fetch("nameIdentifiers", [])).detect do |n|
             %w[ORCID ROR].include?(n.fetch("nameIdentifierScheme", nil))
           end.to_h.
             fetch("nameIdentifier", nil),


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Fixes GraphQL errors when query results contain DOI metadata with creator/contributor `nameIdentifiers` properties stored as hashes instead of arrays in the DB and ES.

closes: #968 

## Approach
<!--- _How does this change address the problem?_ -->

Adds `Array.wrap` to calls for `nameIdentifiers` when displaying aggs and creators/contributors in GQL. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

- [ ] The underlying cause and appearance of hash `nameIdentifiers` properties still needs to be fixed. 

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
