### PR TITLE
Missing related identifiers should default to empty array

### DIFF
--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -1820,7 +1820,7 @@ class Doi < ApplicationRecord
   end
 
   def related_dmp_ids
-    related_identifiers.select { |related_identifier|
+    Array.wrap(related_identifiers).select { |related_identifier|
       related_identifier["relatedIdentifierType"] == "DOI"
     }.select { |related_identifier|
       related_identifier.fetch("resourceTypeGeneral", nil) == "OutputManagementPlan"


### PR DESCRIPTION
## Purpose
While doing a full reindexing some values for related_identifiers were missing.
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: #977

## Approach
Uses `Array.wrap()` to create a new array in the case of missing values.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
