### PR TITLE
Get other_related works/dois

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -237,6 +237,16 @@ type Audiovisual implements DoiItem {
   member: Member
 
   """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
+
+  """
   Total number of parts
   """
   partCount: Int
@@ -562,6 +572,16 @@ type Book implements DoiItem {
   member: Member
 
   """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
+
+  """
   Total number of parts
   """
   partCount: Int
@@ -834,6 +854,16 @@ type BookChapter implements DoiItem {
   The member account managing this resource
   """
   member: Member
+
+  """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
 
   """
   Total number of parts
@@ -1260,6 +1290,16 @@ type Collection implements DoiItem {
   member: Member
 
   """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
+
+  """
   Total number of parts
   """
   partCount: Int
@@ -1583,6 +1623,16 @@ type ConferencePaper implements DoiItem {
   The member account managing this resource
   """
   member: Member
+
+  """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
 
   """
   Total number of parts
@@ -2202,6 +2252,16 @@ type DataManagementPlan implements DoiItem {
   member: Member
 
   """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
+
+  """
   Total number of parts
   """
   partCount: Int
@@ -2527,6 +2587,16 @@ type DataPaper implements DoiItem {
   member: Member
 
   """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
+
+  """
   Total number of parts
   """
   partCount: Int
@@ -2850,6 +2920,16 @@ type Dataset implements DoiItem {
   The member account managing this resource
   """
   member: Member
+
+  """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
 
   """
   Total number of parts
@@ -3295,6 +3375,16 @@ type Dissertation implements DoiItem {
   member: Member
 
   """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
+
+  """
   Total number of parts
   """
   partCount: Int
@@ -3623,6 +3713,16 @@ interface DoiItem {
   member: Member
 
   """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
+
+  """
   Total number of parts
   """
   partCount: Int
@@ -3947,6 +4047,16 @@ type Event implements DoiItem {
   member: Member
 
   """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
+
+  """
   Total number of parts
   """
   partCount: Int
@@ -4248,6 +4358,16 @@ type EventData implements DoiItem {
   The member account managing this resource
   """
   member: Member
+
+  """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
 
   """
   Total number of parts
@@ -4849,6 +4969,16 @@ type Image implements DoiItem {
   member: Member
 
   """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
+
+  """
   Total number of parts
   """
   partCount: Int
@@ -5174,6 +5304,16 @@ type Instrument implements DoiItem {
   member: Member
 
   """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
+
+  """
   Total number of parts
   """
   partCount: Int
@@ -5497,6 +5637,16 @@ type InteractiveResource implements DoiItem {
   The member account managing this resource
   """
   member: Member
+
+  """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
 
   """
   Total number of parts
@@ -5827,6 +5977,16 @@ type JournalArticle implements DoiItem {
   The member account managing this resource
   """
   member: Member
+
+  """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
 
   """
   Total number of parts
@@ -6450,6 +6610,16 @@ type Model implements DoiItem {
   member: Member
 
   """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
+
+  """
   Total number of parts
   """
   partCount: Int
@@ -6972,6 +7142,16 @@ type Other implements DoiItem {
   member: Member
 
   """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
+
+  """
   Total number of parts
   """
   partCount: Int
@@ -7320,6 +7500,16 @@ type PeerReview implements DoiItem {
   The member account managing this resource
   """
   member: Member
+
+  """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
 
   """
   Total number of parts
@@ -7784,6 +7974,16 @@ type PhysicalObject implements DoiItem {
   member: Member
 
   """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
+
+  """
   Total number of parts
   """
   partCount: Int
@@ -8162,6 +8362,16 @@ type Preprint implements DoiItem {
   member: Member
 
   """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
+
+  """
   Total number of parts
   """
   partCount: Int
@@ -8485,6 +8695,16 @@ type Publication implements DoiItem {
   The member account managing this resource
   """
   member: Member
+
+  """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
 
   """
   Total number of parts
@@ -9457,6 +9677,16 @@ type Service implements DoiItem {
   member: Member
 
   """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
+
+  """
   Total number of parts
   """
   partCount: Int
@@ -9781,6 +10011,16 @@ type Software implements DoiItem {
   The member account managing this resource
   """
   member: Member
+
+  """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
 
   """
   Total number of parts
@@ -10137,6 +10377,16 @@ type Sound implements DoiItem {
   The member account managing this resource
   """
   member: Member
+
+  """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
 
   """
   Total number of parts
@@ -10675,6 +10925,16 @@ type Work implements DoiItem {
   member: Member
 
   """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
+
+  """
   Total number of parts
   """
   partCount: Int
@@ -11020,6 +11280,16 @@ type Workflow implements DoiItem {
   The member account managing this resource
   """
   member: Member
+
+  """
+  Other works related to this DOI.
+  """
+  otherRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource
+  """
+  otherRelatedCount: Int
 
   """
   Total number of parts

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -1315,29 +1315,8 @@ class Doi < ApplicationRecord
     Doi.query(nil, ids: version_of_ids, page: { number: 1, size: 25 }).results
   end
 
-  def _other_relation_types
-    additional_relation_types = %w[
-      is-reply-to
-      is-translation-of
-      is-published-in
-    ].freeze
-    remove_relation_types = Event::INCLUDED_RELATION_TYPES | ["is-part-of", "has-part"]
-    other_relation_types = (Event::RELATIONS_RELATION_TYPES | additional_relation_types) - remove_relation_types
-  end
-
   def other_relation_events
-    other_related_source_ids =  %w[
-      datacite_related
-      datacite-crossref
-      crossref
-    ]
-    Event.query(
-      nil,
-      doi: doi,
-      source_id: other_related_source_ids.join(","),
-      relation_type_id: _other_relation_types.join(","),
-      page:{size:500}
-    ).results.results
+    Event.events_involving(doi, Event::OTHER_RELATION_TYPES)
   end
 
   def other_relation_ids

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -1346,6 +1346,10 @@ class Doi < ApplicationRecord
     end.flatten.uniq - [doi.downcase]
   end
 
+  def other_relation_count
+    other_relation_ids.length
+  end
+
   def xml_encoded
     Base64.strict_encode64(xml) if xml.present?
   rescue ArgumentError

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -76,21 +76,23 @@ class Event < ApplicationRecord
   alias_attribute :created, :created_at
   alias_attribute :updated, :updated_at
 
-  INCLUDED_RELATION_TYPES = %w[
-    cites
-    is-cited-by
-    is-supplement-to
-    is-supplemented-by
-    references
-    is-referenced-by
+  # renamed to make it clearer that these relation types are grouped together as references
+  REFERENCE_RELATION_TYPES = %w[
+    cites is-supplemented-by references
   ].freeze
 
-  # renamed to make it clearer that these relation types are grouped together as references
-  REFERENCE_RELATION_TYPES = %w[cites is-supplemented-by references].freeze
-
   # renamed to make it clearer that these relation types are grouped together as citations
-  CITATION_RELATION_TYPES = %w[is-cited-by is-supplement-to is-referenced-by].freeze
+  CITATION_RELATION_TYPES = %w[
+    is-cited-by is-supplement-to is-referenced-by
+  ].freeze
 
+  INCLUDED_RELATION_TYPES = REFERENCE_RELATION_TYPES | CITATION_RELATION_TYPES
+
+  PART_RELATION_TYPES = %w[
+    is-part-of has-part
+  ]
+
+  NEW_RELATION_TYPES = %w[ is-reply-to is-translation-of is-published-in ]
   RELATIONS_RELATION_TYPES = %w[
     compiles
     is-compiled-by
@@ -119,6 +121,16 @@ class Event < ApplicationRecord
     is-previous-version-of
     describes
     is-described-by
+  ].freeze
+
+  OTHER_RELATION_TYPES = (
+    RELATIONS_RELATION_TYPES | NEW_RELATION_TYPES
+  ) - INCLUDED_RELATION_TYPES - PART_RELATION_TYPES
+
+  RELATED_SOURCE_IDS =  %w[
+    datacite-related
+    datacite-crossref
+    crossref
   ].freeze
 
   validates :subj_id, :source_id, :source_token, presence: true
@@ -1043,4 +1055,15 @@ class Event < ApplicationRecord
       self.license = "https://creativecommons.org/publicdomain/zero/1.0/"
     end
   end # overridden, use uuid instead of id
+
+  def self.events_involving(_doi, relation_types = OTHER_RELATION_TYPES)
+    self.query(
+      nil,
+      doi: _doi,
+      source_id: RELATED_SOURCE_IDS.join(","),
+      relation_type_id: relation_types.join(","),
+      page:{size:500}
+    ).results.results
+  end
+
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -127,7 +127,7 @@ class Event < ApplicationRecord
     RELATIONS_RELATION_TYPES | NEW_RELATION_TYPES
   ) - INCLUDED_RELATION_TYPES - PART_RELATION_TYPES
 
-  RELATED_SOURCE_IDS =  %w[
+  RELATED_SOURCE_IDS = %w[
     datacite-related
     datacite-crossref
     crossref
@@ -1062,8 +1062,7 @@ class Event < ApplicationRecord
       doi: _doi,
       source_id: RELATED_SOURCE_IDS.join(","),
       relation_type_id: relation_types.join(","),
-      page:{size:500}
+      page: { size: 500 }
     ).results.results
   end
-
 end

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
     occurred_at { Time.zone.now }
 
     factory :event_for_datacite_related do
-      source_id { "datacite_related" }
+      source_id { "datacite-related" }
       source_token { "datacite_related_123" }
       sequence(:subj_id) { |n| "http://doi.org/10.5061/DRYAD.47SD5e/#{n}" }
       subj do
@@ -39,7 +39,7 @@ FactoryBot.define do
     end
 
     factory :event_for_datacite_parts do
-      source_id { "datacite_related" }
+      source_id { "datacite-related" }
       source_token { "datacite_related_123" }
       subj_id { "http://doi.org/10.5061/DRYAD.47SD5" }
       subj { { "datePublished" => "2006-06-13T16:14:19Z" } }
@@ -48,7 +48,7 @@ FactoryBot.define do
     end
 
     factory :event_for_datacite_part_of do
-      source_id { "datacite_related" }
+      source_id { "datacite-related" }
       source_token { "datacite_related_123" }
       subj_id { "http://doi.org/10.5061/DRYAD.47SD5/1" }
       subj { { "datePublished" => "2006-06-13T16:14:19Z" } }
@@ -57,7 +57,7 @@ FactoryBot.define do
     end
 
     factory :event_for_datacite_versions do
-      source_id { "datacite_related" }
+      source_id { "datacite-related" }
       source_token { "datacite_related_123" }
       subj_id { "http://doi.org/10.5061/DRYAD.47SD5" }
       subj { { "datePublished" => "2006-06-13T16:14:19Z" } }
@@ -66,7 +66,7 @@ FactoryBot.define do
     end
 
     factory :event_for_datacite_version_of do
-      source_id { "datacite_related" }
+      source_id { "datacite-related" }
       source_token { "datacite_related_123" }
       subj_id { "http://doi.org/10.5061/DRYAD.47SD5/1" }
       subj { { "datePublished" => "2006-06-13T16:14:19Z" } }

--- a/spec/graphql/types/doi_item_spec.rb
+++ b/spec/graphql/types/doi_item_spec.rb
@@ -47,6 +47,7 @@ describe DoiItem do
     it { is_expected.to have_field(:downloadCount).of_type("Int") }
     it { is_expected.to have_field(:versionCount).of_type("Int") }
     it { is_expected.to have_field(:versionOfCount).of_type("Int") }
+    it { is_expected.to have_field(:otherRelatedCount).of_type("Int") }
     it { is_expected.to have_field(:partCount).of_type("Int") }
     it { is_expected.to have_field(:partOfCount).of_type("Int") }
     it { is_expected.to have_field(:citationsOverTime).of_type("[YearTotal!]") }
@@ -71,6 +72,9 @@ describe DoiItem do
     end
     it do
       is_expected.to have_field(:version_of).of_type("WorkConnectionWithTotal")
+    end
+    it do
+      is_expected.to have_field(:other_related).of_type("WorkConnectionWithTotal")
     end
   end
 end

--- a/spec/graphql/types/work_type_spec.rb
+++ b/spec/graphql/types/work_type_spec.rb
@@ -1911,7 +1911,7 @@ describe WorkType do
     end
   end
 
-describe "query with relationships", elasticsearch: true, vcr: true do
+  describe "query with relationships", elasticsearch: true, vcr: true do
     let(:client) { create(:client) }
     let(:doi) { create(:doi, client: client, aasm_state: "findable") }
 
@@ -2029,9 +2029,5 @@ describe "query with relationships", elasticsearch: true, vcr: true do
       expect(@response.dig("data", "work", "otherRelatedCount")).to eq(3)
       expect(@response.dig("data", "work", "otherRelated", "nodes").length).to eq(3)
     end
-end
-
-
-
-
+  end
 end

--- a/spec/models/doi_related_spec.rb
+++ b/spec/models/doi_related_spec.rb
@@ -230,6 +230,5 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
       expect(doi.other_relation_ids.length).to eq(3)
       expect(doi.other_relation_count).to eq(3)
     end
-
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -315,7 +315,7 @@ describe Event, type: :model, vcr: true do
       expect(subject.subj_id).to eq("https://doi.org/10.5061/dryad.47sd5")
       expect(subject.obj_id).to eq("https://doi.org/10.5061/dryad.47sd5/1")
       expect(subject.relation_type_id).to eq("has-version")
-      expect(subject.source_id).to eq("datacite_related")
+      expect(subject.source_id).to eq("datacite-related")
       expect(subject.dois_to_import).to eq([])
     end
   end


### PR DESCRIPTION
Get other_related_ids from Event info

Add specs for other_relation connections

Update factory for events to use hyphenated datacite-related, like production data

Refactor and move events query to events model

Add other_related items to graphql

Add other_related items to graphql specs

Appease rubocop

## Purpose
Adds other_related works/dois

closes: #1024

## Approach
Pulls relevant related works from the Event data
There is an explicit list of source_ids considered
and a list of explicit relationships that are included in the category "Other Related"


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
