### PR TITLE
Fix DEPRECATION WARNING: ActiveModel::Errors#values is deprecated

### DIFF
--- a/app/controllers/concerns/error_serializable.rb
+++ b/app/controllers/concerns/error_serializable.rb
@@ -8,10 +8,10 @@ module ErrorSerializable
       return nil if errors.nil?
 
       arr =
-        Array.wrap(errors).reduce([]) do |sum, err|
-          source = err.keys.first
+        Array.wrap(errors.errors).reduce([]) do |sum, err|
+          source = err.attribute
 
-          Array.wrap(err.values.first).each do |title|
+          Array.wrap(err.message).each do |title|
             sum <<
               {
                 source: source,


### PR DESCRIPTION
## Purpose
Fix the deprication warning.

closes: #datacite/datacite/issues/991

## Approach
The original deprication warning included the fix.  This just implemented it.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
