### PR TITLE
Temporarily remove related_doi indexing

### DIFF
--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -662,7 +662,6 @@ class Doi < ApplicationRecord
       "version_ids" => version_ids,
       "version_of_ids" => version_of_ids,
       "primary_title" => Array.wrap(primary_title),
-      "related_doi" => related_dois,
     }
   end
 


### PR DESCRIPTION
## Purpose
related_doi indexing was causing issues with stystem stability

## Approach
remove related_doi indexing from as_indexed_json
This temporarily removes it while keeping all other merges in place.

Will renable in the future when we find a more performant indexing solution

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
