### PR TITLE
Flattened Person-Worktype facets for Sankey Visualizations

### DIFF
--- a/app/controllers/concerns/facetable.rb
+++ b/app/controllers/concerns/facetable.rb
@@ -534,8 +534,8 @@ module Facetable
     def multi_facet_by_contributors_and_worktype(arr)
       outer = _facet_by_general_contributor(arr, "creators_and_contributors", "creators_and_contributors")
       outer.map do |hsh|
-        creator_hash = arr.find{ |h| h["key"] == hsh["id"] }
-        inner = facet_by_combined_key(creator_hash.dig("work_types","buckets"))
+        creator_hash = arr.find { |h| h["key"] == hsh["id"] }
+        inner = facet_by_combined_key(creator_hash.dig("work_types", "buckets"))
         hsh.merge("inner" => inner)
       end
     end
@@ -543,7 +543,7 @@ module Facetable
     def flatten_muti_facet(arr)
       arr.map do |hsh|
         outer_title = hsh["title"]
-        inner = hsh.fetch("inner",[])
+        inner = hsh.fetch("inner", [])
         inner.map do |ihsh|
           {
             "data" => [outer_title, ihsh["title"]],

--- a/app/controllers/concerns/facetable.rb
+++ b/app/controllers/concerns/facetable.rb
@@ -540,6 +540,19 @@ module Facetable
       end
     end
 
+    def flatten_muti_facet(arr)
+      arr.map do |hsh|
+        outer_title = hsh["title"]
+        inner = hsh.fetch("inner",[])
+        inner.map do |ihsh|
+          {
+            "data" => [outer_title, ihsh["title"]],
+            "count" => ihsh["count"]
+          }
+        end
+      end.flatten
+    end
+
     def add_other(arr, other_count)
       if other_count > 0
         arr << {

--- a/app/controllers/concerns/facetable.rb
+++ b/app/controllers/concerns/facetable.rb
@@ -531,6 +531,15 @@ module Facetable
       _facet_by_general_contributor(arr, "creators_and_contributors", "creators_and_contributors")
     end
 
+    def multi_facet_by_contributors_and_worktype(arr)
+      outer = _facet_by_general_contributor(arr, "creators_and_contributors", "creators_and_contributors")
+      outer.map do |hsh|
+        creator_hash = arr.find{ |h| h["key"] == hsh["id"] }
+        inner = facet_by_combined_key(creator_hash.dig("work_types","buckets"))
+        hsh.merge("inner" => inner)
+      end
+    end
+
     def add_other(arr, other_count)
       if other_count > 0
         arr << {

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -412,6 +412,8 @@ type AudiovisualConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -1010,6 +1012,8 @@ type BookChapterConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -1060,6 +1064,8 @@ type BookConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -1432,6 +1438,8 @@ type CollectionConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -1756,6 +1764,8 @@ type ConferencePaperConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -2372,6 +2382,8 @@ type DataManagementPlanConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -2696,6 +2708,8 @@ type DataPaperConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -3045,6 +3059,8 @@ type DatasetConnectionWithTotal implements WorkFacetsInterface {
   """
   pageInfo: PageInfo!
   personConnectionCount: Int!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   publicationConnectionCount: Int!
   published: [Facet!]
   registrationAgencies: [Facet!]
@@ -3462,6 +3478,8 @@ type DissertationConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -4478,6 +4496,21 @@ type FieldOfScience {
 }
 
 """
+Flattened Count Type for Multi-level Facets
+"""
+type FlattenedCount {
+  """
+  Count
+  """
+  count: Int
+
+  """
+  Flattened facets
+  """
+  data: [String!]
+}
+
+"""
 Information about funders
 """
 type Funder implements ActorItem {
@@ -5015,6 +5048,8 @@ type ImageConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -5339,6 +5374,8 @@ type InstrumentConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -5663,6 +5700,8 @@ type InteractiveResourceConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -5992,6 +6031,8 @@ type JournalArticleConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -6612,6 +6653,8 @@ type ModelConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -6631,6 +6674,31 @@ type ModelEdge {
   The item at the end of the edge.
   """
   node: Model
+}
+
+"""
+Multi-level Facets
+"""
+type MultiFacet {
+  """
+  Count
+  """
+  count: Int
+
+  """
+  ID
+  """
+  id: String
+
+  """
+  Inner facets
+  """
+  inner: [Facet!]
+
+  """
+  Title
+  """
+  title: String
 }
 
 type Mutation {
@@ -7108,6 +7176,8 @@ type OtherConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -7457,6 +7527,8 @@ type PeerReviewConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -7918,6 +7990,8 @@ type PhysicalObjectConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -8295,6 +8369,8 @@ type PreprintConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -8623,6 +8699,8 @@ type PublicationConnectionWithTotal implements WorkFacetsInterface {
   """
   pageInfo: PageInfo!
   personConnectionCount: Int!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   publicationConnectionCount: Int!
   published: [Facet!]
   registrationAgencies: [Facet!]
@@ -9588,6 +9666,8 @@ type ServiceConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   pidEntities: [Facet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
@@ -9942,6 +10022,8 @@ type SoftwareConnectionWithTotal implements WorkFacetsInterface {
   """
   pageInfo: PageInfo!
   personConnectionCount: Int!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   publicationConnectionCount: Int!
   published: [Facet!]
   registrationAgencies: [Facet!]
@@ -10268,6 +10350,8 @@ type SoundConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -10803,6 +10887,8 @@ type WorkConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -10839,6 +10925,8 @@ interface WorkFacetsInterface {
   languages: [Facet!]
   licenses: [Facet!]
   openLicenseResourceTypes: [Facet!]
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]
@@ -11148,6 +11236,8 @@ type WorkflowConnectionWithTotal implements WorkFacetsInterface {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  personToWorkTypesFlat: [FlattenedCount!]
+  personToWorkTypesMultilevel: [MultiFacet!]
   published: [Facet!]
   registrationAgencies: [Facet!]
   repositories: [Facet!]

--- a/app/graphql/types/flattened_count_type.rb
+++ b/app/graphql/types/flattened_count_type.rb
@@ -1,0 +1,7 @@
+
+class FlattenedCountType < BaseObject
+  description "Flattened Count Type for Multi-level Facets"
+
+  field :count, Int, null: true, description: "Count"
+  field :data, [String], null: true, description: "Flattened facets"
+end

--- a/app/graphql/types/flattened_count_type.rb
+++ b/app/graphql/types/flattened_count_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 class FlattenedCountType < BaseObject
   description "Flattened Count Type for Multi-level Facets"

--- a/app/graphql/types/interfaces/work_facets_interface.rb
+++ b/app/graphql/types/interfaces/work_facets_interface.rb
@@ -19,6 +19,27 @@ module Interfaces::WorkFacetsInterface
   field :fields_of_science_repository, [FacetType], null: true, cache: true
   field :licenses, [FacetType], null: true, cache: true
   field :languages, [FacetType], null: true, cache: true
+  field :person_to_work_types_multilevel, [MultiFacetType], null: true, cache: true
+  field :person_to_work_types_flat, [FlattenedCountType], null: true, cache: true
+
+  def person_to_work_types_multilevel
+    if object.aggregations.creators_and_contributors
+      multi_facet_by_contributors_and_worktype(object.aggregations.creators_and_contributors.buckets)
+    else
+      []
+    end
+  end
+
+  def person_to_work_types_flat
+    if object.aggregations.creators_and_contributors
+      contributors_works = multi_facet_by_contributors_and_worktype(
+        object.aggregations.creators_and_contributors.buckets
+      )
+      flatten_muti_facet(contributors_works)
+    else
+      []
+    end
+  end
 
   def total_count
     object.total_count

--- a/app/graphql/types/multi_facet_type.rb
+++ b/app/graphql/types/multi_facet_type.rb
@@ -1,0 +1,9 @@
+
+class MultiFacetType < BaseObject
+  description "Multi-level Facets"
+
+  field :id, String, null: true, description: "ID"
+  field :title, String, null: true, description: "Title"
+  field :count, Int, null: true, description: "Count"
+  field :inner, [FacetType], null: true, description: "Inner facets"
+end

--- a/app/graphql/types/multi_facet_type.rb
+++ b/app/graphql/types/multi_facet_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 class MultiFacetType < BaseObject
   description "Multi-level Facets"

--- a/app/models/doi/graphql_query.rb
+++ b/app/models/doi/graphql_query.rb
@@ -328,7 +328,7 @@ module Doi::GraphqlQuery
               "work_types": {
                 "terms": {
                   "field": "resource_type_id_and_name",
-                  "min_doc_count":1
+                  "min_doc_count": 1
                 }
               }
             }

--- a/app/models/doi/graphql_query.rb
+++ b/app/models/doi/graphql_query.rb
@@ -324,6 +324,12 @@ module Doi::GraphqlQuery
                   },
                   size: 1
                 }
+              },
+              "work_types": {
+                "terms": {
+                  "field": "resource_type_id_and_name",
+                  "min_doc_count":1
+                }
               }
             }
           },

--- a/app/models/doi/graphql_query.rb
+++ b/app/models/doi/graphql_query.rb
@@ -260,7 +260,20 @@ module Doi::GraphqlQuery
           resource_types: { terms: { field: "resource_type_id_and_name", size: facet_count, min_doc_count: 1, missing: "__missing__" } },
           clients: { terms: { field: "client_id_and_name", size: facet_count, min_doc_count: 1 } },
           open_licenses: {
-            filter: { terms: { "rights_list.rightsIdentifier": ["cc-by-1.0", "cc-by-2.0", "cc-by-2.5", "cc-by-3.0", "cc-by-3.0-at", "cc-by-3.0-us", "cc-by-4.0", "cc-pddc", "cc0-1.0", "cc-pdm-1.0"] } },
+            filter: { terms: {
+              "rights_list.rightsIdentifier": [
+                "cc-by-1.0",
+                "cc-by-2.0",
+                "cc-by-2.5",
+                "cc-by-3.0",
+                "cc-by-3.0-at",
+                "cc-by-3.0-us",
+                "cc-by-4.0",
+                "cc-pddc",
+                "cc0-1.0",
+                "cc-pdm-1.0"
+              ]
+            } },
             aggs: {
               resource_types: {
                 terms: { field: "resource_type_id_and_name", size: facet_count, min_doc_count: 1 }
@@ -294,12 +307,20 @@ module Doi::GraphqlQuery
             }
           },
           creators_and_contributors: {
-            terms: { field: "creators_and_contributors.nameIdentifiers.nameIdentifier", size: facet_count, min_doc_count: 1, include: "https?://orcid.org/.*" },
+            terms: {
+              field: "creators_and_contributors.nameIdentifiers.nameIdentifier",
+              size: facet_count,
+              min_doc_count: 1,
+              include: "https?://orcid.org/.*"
+            },
             aggs: {
               creators_and_contributors: {
                 top_hits: {
                   _source: {
-                    includes: [ "creators_and_contributors.name", "creators_and_contributors.nameIdentifiers.nameIdentifier"]
+                    includes: [
+                      "creators_and_contributors.name",
+                      "creators_and_contributors.nameIdentifiers.nameIdentifier"
+                    ]
                   },
                   size: 1
                 }
@@ -329,8 +350,24 @@ module Doi::GraphqlQuery
           pid_entities: {
             filter: { term: { "subjects.subjectScheme": "PidEntity" } },
             aggs: {
-              subject: { terms: { field: "subjects.subject", size: facet_count, min_doc_count: 1,
-                                  include: %w(Dataset Publication Software Organization Funder Person Grant Sample Instrument Repository Project) } },
+              subject: { terms: {
+                field: "subjects.subject",
+                size: facet_count,
+                min_doc_count: 1,
+                include: %w(
+                  Dataset
+                  Publication
+                  Software
+                  Organization
+                  Funder
+                  Person
+                  Grant
+                  Sample
+                  Instrument
+                  Repository
+                  Project
+                )
+              } },
             },
           },
           fields_of_science: {

--- a/spec/concerns/facetable_spec.rb
+++ b/spec/concerns/facetable_spec.rb
@@ -90,48 +90,48 @@ describe "Facetable", type: :controller do
 
 
       expected_results = [
-        {"count"=>98,
-         "id"=>"https://orcid.org/0000-0003-1419-2405",
-         "inner"=>
-          [{"count"=>75, "id"=>"text", "title"=>"Text"},
-           {"count"=>15, "id"=>"software", "title"=>"Software"},
-           {"count"=>4, "id"=>"collection", "title"=>"Collection"},
-           {"count"=>1, "id"=>"computational-notebook", "title"=>"Computational Notebook"},
-           {"count"=>1, "id"=>"dataset", "title"=>"Dataset"},
-           {"count"=>1, "id"=>"report", "title"=>"Report"},
-           {"count"=>1, "id"=>"service", "title"=>"Service"}],
-         "title"=>"Fenner, Martin"},
-        {"count"=>37,
-         "id"=>"https://orcid.org/0000-0001-6660-6214",
-         "inner"=>
-          [{"count"=>34, "id"=>"text", "title"=>"Text"},
-           {"count"=>1, "id"=>"audiovisual", "title"=>"Audiovisual"},
-           {"count"=>1,
-            "id"=>"output-management-plan",
-            "title"=>"Output Management Plan"},
-           {"count"=>1, "id"=>"service", "title"=>"Service"}],
-         "title"=>"Cousijn, Helena"},
-        {"count"=>29,
-         "id"=>"https://orcid.org/0000-0002-4695-7874",
-         "inner"=>
-          [{"count"=>28, "id"=>"text", "title"=>"Text"},
-           {"count"=>1, "id"=>"collection", "title"=>"Collection"}],
-         "title"=>"Dasler, Robin"},
-        {"count"=>29,
-         "id"=>"https://orcid.org/0000-0003-4448-3844",
-         "inner"=>
-          [{"count"=>27, "id"=>"text", "title"=>"Text"},
-           {"count"=>1, "id"=>"other", "title"=>"Other"},
-           {"count"=>1, "id"=>"report", "title"=>"Report"}],
-         "title"=>"Vierkant, Paul"},
-        {"count"=>28,
-         "id"=>"https://orcid.org/0000-0003-3484-6875",
-         "inner"=>
-          [{"count"=>21, "id"=>"text", "title"=>"Text"},
-           {"count"=>4, "id"=>"software", "title"=>"Software"},
-           {"count"=>2, "id"=>"collection", "title"=>"Collection"},
-           {"count"=>1, "id"=>"other", "title"=>"Other"}],
-         "title"=>"Garza, Kristian"}]
+        { "count" => 98,
+         "id" => "https://orcid.org/0000-0003-1419-2405",
+         "inner" =>
+          [{ "count" => 75, "id" => "text", "title" => "Text" },
+           { "count" => 15, "id" => "software", "title" => "Software" },
+           { "count" => 4, "id" => "collection", "title" => "Collection" },
+           { "count" => 1, "id" => "computational-notebook", "title" => "Computational Notebook" },
+           { "count" => 1, "id" => "dataset", "title" => "Dataset" },
+           { "count" => 1, "id" => "report", "title" => "Report" },
+           { "count" => 1, "id" => "service", "title" => "Service" }],
+         "title" => "Fenner, Martin" },
+        { "count" => 37,
+         "id" => "https://orcid.org/0000-0001-6660-6214",
+         "inner" =>
+          [{ "count" => 34, "id" => "text", "title" => "Text" },
+           { "count" => 1, "id" => "audiovisual", "title" => "Audiovisual" },
+           { "count" => 1,
+            "id" => "output-management-plan",
+            "title" => "Output Management Plan" },
+           { "count" => 1, "id" => "service", "title" => "Service" }],
+         "title" => "Cousijn, Helena" },
+        { "count" => 29,
+         "id" => "https://orcid.org/0000-0002-4695-7874",
+         "inner" =>
+          [{ "count" => 28, "id" => "text", "title" => "Text" },
+           { "count" => 1, "id" => "collection", "title" => "Collection" }],
+         "title" => "Dasler, Robin" },
+        { "count" => 29,
+         "id" => "https://orcid.org/0000-0003-4448-3844",
+         "inner" =>
+          [{ "count" => 27, "id" => "text", "title" => "Text" },
+           { "count" => 1, "id" => "other", "title" => "Other" },
+           { "count" => 1, "id" => "report", "title" => "Report" }],
+         "title" => "Vierkant, Paul" },
+        { "count" => 28,
+         "id" => "https://orcid.org/0000-0003-3484-6875",
+         "inner" =>
+          [{ "count" => 21, "id" => "text", "title" => "Text" },
+           { "count" => 4, "id" => "software", "title" => "Software" },
+           { "count" => 2, "id" => "collection", "title" => "Collection" },
+           { "count" => 1, "id" => "other", "title" => "Other" }],
+         "title" => "Garza, Kristian" }]
 
       expect(contributors_works).to eq (expected_results)
     end
@@ -141,26 +141,26 @@ describe "Facetable", type: :controller do
       flattened_contributors_works = model.flatten_muti_facet(contributors_works)
 
       expected_results = [
-        {"count"=>75, "data"=>["Fenner, Martin", "Text"]},
-        {"count"=>15, "data"=>["Fenner, Martin", "Software"]},
-        {"count"=>4, "data"=>["Fenner, Martin", "Collection"]},
-        {"count"=>1, "data"=>["Fenner, Martin", "Computational Notebook"]},
-        {"count"=>1, "data"=>["Fenner, Martin", "Dataset"]},
-        {"count"=>1, "data"=>["Fenner, Martin", "Report"]},
-        {"count"=>1, "data"=>["Fenner, Martin", "Service"]},
-        {"count"=>34, "data"=>["Cousijn, Helena", "Text"]},
-        {"count"=>1, "data"=>["Cousijn, Helena", "Audiovisual"]},
-        {"count"=>1, "data"=>["Cousijn, Helena", "Output Management Plan"]},
-        {"count"=>1, "data"=>["Cousijn, Helena", "Service"]},
-        {"count"=>28, "data"=>["Dasler, Robin", "Text"]},
-        {"count"=>1, "data"=>["Dasler, Robin", "Collection"]},
-        {"count"=>27, "data"=>["Vierkant, Paul", "Text"]},
-        {"count"=>1, "data"=>["Vierkant, Paul", "Other"]},
-        {"count"=>1, "data"=>["Vierkant, Paul", "Report"]},
-        {"count"=>21, "data"=>["Garza, Kristian", "Text"]},
-        {"count"=>4, "data"=>["Garza, Kristian", "Software"]},
-        {"count"=>2, "data"=>["Garza, Kristian", "Collection"]},
-        {"count"=>1, "data"=>["Garza, Kristian", "Other"]}
+        { "count" => 75, "data" => ["Fenner, Martin", "Text"] },
+        { "count" => 15, "data" => ["Fenner, Martin", "Software"] },
+        { "count" => 4, "data" => ["Fenner, Martin", "Collection"] },
+        { "count" => 1, "data" => ["Fenner, Martin", "Computational Notebook"] },
+        { "count" => 1, "data" => ["Fenner, Martin", "Dataset"] },
+        { "count" => 1, "data" => ["Fenner, Martin", "Report"] },
+        { "count" => 1, "data" => ["Fenner, Martin", "Service"] },
+        { "count" => 34, "data" => ["Cousijn, Helena", "Text"] },
+        { "count" => 1, "data" => ["Cousijn, Helena", "Audiovisual"] },
+        { "count" => 1, "data" => ["Cousijn, Helena", "Output Management Plan"] },
+        { "count" => 1, "data" => ["Cousijn, Helena", "Service"] },
+        { "count" => 28, "data" => ["Dasler, Robin", "Text"] },
+        { "count" => 1, "data" => ["Dasler, Robin", "Collection"] },
+        { "count" => 27, "data" => ["Vierkant, Paul", "Text"] },
+        { "count" => 1, "data" => ["Vierkant, Paul", "Other"] },
+        { "count" => 1, "data" => ["Vierkant, Paul", "Report"] },
+        { "count" => 21, "data" => ["Garza, Kristian", "Text"] },
+        { "count" => 4, "data" => ["Garza, Kristian", "Software"] },
+        { "count" => 2, "data" => ["Garza, Kristian", "Collection"] },
+        { "count" => 1, "data" => ["Garza, Kristian", "Other"] }
       ]
 
 

--- a/spec/concerns/facetable_spec.rb
+++ b/spec/concerns/facetable_spec.rb
@@ -7,6 +7,7 @@ describe "Facetable", type: :controller do
     let(:author_aggs_with_multiple_name_identifiers) { JSON.parse(file_fixture("authors_aggs_with_multiple_name_identifiers.json").read) }
     let(:model) { DataciteDoisController.new }
     let(:funder_aggs) { JSON.parse(file_fixture("funders_aggs.json").read) }
+    let(:contributor_worktype_multiaggs) { JSON.parse(file_fixture("contributor_worktype_multi_aggs.json").read) }
     it "facet by author" do
       authors = model.facet_by_authors(author_aggs)
 
@@ -82,6 +83,58 @@ describe "Facetable", type: :controller do
       ]
 
       expect(funders).to eq (expected_result)
+    end
+
+    it "multifacet by contributor-worktype combinations" do
+      contributors_works = model.multi_facet_by_contributors_and_worktype(contributor_worktype_multiaggs)
+
+
+      expected_results = [{"count"=>98,
+         "id"=>"https://orcid.org/0000-0003-1419-2405",
+         "inner"=>
+          [{"count"=>75, "id"=>"text", "title"=>"Text"},
+           {"count"=>15, "id"=>"software", "title"=>"Software"},
+           {"count"=>4, "id"=>"collection", "title"=>"Collection"},
+           {"count"=>1,
+            "id"=>"computational-notebook",
+            "title"=>"Computational Notebook"},
+           {"count"=>1, "id"=>"dataset", "title"=>"Dataset"},
+           {"count"=>1, "id"=>"report", "title"=>"Report"},
+           {"count"=>1, "id"=>"service", "title"=>"Service"}],
+         "title"=>"Fenner, Martin"},
+        {"count"=>37,
+         "id"=>"https://orcid.org/0000-0001-6660-6214",
+         "inner"=>
+          [{"count"=>34, "id"=>"text", "title"=>"Text"},
+           {"count"=>1, "id"=>"audiovisual", "title"=>"Audiovisual"},
+           {"count"=>1,
+            "id"=>"output-management-plan",
+            "title"=>"Output Management Plan"},
+           {"count"=>1, "id"=>"service", "title"=>"Service"}],
+         "title"=>"Cousijn, Helena"},
+        {"count"=>29,
+         "id"=>"https://orcid.org/0000-0002-4695-7874",
+         "inner"=>
+          [{"count"=>28, "id"=>"text", "title"=>"Text"},
+           {"count"=>1, "id"=>"collection", "title"=>"Collection"}],
+         "title"=>"Dasler, Robin"},
+        {"count"=>29,
+         "id"=>"https://orcid.org/0000-0003-4448-3844",
+         "inner"=>
+          [{"count"=>27, "id"=>"text", "title"=>"Text"},
+           {"count"=>1, "id"=>"other", "title"=>"Other"},
+           {"count"=>1, "id"=>"report", "title"=>"Report"}],
+         "title"=>"Vierkant, Paul"},
+        {"count"=>28,
+         "id"=>"https://orcid.org/0000-0003-3484-6875",
+         "inner"=>
+          [{"count"=>21, "id"=>"text", "title"=>"Text"},
+           {"count"=>4, "id"=>"software", "title"=>"Software"},
+           {"count"=>2, "id"=>"collection", "title"=>"Collection"},
+           {"count"=>1, "id"=>"other", "title"=>"Other"}],
+         "title"=>"Garza, Kristian"}]
+
+      expect(contributors_works).to eq (expected_results)
     end
   end
 

--- a/spec/concerns/facetable_spec.rb
+++ b/spec/concerns/facetable_spec.rb
@@ -89,15 +89,14 @@ describe "Facetable", type: :controller do
       contributors_works = model.multi_facet_by_contributors_and_worktype(contributor_worktype_multiaggs)
 
 
-      expected_results = [{"count"=>98,
+      expected_results = [
+        {"count"=>98,
          "id"=>"https://orcid.org/0000-0003-1419-2405",
          "inner"=>
           [{"count"=>75, "id"=>"text", "title"=>"Text"},
            {"count"=>15, "id"=>"software", "title"=>"Software"},
            {"count"=>4, "id"=>"collection", "title"=>"Collection"},
-           {"count"=>1,
-            "id"=>"computational-notebook",
-            "title"=>"Computational Notebook"},
+           {"count"=>1, "id"=>"computational-notebook", "title"=>"Computational Notebook"},
            {"count"=>1, "id"=>"dataset", "title"=>"Dataset"},
            {"count"=>1, "id"=>"report", "title"=>"Report"},
            {"count"=>1, "id"=>"service", "title"=>"Service"}],
@@ -135,6 +134,37 @@ describe "Facetable", type: :controller do
          "title"=>"Garza, Kristian"}]
 
       expect(contributors_works).to eq (expected_results)
+    end
+
+    it "flattened multifacet contributor-worktype combinations" do
+      contributors_works = model.multi_facet_by_contributors_and_worktype(contributor_worktype_multiaggs)
+      flattened_contributors_works = model.flatten_muti_facet(contributors_works)
+
+      expected_results = [
+        {"count"=>75, "data"=>["Fenner, Martin", "Text"]},
+        {"count"=>15, "data"=>["Fenner, Martin", "Software"]},
+        {"count"=>4, "data"=>["Fenner, Martin", "Collection"]},
+        {"count"=>1, "data"=>["Fenner, Martin", "Computational Notebook"]},
+        {"count"=>1, "data"=>["Fenner, Martin", "Dataset"]},
+        {"count"=>1, "data"=>["Fenner, Martin", "Report"]},
+        {"count"=>1, "data"=>["Fenner, Martin", "Service"]},
+        {"count"=>34, "data"=>["Cousijn, Helena", "Text"]},
+        {"count"=>1, "data"=>["Cousijn, Helena", "Audiovisual"]},
+        {"count"=>1, "data"=>["Cousijn, Helena", "Output Management Plan"]},
+        {"count"=>1, "data"=>["Cousijn, Helena", "Service"]},
+        {"count"=>28, "data"=>["Dasler, Robin", "Text"]},
+        {"count"=>1, "data"=>["Dasler, Robin", "Collection"]},
+        {"count"=>27, "data"=>["Vierkant, Paul", "Text"]},
+        {"count"=>1, "data"=>["Vierkant, Paul", "Other"]},
+        {"count"=>1, "data"=>["Vierkant, Paul", "Report"]},
+        {"count"=>21, "data"=>["Garza, Kristian", "Text"]},
+        {"count"=>4, "data"=>["Garza, Kristian", "Software"]},
+        {"count"=>2, "data"=>["Garza, Kristian", "Collection"]},
+        {"count"=>1, "data"=>["Garza, Kristian", "Other"]}
+      ]
+
+
+      expect(flattened_contributors_works).to eq (expected_results)
     end
   end
 

--- a/spec/fixtures/files/contributor_worktype_multi_aggs.json
+++ b/spec/fixtures/files/contributor_worktype_multi_aggs.json
@@ -1,0 +1,305 @@
+[
+    {
+        "key": "https://orcid.org/0000-0003-1419-2405",
+        "doc_count": 98,
+        "creators_and_contributors": {
+            "hits": {
+                "total": {
+                    "value": 98,
+                    "relation": "eq"
+                },
+                "max_score": 18.399986,
+                "hits": [
+                    {
+                        "_index": "dois_v2",
+                        "_type": "_doc",
+                        "_id": "10082554",
+                        "_score": 18.399986,
+                        "_ignored": [
+                            "landing_page.checked"
+                        ],
+                        "_source": {
+                            "creators_and_contributors": [
+                                {
+                                    "name": "Fenner, Martin",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0003-1419-2405"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "work_types": {
+            "doc_count_error_upper_bound": 0,
+            "sum_other_doc_count": 0,
+            "buckets": [
+                {
+                    "key": "text:Text",
+                    "doc_count": 75
+                },
+                {
+                    "key": "software:Software",
+                    "doc_count": 15
+                },
+                {
+                    "key": "collection:Collection",
+                    "doc_count": 4
+                },
+                {
+                    "key": "computational-notebook:Computational Notebook",
+                    "doc_count": 1
+                },
+                {
+                    "key": "dataset:Dataset",
+                    "doc_count": 1
+                },
+                {
+                    "key": "report:Report",
+                    "doc_count": 1
+                },
+                {
+                    "key": "service:Service",
+                    "doc_count": 1
+                }
+            ]
+        }
+    },
+    {
+        "key": "https://orcid.org/0000-0001-6660-6214",
+        "doc_count": 37,
+        "creators_and_contributors": {
+            "hits": {
+                "total": {
+                    "value": 37,
+                    "relation": "eq"
+                },
+                "max_score": 18.399986,
+                "hits": [
+                    {
+                        "_index": "dois_v2",
+                        "_type": "_doc",
+                        "_id": "17024242",
+                        "_score": 18.399986,
+                        "_ignored": [
+                            "landing_page.checked"
+                        ],
+                        "_source": {
+                            "creators_and_contributors": [
+                                {
+                                    "name": "Cousijn, Helena",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0001-6660-6214"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "Lowenberg, Daniella",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0003-2255-1869"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "work_types": {
+            "doc_count_error_upper_bound": 0,
+            "sum_other_doc_count": 0,
+            "buckets": [
+                {
+                    "key": "text:Text",
+                    "doc_count": 34
+                },
+                {
+                    "key": "audiovisual:Audiovisual",
+                    "doc_count": 1
+                },
+                {
+                    "key": "output-management-plan:Output Management Plan",
+                    "doc_count": 1
+                },
+                {
+                    "key": "service:Service",
+                    "doc_count": 1
+                }
+            ]
+        }
+    },
+    {
+        "key": "https://orcid.org/0000-0002-4695-7874",
+        "doc_count": 29,
+        "creators_and_contributors": {
+            "hits": {
+                "total": {
+                    "value": 29,
+                    "relation": "eq"
+                },
+                "max_score": 18.399986,
+                "hits": [
+                    {
+                        "_index": "dois_v2",
+                        "_type": "_doc",
+                        "_id": "19717809",
+                        "_score": 18.399986,
+                        "_ignored": [
+                            "landing_page.checked"
+                        ],
+                        "_source": {
+                            "creators_and_contributors": [
+                                {
+                                    "name": "Dasler, Robin",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0002-4695-7874"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "work_types": {
+            "doc_count_error_upper_bound": 0,
+            "sum_other_doc_count": 0,
+            "buckets": [
+                {
+                    "key": "text:Text",
+                    "doc_count": 28
+                },
+                {
+                    "key": "collection:Collection",
+                    "doc_count": 1
+                }
+            ]
+        }
+    },
+    {
+        "key": "https://orcid.org/0000-0003-4448-3844",
+        "doc_count": 29,
+        "creators_and_contributors": {
+            "hits": {
+                "total": {
+                    "value": 29,
+                    "relation": "eq"
+                },
+                "max_score": 18.399986,
+                "hits": [
+                    {
+                        "_index": "dois_v2",
+                        "_type": "_doc",
+                        "_id": "50877604",
+                        "_score": 18.399986,
+                        "_source": {
+                            "creators_and_contributors": [
+                                {
+                                    "name": "Vierkant, Paul",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0003-4448-3844"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "work_types": {
+            "doc_count_error_upper_bound": 0,
+            "sum_other_doc_count": 0,
+            "buckets": [
+                {
+                    "key": "text:Text",
+                    "doc_count": 27
+                },
+                {
+                    "key": "other:Other",
+                    "doc_count": 1
+                },
+                {
+                    "key": "report:Report",
+                    "doc_count": 1
+                }
+            ]
+        }
+    },
+    {
+        "key": "https://orcid.org/0000-0003-3484-6875",
+        "doc_count": 28,
+        "creators_and_contributors": {
+            "hits": {
+                "total": {
+                    "value": 28,
+                    "relation": "eq"
+                },
+                "max_score": 18.399986,
+                "hits": [
+                    {
+                        "_index": "dois_v2",
+                        "_type": "_doc",
+                        "_id": "15175593",
+                        "_score": 18.399986,
+                        "_ignored": [
+                            "landing_page.checked"
+                        ],
+                        "_source": {
+                            "creators_and_contributors": [
+                                {
+                                    "name": "Garza, Kristian",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0003-3484-6875"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "Fenner, Martin",
+                                    "nameIdentifiers": [
+                                        {
+                                            "nameIdentifier": "https://orcid.org/0000-0003-1419-2405"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "work_types": {
+            "doc_count_error_upper_bound": 0,
+            "sum_other_doc_count": 0,
+            "buckets": [
+                {
+                    "key": "text:Text",
+                    "doc_count": 21
+                },
+                {
+                    "key": "software:Software",
+                    "doc_count": 4
+                },
+                {
+                    "key": "collection:Collection",
+                    "doc_count": 2
+                },
+                {
+                    "key": "other:Other",
+                    "doc_count": 1
+                }
+            ]
+        }
+    }
+]

--- a/spec/graphql/types/work_type_spec.rb
+++ b/spec/graphql/types/work_type_spec.rb
@@ -1735,7 +1735,6 @@ describe WorkType do
       expect(response.dig(
         "data", "works", "personToWorkTypesMultilevel", 0, "inner"
       ).length()).to eq(1)
-
     end
 
     it "returns the correct counts for the person_to_work_types flattened" do
@@ -1755,11 +1754,10 @@ describe WorkType do
       expect(response.dig("data", "works", "personToWorkTypesFlat").length()).to eq(2)
       expect(response.dig("data", "works", "personToWorkTypesFlat")).to eq(
         [
-          {"count"=>1, "data"=>["Garza, Kristian", "Dataset"]},
-          {"count"=>1, "data"=>["Ross, Cody", "Dataset"]}
+          { "count" => 1, "data" => ["Garza, Kristian", "Dataset"] },
+          { "count" => 1, "data" => ["Ross, Cody", "Dataset"] }
         ]
       )
-
     end
   end
 

--- a/spec/graphql/types/work_type_spec.rb
+++ b/spec/graphql/types/work_type_spec.rb
@@ -1710,6 +1710,57 @@ describe WorkType do
       expect(response.dig("data", "works", "authors").length()).to eq(1)
       expect(response.dig("data", "works", "creatorsAndContributors").length()).to eq(2)
     end
+
+    it "returns the correct counts for the person_to_work_types multi-facet" do
+      gql_query = """
+        query($first: Int, $cursor: String, $facetCount: Int) {
+          works(first: $first, after: $cursor, facetCount: $facetCount) {
+            totalCount
+            personToWorkTypesMultilevel {
+              id
+              title
+              count
+              inner {
+                id
+                title
+                count
+              }
+            }
+          }
+        }
+      """
+
+      response = LupoSchema.execute(gql_query).as_json
+      expect(response.dig("data", "works", "personToWorkTypesMultilevel").length()).to eq(2)
+      expect(response.dig(
+        "data", "works", "personToWorkTypesMultilevel", 0, "inner"
+      ).length()).to eq(1)
+
+    end
+
+    it "returns the correct counts for the person_to_work_types flattened" do
+      gql_query = """
+        query($first: Int, $cursor: String, $facetCount: Int) {
+          works(first: $first, after: $cursor, facetCount: $facetCount) {
+            totalCount
+            personToWorkTypesFlat{
+              count
+              data
+            }
+          }
+        }
+      """
+
+      response = LupoSchema.execute(gql_query).as_json
+      expect(response.dig("data", "works", "personToWorkTypesFlat").length()).to eq(2)
+      expect(response.dig("data", "works", "personToWorkTypesFlat")).to eq(
+        [
+          {"count"=>1, "data"=>["Garza, Kristian", "Dataset"]},
+          {"count"=>1, "data"=>["Ross, Cody", "Dataset"]}
+        ]
+      )
+
+    end
   end
 
 


### PR DESCRIPTION
- Formatting
- Facet processing for multi-level facet with contributors and work-typs
- Facet processing to flatten multi-level facets
- Add multi-level and flat facets for person-worktypes
- Appease Rubocop
- Add specs for multi-level and flattened facets
- Appease Rubocop

## Purpose
Provide a flattened facet for person-worktypes
To be used in Sankey diagrams for DMPs
Can be used for any collection of works.

closes: datacite/datacite#1913



## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [X] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
