### PR TITLE
Allow events to trigger on specific conditions

### DIFF
--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -21,11 +21,10 @@ module Indexable
       end
 
       if instance_of?(DataciteDoi) || instance_of?(OtherDoi) || instance_of?(Doi)
-        if aasm_state == "findable" && !Rails.env.test?
-          # If following fields are modified or the state has changed (any other state to findable), send import message
-          if saved_change_to_attribute?("related_identifiers") || saved_change_to_attribute?("creators") || saved_change_to_attribute?("funding_references") || aasm_state_changed?
-            send_import_message(to_jsonapi)
-          end
+        if aasm_state == "findable"
+          changed_attributes = saved_changes
+          relevant_changes = changed_attributes.keys & %w[related_identifiers creators funding_references aasm_state]
+          send_import_message(to_jsonapi) if relevant_changes.any?
         end
       elsif instance_of?(Event)
         OtherDoiJob.perform_later(dois_to_import)

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -20,17 +20,12 @@ module Indexable
         end
       end
 
-      if (
-         instance_of?(DataciteDoi) || instance_of?(OtherDoi) ||
-           instance_of?(Doi)
-       ) &&
-          (
-            saved_change_to_attribute?("related_identifiers") ||
-              saved_change_to_attribute?("creators") ||
-              saved_change_to_attribute?("funding_references")
-          )
-        if aasm_state == "findable" && !Rails.env.test?
-          send_import_message(to_jsonapi)
+      if (instance_of?(DataciteDoi) || instance_of?(OtherDoi) ||instance_of?(Doi))
+        if aasm_state == "findable"
+          # If following fields are modified or the state has changed (any other state to findable), send import message
+          if saved_change_to_attribute?("related_identifiers") || saved_change_to_attribute?("creators") || saved_change_to_attribute?("funding_references") || aasm_state_changed?
+            send_import_message(to_jsonapi)
+          end
         end
       elsif instance_of?(Event)
         OtherDoiJob.perform_later(dois_to_import)

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -21,7 +21,7 @@ module Indexable
       end
 
       if instance_of?(DataciteDoi) || instance_of?(OtherDoi) || instance_of?(Doi)
-        if aasm_state == "findable"
+        if aasm_state == "findable" && !Rails.env.test?
           # If following fields are modified or the state has changed (any other state to findable), send import message
           if saved_change_to_attribute?("related_identifiers") || saved_change_to_attribute?("creators") || saved_change_to_attribute?("funding_references") || aasm_state_changed?
             send_import_message(to_jsonapi)

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -20,7 +20,7 @@ module Indexable
         end
       end
 
-      if (instance_of?(DataciteDoi) || instance_of?(OtherDoi) ||instance_of?(Doi))
+      if instance_of?(DataciteDoi) || instance_of?(OtherDoi) || instance_of?(Doi)
         if aasm_state == "findable"
           # If following fields are modified or the state has changed (any other state to findable), send import message
           if saved_change_to_attribute?("related_identifiers") || saved_change_to_attribute?("creators") || saved_change_to_attribute?("funding_references") || aasm_state_changed?

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -31,48 +31,48 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
     end
   end
 
-  describe 'after_commit' do
-    let(:doi) { create(:doi, aasm_state: 'findable') }
-    context 'when aasm_state is findable' do
+  describe "after_commit" do
+    let(:doi) { create(:doi, aasm_state: "findable") }
+    context "when aasm_state is findable" do
       before do
         allow(doi).to receive(:saved_change_to_attribute?).and_return(false)
         allow(doi).to receive(:aasm_state_changed?).and_return(false)
         allow(doi).to receive(:send_import_message)
       end
 
-      it 'sends import message if related_identifiers is modified' do
-        doi.related_identifiers = ['new_identifier']
+      it "sends import message if related_identifiers is modified" do
+        doi.related_identifiers = ["new_identifier"]
         doi.save
         expect(doi).to have_received(:send_import_message).with(doi.to_jsonapi)
       end
 
-      it 'sends import message if creators is modified' do
-        doi.creators = ['new_creator']
+      it "sends import message if creators is modified" do
+        doi.creators = ["new_creator"]
         doi.save
         expect(doi).to have_received(:send_import_message).with(doi.to_jsonapi)
       end
 
-      it 'sends import message if funding_references is modified' do
-        doi.funding_references = ['new_reference']
+      it "sends import message if funding_references is modified" do
+        doi.funding_references = ["new_reference"]
         doi.save
         expect(doi).to have_received(:send_import_message).with(doi.to_jsonapi)
       end
 
-      it 'sends import message if aasm_state is changed' do
-        doi.aasm_state = 'another_state'
+      it "sends import message if aasm_state is changed" do
+        doi.aasm_state = "another_state"
         doi.save
         expect(doi).to have_received(:send_import_message).with(doi.to_jsonapi)
       end
 
-      it 'does not send import message if none of the conditions are met' do
+      it "does not send import message if none of the conditions are met" do
         doi.save
         expect(doi).not_to have_received(:send_import_message)
       end
     end
 
-    context 'when aasm_state is not findable' do
-      it 'does not send import message' do
-        allow(doi).to receive(:aasm_state).and_return('not_findable')
+    context "when aasm_state is not findable" do
+      it "does not send import message" do
+        allow(doi).to receive(:aasm_state).and_return("not_findable")
         doi.save
         expect(doi).not_to have_received(:send_import_message)
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,6 +46,7 @@ RSpec.configure do |config|
   config.include RSpec::Benchmark::Matchers
   config.include Rack::Test::Methods, type: :request
   config.include RSpec::GraphqlMatchers::TypesHelper
+  config.include ActiveSupport::Testing::TimeHelpers
 
   # don't use transactions, use database_clear gem via support file
   config.use_transactional_fixtures = false

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -925,7 +925,10 @@ describe EventsController, type: :request, elasticsearch: true, vcr: true do
   end
 
   context "show" do
-    let(:doi) { create(:doi, client: client, aasm_state: "findable") }
+    let(:doi) do
+      allow_any_instance_of(DataciteDoi).to receive(:send_import_message)
+      create(:doi, client: client, aasm_state: "findable")
+    end
     let(:source_doi) { create(:doi, client: client, aasm_state: "findable") }
     let!(:event) do
       create(

--- a/spec/requests/old_events_spec.rb
+++ b/spec/requests/old_events_spec.rb
@@ -915,7 +915,10 @@ describe EventsController, type: :request, elasticsearch: true, vcr: true do
   end
 
   context "show" do
-    let(:doi) { create(:doi, client: client, aasm_state: "findable") }
+    let(:doi) do
+      allow_any_instance_of(DataciteDoi).to receive(:send_import_message)
+      create(:doi, client: client, aasm_state: "findable")
+    end
     let(:source_doi) { create(:doi, client: client, aasm_state: "findable") }
     let!(:event) do
       create(


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Events not created when DOI first created in registered or draft state

closes: https://github.com/datacite/datacite/issues/1710

## Approach
<!--- _How does this change address the problem?_ -->
Events should be created at following conditions,

- When we create a DOI directly with `findable` state
- When state is `findable` and there is an update in any of these fields `related_identifiers`, `creators`, `funding_references`
- When we change DOI state from `any other state` to `findable`

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
