### PR TITLE
openapi.yaml: move descriptions of structure to comments

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1394,9 +1394,7 @@ components:
             types:
               resourceTypeGeneral: Text
             url: https://schema.datacite.org/meta/kernel-4.1/       
-    DoiAttributes:
-      description: >-
-          Extended attributes for Doi model, used in /dois{id} response.
+    DoiAttributes: # Extended attributes for Doi model, used in /dois{id} response.
       allOf:
         - type: object
           properties:
@@ -1526,9 +1524,7 @@ components:
                 bodyhasPid:
                   type: boolean
         - $ref: '#/components/schemas/DoiPropertiesDates'
-    DoisAttributes:
-      description: >-
-        Doi attributes used in /dois list response.
+    DoisAttributes: # Doi attributes used in /dois list response.
       allOf:
         - type: object
           properties:


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Move descriptions of components to comments, which should not appear publicly in the [ReadMe API Reference.](https://support.datacite.org/reference/introduction)

## Approach
All descriptions appear publicly in ReadMe, for example: 
![Screen Shot 2023-06-07 at 17 05 13](https://github.com/datacite/lupo/assets/17298577/018cc62c-bb9f-4616-a37e-4be91d73470c)

When refactoring openapi.yaml, I added some descriptions to clarify where different components were being reused. This is useful information to have in the file for future development, but it isn't information that end users need when navigating the API reference.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->
"descriptions" in openapi.yaml are for the API user and differ from comments.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
