### PR TITLE
Fixes for activities endpoints.

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -145,9 +145,7 @@ class ActivitiesController < ApplicationController
 
   protected
     def set_activity
-      response = Activity.find_by_request_uuid!(params[:id])
-      @activity = response
-
+      @activity = Activity.find_by_request_uuid!(params[:id])
       fail ActiveRecord::RecordNotFound if @activity.blank?
     end
 end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -145,8 +145,9 @@ class ActivitiesController < ApplicationController
 
   protected
     def set_activity
-      response = Activity.find_by_id(params[:id])
-      @activity = response.results.first
+      response = Activity.find_by_request_uuid!(params[:id])
+      @activity = response
+      puts response.inspect
       fail ActiveRecord::RecordNotFound if @activity.blank?
     end
 end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -147,7 +147,7 @@ class ActivitiesController < ApplicationController
     def set_activity
       response = Activity.find_by_request_uuid!(params[:id])
       @activity = response
-      puts response.inspect
+
       fail ActiveRecord::RecordNotFound if @activity.blank?
     end
 end

--- a/app/serializers/activity_serializer.rb
+++ b/app/serializers/activity_serializer.rb
@@ -28,13 +28,23 @@ class ActivitySerializer
 
     if params&.dig(:publisher) == "true"
       if pub_obj
-        changes[:publisher] = pub_obj
+        changes["publisher"] = pub_obj
       else
-        changes[:publisher] = action == "update" ? [{ "name": pub[0] }, { "name": pub[1] }] : { "name": pub }
+        changes["publisher"] = 
+          action == "update" ? [
+            pub[0] ? { "name": pub[0] } : nil, 
+            pub[1] ? { "name": pub[1] } : nil
+          ] : { "name": pub }
       end
     else
       if pub_obj
-        changes[:publisher] = action == "update" ? [pub_obj[0]["name"], pub_obj[1]["name"]] : pub_obj["name"]
+        changes["publisher"] = 
+          action == "update" ? [
+            pub_obj[0] ? pub_obj[0]["name"] : nil,
+            pub_obj[1] ? pub_obj[1]["name"] : nil
+          ] : pub_obj["name"]
+      else
+        changes["publisher"] = pub
       end
     end
 

--- a/app/serializers/activity_serializer.rb
+++ b/app/serializers/activity_serializer.rb
@@ -14,7 +14,7 @@ class ActivitySerializer
              :version
 
   attribute :changes do |object, params|
-    # Object is of different class if it comes from /activities/:uid
+    # Determine the source and action based on the object's type
     if object.is_a? Activity
       changes = object.audited_changes
       action = object.action
@@ -23,9 +23,11 @@ class ActivitySerializer
       action = object._source.action
     end
 
+    # Extract publisher and publisher_obj from changes
     pub = changes&.dig("publisher")
     pub_obj = changes&.dig("publisher_obj")
 
+    # Customize publisher information based on params[:publisher]
     if pub || pub_obj
       if params&.dig(:publisher) == "true"
         if pub_obj
@@ -50,8 +52,10 @@ class ActivitySerializer
       end
     end
 
+    # Remove the not needed "publisher_obj" key
     changes.delete("publisher_obj")
 
+    # Return the modified changes
     changes
   end
 

--- a/app/serializers/activity_serializer.rb
+++ b/app/serializers/activity_serializer.rb
@@ -14,6 +14,7 @@ class ActivitySerializer
              :version
 
   attribute :changes do |object, params|
+    # Object is of different class if it comes from /activities/:uid
     if object.is_a? Activity
       changes = object.audited_changes
       action = object.action
@@ -22,16 +23,15 @@ class ActivitySerializer
       action = object._source.action
     end
 
-    pub = changes.dig("publisher")
-    pub_obj = changes.dig("publisher_obj")
+    pub = changes&.dig("publisher")
+    pub_obj = changes&.dig("publisher_obj")
 
     if params&.dig(:publisher) == "true"
-      changes[:publisher] =
-        if pub_obj
-          changes[:publisher] = pub_obj
-        else
-          changes[:publisher] = action == "update" ? [{ "name": pub[0] }, { "name": pub[1] }] : { "name": pub }
-        end
+      if pub_obj
+        changes[:publisher] = pub_obj
+      else
+        changes[:publisher] = action == "update" ? [{ "name": pub[0] }, { "name": pub[1] }] : { "name": pub }
+      end
     else
       if pub_obj
         changes[:publisher] = action == "update" ? [pub_obj[0]["name"], pub_obj[1]["name"]] : pub_obj["name"]

--- a/app/serializers/activity_serializer.rb
+++ b/app/serializers/activity_serializer.rb
@@ -26,29 +26,31 @@ class ActivitySerializer
     pub = changes&.dig("publisher")
     pub_obj = changes&.dig("publisher_obj")
 
-    if params&.dig(:publisher) == "true"
-      if pub_obj
-        changes["publisher"] = pub_obj
+    if pub || pub_obj
+      if params&.dig(:publisher) == "true"
+        if pub_obj
+          changes["publisher"] = pub_obj
+        else
+          changes["publisher"] =
+            action == "update" ? [
+              pub[0] ? { "name": pub[0] } : nil,
+              pub[1] ? { "name": pub[1] } : nil
+            ] : { "name": pub }
+        end
       else
-        changes["publisher"] =
-          action == "update" ? [
-            pub[0] ? { "name": pub[0] } : nil,
-            pub[1] ? { "name": pub[1] } : nil
-          ] : { "name": pub }
-      end
-    else
-      if pub_obj
-        changes["publisher"] =
-          action == "update" ? [
-            pub_obj[0] ? pub_obj[0]["name"] : nil,
-            pub_obj[1] ? pub_obj[1]["name"] : nil
-          ] : pub_obj["name"]
-      else
-        changes["publisher"] = pub
+        if pub_obj
+          changes["publisher"] =
+            action == "update" ? [
+              pub_obj[0] ? pub_obj[0]["name"] : nil,
+              pub_obj[1] ? pub_obj[1]["name"] : nil
+            ] : pub_obj["name"]
+        else
+          changes["publisher"] = pub
+        end
       end
     end
 
-    changes.delete("publisher_obj") if pub_obj
+    changes.delete("publisher_obj")
 
     changes
   end

--- a/app/serializers/activity_serializer.rb
+++ b/app/serializers/activity_serializer.rb
@@ -30,15 +30,15 @@ class ActivitySerializer
       if pub_obj
         changes["publisher"] = pub_obj
       else
-        changes["publisher"] = 
+        changes["publisher"] =
           action == "update" ? [
-            pub[0] ? { "name": pub[0] } : nil, 
+            pub[0] ? { "name": pub[0] } : nil,
             pub[1] ? { "name": pub[1] } : nil
           ] : { "name": pub }
       end
     else
       if pub_obj
-        changes["publisher"] = 
+        changes["publisher"] =
           action == "update" ? [
             pub_obj[0] ? pub_obj[0]["name"] : nil,
             pub_obj[1] ? pub_obj[1]["name"] : nil

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,7 +178,7 @@ Rails.application.routes.draw do
 
   resources :heartbeat, only: %i[index]
 
-  resources :activities, only: %i[index show]
+  resources :activities, constraints: { id: /.+/ }
 
   resources :clients, constraints: { id: /.+/ } do
     resources :prefixes, constraints: { id: /.+/ }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,7 +178,7 @@ Rails.application.routes.draw do
 
   resources :heartbeat, only: %i[index]
 
-  resources :activities, constraints: { id: /.+/ }
+  resources :activities, only: %i[index show], constraints: { id: /.+/ }
 
   resources :clients, constraints: { id: /.+/ } do
     resources :prefixes, constraints: { id: /.+/ }

--- a/lib/tasks/activity.rake
+++ b/lib/tasks/activity.rake
@@ -36,6 +36,11 @@ namespace :activity do
     puts Activity.monitor_reindex
   end
 
+  desc "Create alias for activities"
+  task create_alias: :environment do
+    puts Activity.create_alias(index: ENV["INDEX"], alias: ENV["ALIAS"])
+  end
+
   desc "Import all activities"
   task import: :environment do
     from_id = (ENV["FROM_ID"] || 1).to_i

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -32,6 +32,7 @@ namespace :elasticsearch do
     Rake::Task["event:create_alias"].invoke
 
     Rake::Task["activity:create_index"].invoke
+    Rake::Task["activity:create_alias"].invoke
 
     Rake::Task["contact:create_index"].invoke
     Rake::Task["contact:create_alias"].invoke


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Should fix a several problems.  

1. The first is the https://github.com/datacite/lupo/issues/1054, where trying to retrieve activities for a DOI would cause a 'NoMethodError: undefined method 'name' for nil:NilClass' error when trying to display activities using /dois/:id/activities endpoint older DOIs in production.  This was a problem in the serializer.
2. Added a fix for https://github.com/datacite/lupo/issues/1060  where the /activities/:uid endpoint would always return not found.  Turns out it was not implemented. 
3. This is the same as item 1, described, above:  https://github.com/datacite/lupo/issues/1062
4. Minor fix for the dev environment setup so activities can successfully be tested manually: https://github.com/datacite/lupo/issues/1065
5. Also found it necessary in the activities serializer to guard to guard against audited changes that show an initial value of null for publisher or publisher_obj.  This happens when these fields are first assigned a value.  An example be found in the audit date for https://api.datacite.org/activities/7b333de3-77af-4200-8ffd-c8b2012a8d9e:

<img width="724" alt="image" src="https://github.com/datacite/lupo/assets/4681304/28d7cb9e-5c53-4c36-a058-9b2a8e67c762">

closes: https://github.com/datacite/lupo/issues/1054, https://github.com/datacite/lupo/issues/1060, https://github.com/datacite/lupo/issues/1062, https://github.com/datacite/lupo/issues/1065

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
