### PR TITLE
Updates to openapi.yaml

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -504,7 +504,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/vnd.api+json:
+          application/json:
             schema:
               $ref: '#/components/schemas/Doi'
       responses:
@@ -546,7 +546,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/vnd.api+json:
+          application/json:
             schema:
               $ref: '#/components/schemas/Doi'
       responses:
@@ -1047,7 +1047,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/vnd.api+json:
+          application/json:
             schema:
               $ref: '#/components/schemas/Report'
       responses:
@@ -1089,7 +1089,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/vnd.api+json:
+          application/json:
             schema:
               $ref: '#/components/schemas/Report'
       responses:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -463,42 +463,42 @@ paths:
               - 503
         - in: query
           name: has-citations
-          description: Searches the citation_count field for integer values greater than or equal to the inputted value. 
+          description: Searches the citationCount field for integer values greater than or equal to the inputted value. 
           schema:
             type: integer
         - in: query
           name: has-references
-          description: Searches the reference_count field for integer values greater than or equal to the inputted value. 
+          description: Searches the referenceCount field for integer values greater than or equal to the inputted value. 
           schema:
             type: integer
         - in: query
           name: has-parts
-          description: Searches the part_count field for integer values greater than or equal to the inputted value. 
+          description: Searches the partCount field for integer values greater than or equal to the inputted value. 
           schema:
             type: integer
         - in: query
           name: has-part-of
-          description: Searches the part_of_count field for integer values greater than or equal to the inputted value. 
+          description: Searches the partOfCount field for integer values greater than or equal to the inputted value. 
           schema:
             type: integer
         - in: query
           name: has-versions
-          description: Searches the version_count field for integer values greater than or equal to the inputted value. 
+          description: Searches the versionCount field for integer values greater than or equal to the inputted value. 
           schema:
             type: integer
         - in: query
           name: has-version-of
-          description: Searches the version_of_count field for integer values greater than or equal to the inputted value. 
+          description: Searches the versionOfCount field for integer values greater than or equal to the inputted value. 
           schema:
             type: integer
         - in: query
           name: has-views
-          description: Searches the view_count field for integer values greater than or equal to the inputted value. 
+          description: Searches the viewCount field for integer values greater than or equal to the inputted value. 
           schema:
             type: integer
         - in: query
           name: has-downloads
-          description: Searches the download_count field for integer values greater than or equal to the inputted value. 
+          description: Searches the downloadCount field for integer values greater than or equal to the inputted value. 
           schema:
             type: integer
         - in: query
@@ -518,7 +518,7 @@ paths:
             type: boolean
         - in: query
           name: has-funder
-          description: Returns DOIs where funding_references.funderIdentifierType has at least one "Crossref Funder ID" value. 
+          description: Returns DOIs where fundingReferences.funderIdentifierType has at least one "Crossref Funder ID" value. 
           schema:
             type: boolean
         - in: query

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -206,6 +206,7 @@ paths:
             enum:
               - repository
               - periodical
+              - igsnCatalog
         - in: query
           name: repository-type
           schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -343,6 +343,14 @@ paths:
           schema:
             type: string
         - in: query
+          name: client-type
+          schema:
+            type: string
+            enum:
+              - repository
+              - periodical
+              - igsnCatalog
+        - in: query
           name: certificate
           schema:
             type: string
@@ -359,7 +367,12 @@ paths:
           schema:
             type: string
         - in: query
+          name: funder-id
+          schema:
+            type: string
+        - in: query
           name: resource-type-id
+          description: Filter by the resourceTypeGeneral.
           schema:
             type: string
             enum:
@@ -391,6 +404,11 @@ paths:
               - text
               - workflow
               - other
+        - in: query
+          name: resource-type
+          description: Filter by the free text resourceType.
+          schema:
+            type: string  
         - in: query
           name: subject
           schema:
@@ -488,6 +506,21 @@ paths:
               - '-created'
               - updated
               - '-updated'
+        - in: query
+          name: disable-facets
+          description: Exclude facets from the response.
+          schema:
+            type: boolean
+        - in: query
+          name: detail
+          description: When set to true, will include the following attributes in the response - prefix, suffix, viewsOverTime, citationsOverTime, provider, references, citations. parts, partOf, versions, versionOf, xml, alternateIdentifiers.
+          schema:
+            type: boolean
+        - in: query
+          name: field[dois]
+          description: Only return the attributes specified. For example, "fields[dois]=titles,subjects" will only return titles and subjects.
+          schema:
+            type: string
       responses:
         '200':
           description: A JSON array of dois.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -368,6 +368,9 @@ paths:
             type: string
         - in: query
           name: funder-id
+        - in: query
+          name: user-id
+          description: Searches creators.nameIdentifiers.nameIdentifier for an ORCID iD.
           schema:
             type: string
         - in: query

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -462,6 +462,66 @@ paths:
               - 502
               - 503
         - in: query
+          name: has-citations
+          description: Searches the citation_count field for integer values greater than or equal to the inputted value. 
+          schema:
+            type: integer
+        - in: query
+          name: has-references
+          description: Searches the reference_count field for integer values greater than or equal to the inputted value. 
+          schema:
+            type: integer
+        - in: query
+          name: has-parts
+          description: Searches the part_count field for integer values greater than or equal to the inputted value. 
+          schema:
+            type: integer
+        - in: query
+          name: has-part-of
+          description: Searches the part_of_count field for integer values greater than or equal to the inputted value. 
+          schema:
+            type: integer
+        - in: query
+          name: has-versions
+          description: Searches the version_count field for integer values greater than or equal to the inputted value. 
+          schema:
+            type: integer
+        - in: query
+          name: has-version-of
+          description: Searches the version_of_count field for integer values greater than or equal to the inputted value. 
+          schema:
+            type: integer
+        - in: query
+          name: has-views
+          description: Searches the view_count field for integer values greater than or equal to the inputted value. 
+          schema:
+            type: integer
+        - in: query
+          name: has-downloads
+          description: Searches the download_count field for integer values greater than or equal to the inputted value. 
+          schema:
+            type: integer
+        - in: query
+          name: has-person
+          description: Returns DOIs where creators.nameIdentifiers.nameIdentifierScheme has at least one "ORCID" value. 
+          schema:
+            type: boolean
+        - in: query
+          name: has-affiliation
+          description: Returns DOIs where either creators.affiliation.affiliationIdentifierScheme or contributors.affiliation.affiliationIdentifierScheme has at least one "ROR" value. 
+          schema:
+            type: boolean
+        - in: query
+          name: has-organization
+          description: Returns DOIs where either creators.nameIdentifiers.nameIdentifierScheme or contributors.nameIdentifiers.nameIdentifierScheme has at least one "ROR" value. 
+          schema:
+            type: boolean
+        - in: query
+          name: has-funder
+          description: Returns DOIs where funding_references.funderIdentifierType has at least one "Crossref Funder ID" value. 
+          schema:
+            type: boolean
+        - in: query
           name: random
           description: Retreive a random sample of DOIs. When true, the page[number] parameter is ignored.
           schema:
@@ -528,6 +588,16 @@ paths:
           description: Only return the attributes specified. For example, "fields[dois]=titles,subjects" will only return titles and subjects.
           schema:
             type: string
+        - in: query
+          name: source
+          schema:
+            type: string
+            enum:
+                - mds
+                - api
+                - fabricaForm
+                - fabrica
+                - ez
       responses:
         '200':
           description: A JSON array of dois.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -364,10 +364,14 @@ paths:
               - WDS
         - in: query
           name: affiliation-id
+          description: Searches creators.affiliation.affiliationIdentifier and contributors.affiliation.affiliationIdentifier for a ROR ID.
           schema:
             type: string
         - in: query
           name: funder-id
+          description: Searches fundingReferences.funderIdentifier for a Crossref Funder ID.
+          schema:
+            type: string
         - in: query
           name: user-id
           description: Searches creators.nameIdentifiers.nameIdentifier for an ORCID iD.


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

## Approach
<!--- _How does this change address the problem?_ -->
- Changes the requestBody content type from `application/vnd.api+json` to `application/json`. 
   - This results in cleaner code snippet generation in the [ReadMe.io API Reference](https://support.datacite.org/reference), because the content type is properly recognized as JSON.
- Adds parameters to the GET /dois request:
  - `funder-id`
  - `resource-type`
  - `disable-facets`
  - `client-type`
  - `detail`
  - `field[dois]`
  - `user-id`
  - `has-citations`
  - `has-references`
  - `has-parts`
  - `has-part-of`
  - `has-versions`
  - `has-version-of`
  - `has-views`
  - `has-downloads`
  - `has-person`
  - `has-affiliation`
  - `has-organization`
  - `has-funder`
  - `source`
- Updates the options for `client-type` to include `igsnCatalog`.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
