### PR TITLE
Allow subjects valueUri to be null

### DIFF
--- a/app/models/schemas/client/subjects.json
+++ b/app/models/schemas/client/subjects.json
@@ -7,7 +7,12 @@
       "properties": {
         "classificationCode":  { "type": "string" },
         "schemeUri":           { "type": "string" },
-        "valueUri":            { "type": "string" },
+        "valueUri": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "lang":                { "type": "string" },
         "subject":             { "type": "string" },
         "subjectScheme":       { "type": "string" }

--- a/spec/requests/repositories_spec.rb
+++ b/spec/requests/repositories_spec.rb
@@ -405,6 +405,7 @@ describe RepositoriesController, type: :request, elasticsearch: true do
            "schemeUri" => "http://www.abs.gov.au/ausstats/abs@.nsf/0/6BB427AB9696C225CA2574180004463E",
            "subjectScheme" => "FOR",
            "lang" => "en",
+           "valueUri" => nil,
            "classificationCode" => "001" }]
       end
       let(:update_attributes) do
@@ -437,6 +438,7 @@ describe RepositoriesController, type: :request, elasticsearch: true do
             "schemeUri" => "http://www.abs.gov.au/ausstats/abs@.nsf/0/6BB427AB9696C225CA2574180004463E",
             "subject" => "80505 Web Technologies (excl. Web Search)",
             "subjectScheme" => "FOR",
+            "valueUri" => nil,
             "classificationCode" => "001"
           }
         ])


### PR DESCRIPTION
Allow json schema validation to accept null values for valueUri

## Purpose
Fix for https://github.com/datacite/datacite/issues/1971

## Approach
Ensure null can be an accepted validation type for json schema.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
