### PR TITLE
Account for nil related_identifiers when indexing related_dois

### DIFF
--- a/app/models/doi/indexer/related_doi_indexer.rb
+++ b/app/models/doi/indexer/related_doi_indexer.rb
@@ -3,12 +3,12 @@
 module Doi::Indexer
   class RelatedDoiIndexer
     def initialize(related_identifiers)
-      @related_identifiers = related_identifiers
+      @related_identifiers = Array.wrap(related_identifiers)
       @related_dois = nil
     end
 
     def related_dois
-      @related_dois ||= @related_identifiers.select { |r| r["relatedIdentifierType"] == "DOI" }
+      @related_dois ||= @related_identifiers.select { |r| r.fetch("relatedIdentifierType", nil) == "DOI" }
     end
 
     def related_grouped_by_id


### PR DESCRIPTION
## Purpose
Related_identifiers may be nil.  We need to makes sure we can handle this.

closes: #1058

## Approach
Uses Array.Wrap to create an empty array if related_identifiers is nil.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
