### PR TITLE
Set reconnect: true in config/database.yml to avoid random timeouts du…

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -11,6 +11,7 @@ defaults: &defaults
   database: <%= ENV['MYSQL_DATABASE'] %>
   host: <%= ENV['MYSQL_HOST'] %>
   port: <%= ENV['MYSQL_PORT'] %>
+  reconnect: true
 
   <<: *mysql
 


### PR DESCRIPTION
…ring db queries.

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Reconnect on DB query timeouts.  This is related to the timeout that happened during a db migration operation in staging using the Departure gem (w/ percona toolset).  The  migration was completed but on updating the schema_migrations table to show that the migration had been done, the query timed out.  This setting would allow the mysql2 client to reconnect and try the op again.

UPDATE - What are the side-effects of allowing reconnects like this.  Is it safe?  Would increasing the timeout period be a good alternative solution?

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
