### PR TITLE
Relax selection criteria for linking Work to Organization via Contributor

### DIFF
--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -1065,8 +1065,8 @@ class Doi < ApplicationRecord
 
     if options[:fair_organization_id].present?
       _ror_id = ror_from_url(options[:fair_organization_id])
-      should << { term: { "fair_organization_id" => _ror_id } }
-      should << { term: { "fair_affiliation_id" => _ror_id } }
+      should << { term: { "organization_id" => _ror_id } }
+      should << { term: { "affiliation_id" => _ror_id } }
       should << { term: { "related_dmp_organization_id" => _ror_id } }
       minimum_should_match = 1
     end
@@ -1881,8 +1881,8 @@ class Doi < ApplicationRecord
 
   def related_dmp_organization_and_affiliation_id
     related_dmp_works.reduce([]) do |sum, dmp|
-      sum.concat(dmp.fair_organization_id)
-      sum.concat(dmp.fair_affiliation_id)
+      sum.concat(dmp.organization_id)
+      sum.concat(dmp.affiliation_id)
 
       sum
     end


### PR DESCRIPTION
## Purpose
Removes the necessity for `afficiation==Sponsor` in contributors

closes: datacite/datacite#1898

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
