### PR TITLE
Fair viz feature 1 amendment

### DIFF
--- a/app/graphql/types/organization_type.rb
+++ b/app/graphql/types/organization_type.rb
@@ -351,8 +351,7 @@ class OrganizationType < BaseObject
     Doi.gql_query(
       args[:query],
       ids: args[:ids],
-      affiliation_id: object.id,
-      organization_id: object.id,
+      fair_organization_id: object.id,
       member_id:
         if %w[direct_member consortium_organization].include?(
           member["member_role_id"],

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -245,12 +245,15 @@ class Doi < ApplicationRecord
       indexes :consortium_id,                  type: :keyword
       indexes :resource_type_id,               type: :keyword
       indexes :affiliation_id,                 type: :keyword
+      indexes :fair_affiliation_id,            type: :keyword
       indexes :organization_id,                type: :keyword
+      indexes :fair_organization_id,           type: :keyword
       indexes :related_dmp_organization_id,    type: :keyword
       indexes :client_id_and_name,             type: :keyword
       indexes :provider_id_and_name,           type: :keyword
       indexes :resource_type_id_and_name,      type: :keyword
       indexes :affiliation_id_and_name,        type: :keyword
+      indexes :fair_affiliation_id_and_name,   type: :keyword
       indexes :media_ids,                      type: :keyword
       indexes :media,                          type: :object, properties: {
         type: { type: :keyword },
@@ -571,9 +574,12 @@ class Doi < ApplicationRecord
       "provider_id_and_name" => provider_id_and_name,
       "resource_type_id_and_name" => resource_type_id_and_name,
       "affiliation_id" => affiliation_id,
+      "fair_affiliation_id" => fair_affiliation_id,
       "organization_id" => organization_id,
+      "fair_organization_id" => fair_organization_id,
       "related_dmp_organization_id" => related_dmp_organization_and_affiliation_id,
       "affiliation_id_and_name" => affiliation_id_and_name,
+      "fair_affiliation_id_and_name" => fair_affiliation_id_and_name,
       "media_ids" => media_ids,
       "view_count" => view_count,
       "views_over_time" => views_over_time,
@@ -1021,9 +1027,17 @@ class Doi < ApplicationRecord
       # TODO: remove after organization_id has been indexed
       should << { term: { "contributors.nameIdentifiers.nameIdentifier" => "https://#{ror_from_url(options[:organization_id])}" } }
       should << { term: { "organization_id" => ror_from_url(options[:organization_id]) } }
-      should << { term: { "related_dmp_organization_id" => ror_from_url(options[:organization_id]) } }
       minimum_should_match = 1
     end
+
+    if options[:fair_organization_id].present?
+      _ror_id = ror_from_url(options[:fair_organization_id])
+      should << { term: { "fair_organization_id" => _ror_id } }
+      should << { term: { "fair_affiliation_id" => _ror_id } }
+      should << { term: { "related_dmp_organization_id" => _ror_id } }
+      minimum_should_match = 1
+    end
+
     if options[:affiliation_id].present?
       should << { term: { "affiliation_id" => ror_from_url(options[:affiliation_id]) } }
       minimum_should_match = 1
@@ -1233,7 +1247,6 @@ class Doi < ApplicationRecord
       # should << { term: { "creators.nameIdentifiers.nameIdentifier" => "https://#{ror_from_url(options[:organization_id])}" } }
       # should << { term: { "contributors.nameIdentifiers.nameIdentifier" => "https://#{ror_from_url(options[:organization_id])}" } }
       should << { term: { "organization_id" => ror_from_url(options[:organization_id]) } }
-      should << { term: { "related_dmp_organization_id" => ror_from_url(options[:organization_id]) } }
       minimum_should_match = 1
     end
     if options[:affiliation_id].present?
@@ -1835,8 +1848,8 @@ class Doi < ApplicationRecord
 
   def related_dmp_organization_and_affiliation_id
     related_dmp_works.reduce([]) do |sum, dmp|
-      sum.concat(dmp.organization_id)
-      sum.concat(dmp.affiliation_id)
+      sum.concat(dmp.fair_organization_id)
+      sum.concat(dmp.fair_affiliation_id)
 
       sum
     end
@@ -1850,6 +1863,15 @@ class Doi < ApplicationRecord
 
 
   def organization_id
+    (Array.wrap(creators) + Array.wrap(contributors)).reduce([]) do |sum, c|
+      Array.wrap(c.fetch("nameIdentifiers", nil)).each do |name_identifier|
+        sum << ror_from_url(name_identifier.fetch("nameIdentifier", nil)) if name_identifier.is_a?(Hash) && name_identifier.fetch("nameIdentifierScheme", nil) == "ROR" && name_identifier.fetch("nameIdentifier", nil).present?
+      end
+      sum
+    end
+  end
+
+  def fair_organization_id
     (Array.wrap(creators) + sponsor_contributors).reduce([]) do |sum, c|
       Array.wrap(c.fetch("nameIdentifiers", nil)).each do |name_identifier|
         sum << ror_from_url(name_identifier.fetch("nameIdentifier", nil)) if name_identifier.is_a?(Hash) && name_identifier.fetch("nameIdentifierScheme", nil) == "ROR" && name_identifier.fetch("nameIdentifier", nil).present?
@@ -1859,24 +1881,41 @@ class Doi < ApplicationRecord
   end
 
   def affiliation_id
+    (Array.wrap(creators) + Array.wrap(contributors)).reduce([]) do |sum, c|
+      Array.wrap(c.fetch("affiliation", nil)).each do |affiliation|
+        sum << ror_from_url(affiliation.fetch("affiliationIdentifier", nil)) if affiliation.is_a?(Hash) && affiliation.fetch("affiliationIdentifierScheme", nil) == "ROR" && affiliation.fetch("affiliationIdentifier", nil).present?
+      end
+      sum
+    end
+  end
+
+  def fair_affiliation_id
     (Array.wrap(creators) + sponsor_contributors).reduce([]) do |sum, c|
       Array.wrap(c.fetch("affiliation", nil)).each do |affiliation|
         sum << ror_from_url(affiliation.fetch("affiliationIdentifier", nil)) if affiliation.is_a?(Hash) && affiliation.fetch("affiliationIdentifierScheme", nil) == "ROR" && affiliation.fetch("affiliationIdentifier", nil).present?
       end
-
       sum
     end
   end
 
   def affiliation_id_and_name
+    (Array.wrap(creators) + Array.wrap(contributors)).reduce([]) do |sum, c|
+      Array.wrap(c.fetch("affiliation", nil)).each do |affiliation|
+        sum << "#{ror_from_url(affiliation.fetch('affiliationIdentifier', nil))}:#{affiliation.fetch('name', nil)}" if affiliation.is_a?(Hash) && affiliation.fetch("affiliationIdentifierScheme", nil) == "ROR" && affiliation.fetch("affiliationIdentifier", nil).present?
+      end
+      sum
+    end
+  end
+
+  def fair_affiliation_id_and_name
     (Array.wrap(creators) + sponsor_contributors).reduce([]) do |sum, c|
       Array.wrap(c.fetch("affiliation", nil)).each do |affiliation|
         sum << "#{ror_from_url(affiliation.fetch('affiliationIdentifier', nil))}:#{affiliation.fetch('name', nil)}" if affiliation.is_a?(Hash) && affiliation.fetch("affiliationIdentifierScheme", nil) == "ROR" && affiliation.fetch("affiliationIdentifier", nil).present?
       end
-
       sum
     end
   end
+
 
   def prefix
     doi.split("/", 2).first if doi.present?

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -1820,7 +1820,7 @@ class Doi < ApplicationRecord
   end
 
   def related_dmp_ids
-    related_identifiers.select { |related_identifier|
+    Array.wrap(related_identifiers).select { |related_identifier|
       related_identifier["relatedIdentifierType"] == "DOI"
     }.select { |related_identifier|
       related_identifier.fetch("resourceTypeGeneral", nil) == "OutputManagementPlan"

--- a/spec/graphql/types/data_management_plan_type_spec.rb
+++ b/spec/graphql/types/data_management_plan_type_spec.rb
@@ -222,7 +222,7 @@ describe DataManagementPlanType do
         contributors: [
           {
             "name" => "European Commission",
-            "contributorType" => "HostingInstitution",
+            "contributorType" => "Sponsor",
             "nameIdentifiers" => [
               {
                 "nameIdentifier" => "https://ror.org/00k4n6c32",
@@ -239,7 +239,7 @@ describe DataManagementPlanType do
     before do
       Doi.import
       sleep 2
-      @dois = Doi.gql_query(nil, page: { cursor: [], size: 4 }).results.to_a
+      #@dois = Doi.gql_query(nil, page: { cursor: [], size: 4 }).results.to_a
     end
 
     let(:query) do
@@ -350,7 +350,7 @@ describe DataManagementPlanType do
       ).to eq(
         [
           {
-            "contributorType" => "HostingInstitution",
+            "contributorType" => "Sponsor",
             "id" => "https://ror.org/00k4n6c32",
             "name" => "European Commission",
           },

--- a/spec/graphql/types/data_management_plan_type_spec.rb
+++ b/spec/graphql/types/data_management_plan_type_spec.rb
@@ -239,7 +239,7 @@ describe DataManagementPlanType do
     before do
       Doi.import
       sleep 2
-      #@dois = Doi.gql_query(nil, page: { cursor: [], size: 4 }).results.to_a
+      @dois = Doi.gql_query(nil, page: { cursor: [], size: 4 }).results.to_a
     end
 
     let(:query) do

--- a/spec/graphql/types/repository_type_spec.rb
+++ b/spec/graphql/types/repository_type_spec.rb
@@ -138,6 +138,7 @@ describe RepositoryType do
       ReferenceRepository.destroy_all
       Client.destroy_all
       Provider.destroy_all
+      Prefix.destroy_all
     end
 
     let(:search_query) { @search_query }
@@ -488,6 +489,7 @@ describe RepositoryType do
       Client.destroy_all
       Provider.destroy_all
       ReferenceRepository.destroy_all
+      Prefix.destroy_all
     end
 
     before :each do
@@ -599,6 +601,7 @@ describe RepositoryType do
       Provider.destroy_all
       Doi.destroy_all
       Event.destroy_all
+      Prefix.destroy_all
     end
 
     it "returns repository with works total count" do

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -818,269 +818,267 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
         ]
       )
     end
-
   end
 
   describe "affiliation_id" do
-     it "from creators" do
-       subject = build(
-         :doi,
-         creators: [
-           {
-             "familyName" => "Garza",
-             "givenName" => "Kristian",
-             "name" => "Garza, Kristian",
-             "nameIdentifiers" => [
-               {
-                 "nameIdentifier" => "https://orcid.org/0000-0003-3484-6875",
-                 "nameIdentifierScheme" => "ORCID",
-                 "schemeUri" => "https://orcid.org",
-               },
-             ],
-             "nameType" => "Personal",
-             "affiliation" => [
-               {
-                 "name" => "University of Cambridge",
-                 "affiliationIdentifier" => "https://ror.org/013meh722",
-                 "affiliationIdentifierScheme" => "ROR",
-               },
-             ],
-           },
-         ]
-       )
-       expect(subject).to be_valid
-       expect(subject.affiliation_id).to eq(
-         [
-           "ror.org/013meh722",
-         ]
-       )
-     end
-
-     it "from contributors(sponsor)" do
-       subject = build(
-         :doi,
-         creators: [],
-         contributors: [
-           {
-             "contributorType" => "Sponsor",
-             "familyName" => "Garza",
-             "givenName" => "Kristian",
-             "name" => "Garza, Kristian",
-             "nameIdentifiers" => [
-               {
-                 "nameIdentifier" => "https://orcid.org/0000-0003-3484-6875",
-                 "nameIdentifierScheme" => "ORCID",
-                 "schemeUri" => "https://orcid.org",
-               },
-             ],
-             "nameType" => "Personal",
-             "affiliation" => [
-               {
-                 "name" => "University of Cambridge",
-                 "affiliationIdentifier" => "https://ror.org/013meh723",
-                 "affiliationIdentifierScheme" => "ROR",
-               },
-             ],
-           },
-         ]
-       )
-       expect(subject).to be_valid
-       expect(subject.affiliation_id).to eq(
-         [
-           "ror.org/013meh723",
-         ]
-       )
-     end
-
-     it "will be empty from contributors(non-sponsor)" do
-       subject = build(
-         :doi,
-         creators: [],
-         contributors: [
-           {
-             "contributorType" => "ProjectLeader",
-             "familyName" => "Garza",
-             "givenName" => "Kristian",
-             "name" => "Garza, Kristian",
-             "nameIdentifiers" => [
-               {
-                 "nameIdentifier" => "https://orcid.org/0000-0003-3484-6875",
-                 "nameIdentifierScheme" => "ORCID",
-                 "schemeUri" => "https://orcid.org",
-               },
-             ],
-             "nameType" => "Personal",
-             "affiliation" => [
-               {
-                 "name" => "University of Cambridge",
-                 "affiliationIdentifier" => "https://ror.org/013meh723",
-                 "affiliationIdentifierScheme" => "ROR",
-               },
-             ],
-           },
-         ]
-       )
-       expect(subject).to be_valid
-       expect(subject.affiliation_id).to eq(
-         [
-           "ror.org/013meh723",
-         ]
-       )
-     end
-
-     it "from creators_and_contributors(sponsored)" do
-       subject = build(
-         :doi,
-         creators: [
-           {
-             "familyName" => "Garza",
-             "givenName" => "Kristian",
-             "name" => "Garza, Kristian",
-             "nameIdentifiers" => [
-               {
-                 "nameIdentifier" => "https://orcid.org/0000-0003-3484-6875",
-                 "nameIdentifierScheme" => "ORCID",
-                 "schemeUri" => "https://orcid.org",
-               },
-             ],
-             "nameType" => "Personal",
-             "affiliation" => [
-               {
-                 "name" => "University of Cambridge",
-                 "affiliationIdentifier" => "https://ror.org/013meh722",
-                 "affiliationIdentifierScheme" => "ROR",
-               },
+    it "from creators" do
+      subject = build(
+        :doi,
+        creators: [
+          {
+            "familyName" => "Garza",
+            "givenName" => "Kristian",
+            "name" => "Garza, Kristian",
+            "nameIdentifiers" => [
+              {
+                "nameIdentifier" => "https://orcid.org/0000-0003-3484-6875",
+                "nameIdentifierScheme" => "ORCID",
+                "schemeUri" => "https://orcid.org",
+              },
             ],
-           },
-         ],
-         contributors: [
-           {
-             "contributorType" => "Sponsor",
-             "familyName" => "Bob",
-             "givenName" => "Jones",
-             "name" => "Jones, Bob",
-             "nameIdentifiers" => [
-               {
-                 "nameIdentifier" => "https://orcid.org/0000-0003-3484-0000",
-                 "nameIdentifierScheme" => "ORCID",
-                 "schemeUri" => "https://orcid.org",
-               },
-             ],
-             "nameType" => "Personal",
-             "affiliation" => [
-               {
-                 "name" => "University of Examples",
-                 "affiliationIdentifier" => "https://ror.org/013meh8888",
-                 "affiliationIdentifierScheme" => "ROR",
-               },
+            "nameType" => "Personal",
+            "affiliation" => [
+              {
+                "name" => "University of Cambridge",
+                "affiliationIdentifier" => "https://ror.org/013meh722",
+                "affiliationIdentifierScheme" => "ROR",
+              },
             ],
-           },
-         ]
-       )
-       expect(subject).to be_valid
-       expect(subject.affiliation_id).to eq(
-         [
-           "ror.org/013meh722",
-           "ror.org/013meh8888",
-         ]
-       )
-     end
+          },
+        ]
+      )
+      expect(subject).to be_valid
+      expect(subject.affiliation_id).to eq(
+        [
+          "ror.org/013meh722",
+        ]
+      )
+    end
+
+    it "from contributors(sponsor)" do
+      subject = build(
+        :doi,
+        creators: [],
+        contributors: [
+          {
+            "contributorType" => "Sponsor",
+            "familyName" => "Garza",
+            "givenName" => "Kristian",
+            "name" => "Garza, Kristian",
+            "nameIdentifiers" => [
+              {
+                "nameIdentifier" => "https://orcid.org/0000-0003-3484-6875",
+                "nameIdentifierScheme" => "ORCID",
+                "schemeUri" => "https://orcid.org",
+              },
+            ],
+            "nameType" => "Personal",
+            "affiliation" => [
+              {
+                "name" => "University of Cambridge",
+                "affiliationIdentifier" => "https://ror.org/013meh723",
+                "affiliationIdentifierScheme" => "ROR",
+              },
+            ],
+          },
+        ]
+      )
+      expect(subject).to be_valid
+      expect(subject.affiliation_id).to eq(
+        [
+          "ror.org/013meh723",
+        ]
+      )
+    end
+
+    it "will be empty from contributors(non-sponsor)" do
+      subject = build(
+        :doi,
+        creators: [],
+        contributors: [
+          {
+            "contributorType" => "ProjectLeader",
+            "familyName" => "Garza",
+            "givenName" => "Kristian",
+            "name" => "Garza, Kristian",
+            "nameIdentifiers" => [
+              {
+                "nameIdentifier" => "https://orcid.org/0000-0003-3484-6875",
+                "nameIdentifierScheme" => "ORCID",
+                "schemeUri" => "https://orcid.org",
+              },
+            ],
+            "nameType" => "Personal",
+            "affiliation" => [
+              {
+                "name" => "University of Cambridge",
+                "affiliationIdentifier" => "https://ror.org/013meh723",
+                "affiliationIdentifierScheme" => "ROR",
+              },
+            ],
+          },
+        ]
+      )
+      expect(subject).to be_valid
+      expect(subject.affiliation_id).to eq(
+        [
+          "ror.org/013meh723",
+        ]
+      )
+    end
+
+    it "from creators_and_contributors(sponsored)" do
+      subject = build(
+        :doi,
+        creators: [
+          {
+            "familyName" => "Garza",
+            "givenName" => "Kristian",
+            "name" => "Garza, Kristian",
+            "nameIdentifiers" => [
+              {
+                "nameIdentifier" => "https://orcid.org/0000-0003-3484-6875",
+                "nameIdentifierScheme" => "ORCID",
+                "schemeUri" => "https://orcid.org",
+              },
+            ],
+            "nameType" => "Personal",
+            "affiliation" => [
+              {
+                "name" => "University of Cambridge",
+                "affiliationIdentifier" => "https://ror.org/013meh722",
+                "affiliationIdentifierScheme" => "ROR",
+              },
+           ],
+          },
+        ],
+        contributors: [
+          {
+            "contributorType" => "Sponsor",
+            "familyName" => "Bob",
+            "givenName" => "Jones",
+            "name" => "Jones, Bob",
+            "nameIdentifiers" => [
+              {
+                "nameIdentifier" => "https://orcid.org/0000-0003-3484-0000",
+                "nameIdentifierScheme" => "ORCID",
+                "schemeUri" => "https://orcid.org",
+              },
+            ],
+            "nameType" => "Personal",
+            "affiliation" => [
+              {
+                "name" => "University of Examples",
+                "affiliationIdentifier" => "https://ror.org/013meh8888",
+                "affiliationIdentifierScheme" => "ROR",
+              },
+           ],
+          },
+        ]
+      )
+      expect(subject).to be_valid
+      expect(subject.affiliation_id).to eq(
+        [
+          "ror.org/013meh722",
+          "ror.org/013meh8888",
+        ]
+      )
+    end
   end
 
   describe "fair_affiliation_id" do
-     it "will be empty from contributors(non-sponsor)" do
-       subject = build(
-         :doi,
-         creators: [],
-         contributors: [
-           {
-             "contributorType" => "ProjectLeader",
-             "familyName" => "Garza",
-             "givenName" => "Kristian",
-             "name" => "Garza, Kristian",
-             "nameIdentifiers" => [
-               {
-                 "nameIdentifier" => "https://orcid.org/0000-0003-3484-6875",
-                 "nameIdentifierScheme" => "ORCID",
-                 "schemeUri" => "https://orcid.org",
-               },
-             ],
-             "nameType" => "Personal",
-             "affiliation" => [
-               {
-                 "name" => "University of Cambridge",
-                 "affiliationIdentifier" => "https://ror.org/013meh723",
-                 "affiliationIdentifierScheme" => "ROR",
-               },
-             ],
-           },
-         ]
-       )
-       expect(subject).to be_valid
-       expect(subject.fair_affiliation_id).to eq(
-         [
-         ]
-       )
-     end
-
-     it "from creators_and_contributors(sponsored)" do
-       subject = build(
-         :doi,
-         creators: [
-           {
-             "familyName" => "Garza",
-             "givenName" => "Kristian",
-             "name" => "Garza, Kristian",
-             "nameIdentifiers" => [
-               {
-                 "nameIdentifier" => "https://orcid.org/0000-0003-3484-6875",
-                 "nameIdentifierScheme" => "ORCID",
-                 "schemeUri" => "https://orcid.org",
-               },
-             ],
-             "nameType" => "Personal",
-             "affiliation" => [
-               {
-                 "name" => "University of Cambridge",
-                 "affiliationIdentifier" => "https://ror.org/013meh722",
-                 "affiliationIdentifierScheme" => "ROR",
-               },
+    it "will be empty from contributors(non-sponsor)" do
+      subject = build(
+        :doi,
+        creators: [],
+        contributors: [
+          {
+            "contributorType" => "ProjectLeader",
+            "familyName" => "Garza",
+            "givenName" => "Kristian",
+            "name" => "Garza, Kristian",
+            "nameIdentifiers" => [
+              {
+                "nameIdentifier" => "https://orcid.org/0000-0003-3484-6875",
+                "nameIdentifierScheme" => "ORCID",
+                "schemeUri" => "https://orcid.org",
+              },
             ],
-           },
-         ],
-         contributors: [
-           {
-             "contributorType" => "Sponsor",
-             "familyName" => "Bob",
-             "givenName" => "Jones",
-             "name" => "Jones, Bob",
-             "nameIdentifiers" => [
-               {
-                 "nameIdentifier" => "https://orcid.org/0000-0003-3484-0000",
-                 "nameIdentifierScheme" => "ORCID",
-                 "schemeUri" => "https://orcid.org",
-               },
-             ],
-             "nameType" => "Personal",
-             "affiliation" => [
-               {
-                 "name" => "University of Examples",
-                 "affiliationIdentifier" => "https://ror.org/013meh8888",
-                 "affiliationIdentifierScheme" => "ROR",
-               },
+            "nameType" => "Personal",
+            "affiliation" => [
+              {
+                "name" => "University of Cambridge",
+                "affiliationIdentifier" => "https://ror.org/013meh723",
+                "affiliationIdentifierScheme" => "ROR",
+              },
             ],
-           },
-         ]
-       )
-       expect(subject).to be_valid
-       expect(subject.fair_affiliation_id).to eq(
-         [
-           "ror.org/013meh722",
-           "ror.org/013meh8888",
-         ]
-       )
-     end
+          },
+        ]
+      )
+      expect(subject).to be_valid
+      expect(subject.fair_affiliation_id).to eq(
+        [
+        ]
+      )
+    end
 
+    it "from creators_and_contributors(sponsored)" do
+      subject = build(
+        :doi,
+        creators: [
+          {
+            "familyName" => "Garza",
+            "givenName" => "Kristian",
+            "name" => "Garza, Kristian",
+            "nameIdentifiers" => [
+              {
+                "nameIdentifier" => "https://orcid.org/0000-0003-3484-6875",
+                "nameIdentifierScheme" => "ORCID",
+                "schemeUri" => "https://orcid.org",
+              },
+            ],
+            "nameType" => "Personal",
+            "affiliation" => [
+              {
+                "name" => "University of Cambridge",
+                "affiliationIdentifier" => "https://ror.org/013meh722",
+                "affiliationIdentifierScheme" => "ROR",
+              },
+           ],
+          },
+        ],
+        contributors: [
+          {
+            "contributorType" => "Sponsor",
+            "familyName" => "Bob",
+            "givenName" => "Jones",
+            "name" => "Jones, Bob",
+            "nameIdentifiers" => [
+              {
+                "nameIdentifier" => "https://orcid.org/0000-0003-3484-0000",
+                "nameIdentifierScheme" => "ORCID",
+                "schemeUri" => "https://orcid.org",
+              },
+            ],
+            "nameType" => "Personal",
+            "affiliation" => [
+              {
+                "name" => "University of Examples",
+                "affiliationIdentifier" => "https://ror.org/013meh8888",
+                "affiliationIdentifierScheme" => "ROR",
+              },
+           ],
+          },
+        ]
+      )
+      expect(subject).to be_valid
+      expect(subject.fair_affiliation_id).to eq(
+        [
+          "ror.org/013meh722",
+          "ror.org/013meh8888",
+        ]
+      )
+    end
   end
 
   describe "related_identifiers" do

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -636,7 +636,7 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
       )
     end
 
-    it "will be empty from contributors(non-sponsor)" do
+    it "will be populated with contributors(non-sponsor)" do
       subject = build(
         :doi,
         creators: [],
@@ -666,6 +666,7 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
       expect(subject).to be_valid
       expect(subject.organization_id).to eq(
         [
+          "ror.org/013meh333",
         ]
       )
     end
@@ -725,6 +726,99 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
         ]
       )
     end
+  end
+
+  describe "fair_organization_id" do
+    it "will be empty from contributors(non-sponsor)" do
+      subject = build(
+        :doi,
+        creators: [],
+        contributors: [
+          {
+            "contributorType" => "ProjectLeader",
+            "familyName" => "Garza",
+            "givenName" => "Kristian",
+            "name" => "Garza, Kristian",
+            "nameIdentifiers" => [
+              {
+                "nameIdentifier" => "https://ror.org/013meh333",
+                "nameIdentifierScheme" => "ROR",
+              },
+            ],
+            "nameType" => "Personal",
+            "affiliation" => [
+              {
+                "name" => "University of Cambridge",
+                "affiliationIdentifier" => "https://ror.org/013meh723",
+                "affiliationIdentifierScheme" => "ROR",
+              },
+            ],
+          },
+        ]
+      )
+      expect(subject).to be_valid
+      expect(subject.fair_organization_id).to eq(
+        [
+        ]
+      )
+    end
+
+    it "from creators_and_contributors(sponsored)" do
+      subject = build(
+        :doi,
+        creators: [
+          {
+            "familyName" => "Garza",
+            "givenName" => "Kristian",
+            "name" => "Garza, Kristian",
+            "nameIdentifiers" => [
+              {
+                "nameIdentifier" => "https://ror.org/013meh333",
+                "nameIdentifierScheme" => "ROR",
+              },
+            ],
+            "nameType" => "Personal",
+            "affiliation" => [
+              {
+                "name" => "University of Cambridge",
+                "affiliationIdentifier" => "https://ror.org/013meh722",
+                "affiliationIdentifierScheme" => "ROR",
+              },
+            ],
+          },
+        ],
+        contributors: [
+          {
+            "contributorType" => "Sponsor",
+            "familyName" => "Bob",
+            "givenName" => "Jones",
+            "name" => "Jones, Bob",
+            "nameIdentifiers" => [
+              {
+                "nameIdentifier" => "https://ror.org/013meh111",
+                "nameIdentifierScheme" => "ROR",
+              },
+            ],
+            "nameType" => "Personal",
+            "affiliation" => [
+              {
+                "name" => "University of Examples",
+                "affiliationIdentifier" => "https://ror.org/013meh8888",
+                "affiliationIdentifierScheme" => "ROR",
+              },
+            ],
+          },
+        ]
+      )
+      expect(subject).to be_valid
+      expect(subject.fair_organization_id).to eq(
+        [
+          "ror.org/013meh333",
+          "ror.org/013meh111",
+        ]
+      )
+    end
+
   end
 
   describe "affiliation_id" do
@@ -829,6 +923,7 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
        expect(subject).to be_valid
        expect(subject.affiliation_id).to eq(
          [
+           "ror.org/013meh723",
          ]
        )
      end
@@ -890,7 +985,103 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
          ]
        )
      end
-   end
+  end
+
+  describe "fair_affiliation_id" do
+     it "will be empty from contributors(non-sponsor)" do
+       subject = build(
+         :doi,
+         creators: [],
+         contributors: [
+           {
+             "contributorType" => "ProjectLeader",
+             "familyName" => "Garza",
+             "givenName" => "Kristian",
+             "name" => "Garza, Kristian",
+             "nameIdentifiers" => [
+               {
+                 "nameIdentifier" => "https://orcid.org/0000-0003-3484-6875",
+                 "nameIdentifierScheme" => "ORCID",
+                 "schemeUri" => "https://orcid.org",
+               },
+             ],
+             "nameType" => "Personal",
+             "affiliation" => [
+               {
+                 "name" => "University of Cambridge",
+                 "affiliationIdentifier" => "https://ror.org/013meh723",
+                 "affiliationIdentifierScheme" => "ROR",
+               },
+             ],
+           },
+         ]
+       )
+       expect(subject).to be_valid
+       expect(subject.fair_affiliation_id).to eq(
+         [
+         ]
+       )
+     end
+
+     it "from creators_and_contributors(sponsored)" do
+       subject = build(
+         :doi,
+         creators: [
+           {
+             "familyName" => "Garza",
+             "givenName" => "Kristian",
+             "name" => "Garza, Kristian",
+             "nameIdentifiers" => [
+               {
+                 "nameIdentifier" => "https://orcid.org/0000-0003-3484-6875",
+                 "nameIdentifierScheme" => "ORCID",
+                 "schemeUri" => "https://orcid.org",
+               },
+             ],
+             "nameType" => "Personal",
+             "affiliation" => [
+               {
+                 "name" => "University of Cambridge",
+                 "affiliationIdentifier" => "https://ror.org/013meh722",
+                 "affiliationIdentifierScheme" => "ROR",
+               },
+            ],
+           },
+         ],
+         contributors: [
+           {
+             "contributorType" => "Sponsor",
+             "familyName" => "Bob",
+             "givenName" => "Jones",
+             "name" => "Jones, Bob",
+             "nameIdentifiers" => [
+               {
+                 "nameIdentifier" => "https://orcid.org/0000-0003-3484-0000",
+                 "nameIdentifierScheme" => "ORCID",
+                 "schemeUri" => "https://orcid.org",
+               },
+             ],
+             "nameType" => "Personal",
+             "affiliation" => [
+               {
+                 "name" => "University of Examples",
+                 "affiliationIdentifier" => "https://ror.org/013meh8888",
+                 "affiliationIdentifierScheme" => "ROR",
+               },
+            ],
+           },
+         ]
+       )
+       expect(subject).to be_valid
+       expect(subject.fair_affiliation_id).to eq(
+         [
+           "ror.org/013meh722",
+           "ror.org/013meh8888",
+         ]
+       )
+     end
+
+  end
 
   describe "related_identifiers" do
     it "has part" do


### PR DESCRIPTION
## Purpose
Amend the previous PR that re-defined `affiliation_id`
Create new variables and use them for "FAIR" associations between an organization and works.

## Approach
Reverts changes to `affiliation_id`
Creates new variables in elastic-search
Uses the new variables when searching for works associated with an organization via graphql

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
