### PR TITLE
GraphQL person search errors if there is not a query value

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -14,7 +14,9 @@ class GraphqlController < ApplicationController
     result =
       LupoSchema.execute(
         query,
-        variables: variables, context: context, operation_name: operation_name,
+        variables: variables,
+        context: context,
+        operation_name: operation_name,
       )
     render json: ApolloFederation::Tracing.attach_trace_to_result(result)
   rescue StandardError => e

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -208,7 +208,7 @@ class QueryType < BaseObject
   end
 
   def people(**args)
-    query = args[:query].gsub(/^https?:\/\//, "")
+    query = args[:query]&.gsub(/^https?:\/\//, "")
     response = Person.query(query, limit: args[:first], offset: args[:after].present? ? Base64.urlsafe_decode64(args[:after]) : nil)
     HashConnection.new(response, context: context, first: args[:first], after: args[:after])
   end

--- a/spec/fixtures/vcr_cassettes/PersonType/query_people_with_nil_query_should_not_throw_NilClass_error/returns_success_response.yml
+++ b/spec/fixtures/vcr_cassettes/PersonType/query_people_with_nil_query_should_not_throw_NilClass_error/returns_success_response.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pub.sandbox.orcid.org/v3.0/expanded-search/?q=*&rows=25&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/4.9.8; mailto:info@datacite.org)
+      Accept:
+      - application/json;charset=UTF-8
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 20 Oct 2023 05:11:46 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 818ec30c29914eb7-JNB
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Vary:
+      - accept-encoding
+      Pragma:
+      - no-cache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Target:
+      - reg-sbox-papi-use2-a1
+      X-Via:
+      - a1
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAALVXS4/bOAz+KwNfeokC62HJntMWk+7s7PSF6e6p2INiK7EQWxrI9symRf97GTvNpCv1IGMTwEBAmvRHkfxIfU3Uv4/SVKpCTnVD0yfXn78m1pW6QrpKrpMUfggegggTAvE8z5NFstVPyiAjW9XBO2/3xoBwI1vd7E/SB9sps1ZuC6rSqUr3oyq5NkPTLBLb18odJZ//WSSqlbqBv0njJkPGxW/rYamqIQG1Nl2v+6HX1pyMvi2CUDHiKaaIM+xDXckneNfDei+HTStNJNLqeceKbB5IgvIUF0gUjHkg38kePvnsw/yoylJHgmwfD0asoD9wLpJ28r980bTl0kKi4kKgCDOSoZRkwgvhwULm+0AEuuvVPjIEZ9drrdqKifQliOkLy8nhqJkZBKX4EEnGA3kwuqu1H8VKdTI2D0dny9H2HO8hH9VJOKeWKEoFKaA3BQ4UvNGqCXSnanW5i4xhcracbBkvzmJwo6wahfP6geRYIAGJ8PNgjS6lH8MHs5dma2Mbwk5mjLO5/JKneYYELfzWvVfGqL4OsWFfxzPMzk1mZ+0bXd4CAyFS5pfGRzkECuPuSbnORgKNBUUyliOMuZ/r16ZyIep7r55V01wSFUGM0gwxzImH6taprXV7H9at001jjYrM63byt9wezVnBz3rpJ+m8rGOawQTMROETAvjWj34kb1qos0Fd9IgPPJsXiBDuT+YPDzd3q6vfN7LYSBLo9VH99qS+GEaMBOPAqDwwmG9qB+NGj+n+D75PsmmGNrIMym60gtkzlzRpQaC7OfPP8165UMG+K2/kOrZcd7u2fJm8u4PnZVuW4Gjm1CUICABoAAv/kH+xoq3ck3S6jER+drSLpKomHwdhB6k0Crh6Bno48azgqMCZzxQPuqylC+F/dWeMLZX5EjuwXKXBcnaRwLjKRYoIpX6RbLTrOg/rhOeCREsLzhDh1Gen101zZTdX8J2r96PIO8e/4bLiELyAuuGiU4ogLihsJCnx19u/bOsj+6Ou68sConmWwvJR+LP8T1sHrmArG9npsYBwluYoS5mfyFsnaxk4pGlt7y68XlB2uKqm/npxnDJVTjbr/JdT5qS+4NEJnnKUZTjQA66vBxcYMf1QlnXsvWPytjwa/7y0y+5MOvOqDbMHMRFo5U+9eqxVoCrfrNf/U/5BboYWbexgAFVBUka+fQfyfgVc0hAAAA==
+    http_version: null
+  recorded_at: Fri, 20 Oct 2023 05:11:45 GMT
+recorded_with: VCR 5.1.0

--- a/spec/graphql/types/person_type_spec.rb
+++ b/spec/graphql/types/person_type_spec.rb
@@ -629,4 +629,34 @@ describe PersonType do
       expect(response.dig("data", "errors")).to(eq(nil))
     end
   end
+
+  describe "query people with nil query should not throw NilClass error", elasticsearch: true, vcr: true do
+    let(:query) do
+      "query asdfsadfa {
+        people(first: 25, query: null, after: null) {
+          totalCount
+          pageInfo {
+            endCursor
+            hasNextPage
+            __typename
+          }
+          nodes {
+            id
+            name
+            givenName
+            familyName
+            alternateName
+            __typename
+          }
+          __typename
+        }
+      }"
+    end
+
+    it "returns success response" do
+      response = LupoSchema.execute(query).as_json
+
+      expect(response.dig("data", "errors")).to(eq(nil))
+    end
+  end
 end


### PR DESCRIPTION
## Purpose
closes: https://github.com/datacite/datacite/issues/1949


## Approach
Add a null safe operator the when stripping out the URL scheme from the the query value. The query can, it seems, sometimes be null. The previous implementation was simply passing the null value into the GraphQL query so we will continue with that approach.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
