### PR TITLE
Fix contributors missing from filter

### DIFF
--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -668,7 +668,7 @@ class Doi < ApplicationRecord
         registration_agencies: { terms: { field: "agency", size: facet_count, min_doc_count: 1 } },
         affiliations: { terms: { field: "affiliation_id_and_name", size: facet_count, min_doc_count: 1, missing: "__missing__" } },
         authors: {
-          terms: { field: "creators.nameIdentifiers.nameIdentifier", size: facet_count, min_doc_count: 1 },
+          terms: { field: "creators.nameIdentifiers.nameIdentifier", size: facet_count, min_doc_count: 1, include: "https?://orcid.org/.*" },
           aggs: {
             authors: {
               top_hits: {
@@ -681,7 +681,7 @@ class Doi < ApplicationRecord
           }
         },
         creators_and_contributors: {
-          terms: { field: "creators_and_contributors.nameIdentifiers.nameIdentifier", size: facet_count, min_doc_count: 1 },
+          terms: { field: "creators_and_contributors.nameIdentifiers.nameIdentifier", size: facet_count, min_doc_count: 1, include: "https?://orcid.org/.*" },
           aggs: {
             creators_and_contributors: {
               top_hits: {


### PR DESCRIPTION
## Purpose
There is a bug when filtering the contributors. non-ORCID identifiers for names were getting picked up when we [created the facets](https://github.com/datacite/lupo/blob/38c5b5387c83f71201bcfb110e166053334822fc/app/models/doi.rb#L670), and then [filtered out](https://github.com/datacite/lupo/blob/38c5b5387c83f71201bcfb110e166053334822fc/app/controllers/concerns/facetable.rb#L469) since they were not ORCIDs. This meant that if the top 10 faceted identifiers were mostly or all non-ORCID, then the final result would be a mostly empty or empty array.

closes: https://github.com/datacite/datacite/issues/1891

## Approach
Added the following regex filter to the elasticsearch query so that only ORCID iDs are returned in the first place
`https?://orcid.org/.*`

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
