### PR TITLE
Metadata 4.5 - Add field to dataset DB for new publisher_obj

### DIFF
--- a/db/migrate/20231004145109_add_publisher_obj_to_doi.rb
+++ b/db/migrate/20231004145109_add_publisher_obj_to_doi.rb
@@ -4,6 +4,6 @@ class AddPublisherObjToDoi < ActiveRecord::Migration[6.1]
   end
 
   def down
-    remove_column :dataset, :related_items
+    remove_column :dataset, :publisher_obj
   end
 end

--- a/db/migrate/20231004145109_add_publisher_obj_to_doi.rb
+++ b/db/migrate/20231004145109_add_publisher_obj_to_doi.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPublisherObjToDoi < ActiveRecord::Migration[6.1]
   def up
     add_column :dataset, :publisher_obj, :json

--- a/db/migrate/20231004145109_add_publisher_obj_to_doi.rb
+++ b/db/migrate/20231004145109_add_publisher_obj_to_doi.rb
@@ -1,0 +1,9 @@
+class AddPublisherObjToDoi < ActiveRecord::Migration[6.1]
+  def up
+    add_column :dataset, :publisher_obj, :json
+  end
+
+  def down
+    remove_column :dataset, :related_items
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_23_122711) do
+ActiveRecord::Schema.define(version: 2023_10_04_145109) do
+
   create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", null: false
@@ -224,6 +223,7 @@ ActiveRecord::Schema.define(version: 2023_01_23_122711) do
     t.string "agency", limit: 191, default: "datacite"
     t.string "type", limit: 16, default: "DataCiteDoi"
     t.json "related_items"
+    t.json "publisher_obj"
     t.index ["aasm_state"], name: "index_dataset_on_aasm_state"
     t.index ["created", "indexed", "updated"], name: "index_dataset_on_created_indexed_updated"
     t.index ["datacentre"], name: "FK5605B47847B5F5FF"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +13,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2023_10_04_145109) do
-
   create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", null: false


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Add rails db migration for metadata-4.5 to add the publisher_obj field to the dataset.  

Related to: #1016

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [X] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
