### PR TITLE
saved_changes method behaves differently on staging server and on loc…

### DIFF
--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -27,7 +27,7 @@ module Indexable
           changed_attributes = saved_changes
           Rails.logger.info "[Event Data Import Message] #{aasm_state} #{changed_attributes.inspect} before call"
           relevant_changes = changed_attributes.keys & %w[related_identifiers creators funding_references aasm_state]
-          if relevant_changes.any?
+          if relevant_changes.any? || (created == updated)
             send_import_message(to_jsonapi)
             Rails.logger.info "[Event Data Import Message] #{aasm_state} #{to_jsonapi.inspect} send to Event Data service."
           end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -927,6 +927,7 @@ describe EventsController, type: :request, elasticsearch: true, vcr: true do
   context "show" do
     let(:doi) do
       allow_any_instance_of(DataciteDoi).to receive(:send_import_message)
+      allow_any_instance_of(Doi).to receive(:send_import_message)
       create(:doi, client: client, aasm_state: "findable")
     end
     let(:source_doi) { create(:doi, client: client, aasm_state: "findable") }

--- a/spec/requests/old_events_spec.rb
+++ b/spec/requests/old_events_spec.rb
@@ -917,6 +917,7 @@ describe EventsController, type: :request, elasticsearch: true, vcr: true do
   context "show" do
     let(:doi) do
       allow_any_instance_of(DataciteDoi).to receive(:send_import_message)
+      allow_any_instance_of(Doi).to receive(:send_import_message)
       create(:doi, client: client, aasm_state: "findable")
     end
     let(:source_doi) { create(:doi, client: client, aasm_state: "findable") }


### PR DESCRIPTION
…al server. Hence added explicit check to check newly created record

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

https://github.com/datacite/datacite/issues/1710

`Saved_changes` rails method gives incorrect result on staging server, ideally for newly created record it should give whole object, as there was no record before. Hence I have added a condition to check newly created record.

This is the staging server response for `saved_changes`
```
{\"minted\"=>[nil, Tue, 09 Jan 2024 09:53:25.000000000 UTC +00:00], \"version\"=>[1, 2]}
```

Locally we get whole changes of that object, see the log below
```
(byebug) saved_changes
{"id"=>[nil, 1], "created"=>[nil, Thu, 14 Dec 2023 10:07:40.000000000 UTC +00:00], "doi"=>[nil, "10.14454/6ADW4LJPGT9R"], "is_active"=>[nil, "\u0001"], "updated"=>[nil, Thu, 14 Dec 2023 10:07:40.000000000 UTC +00:00], "version"=>[nil, 2], "datacentre"=>[nil, 1], "minted"=>[nil, Sat, 02 Dec 2023 14:40:24.000000000 UTC +00:00], "url"=>[nil, "http://wilkinsonhammes.info/dennis"], "aasm_state"=>[nil, "findable"], "source"=>[nil, "test"], "creators"=>[nil, [{"nameType"=>"Personal", "name"=>"Ollomo, Benjamin", "givenName"=>"Benjamin", "familyName"=>"Ollomo"}, {"nameType"=>"Personal", "name"=>"Durand, Patrick", "givenName"=>"Patrick", "familyName"=>"Durand"}, {"nameType"=>"Personal", "name"=>"Prugnolle, Franck", "givenName"=>"Franck", "familyName"=>"Prugnolle"}, {"nameType"=>"Personal", "name"=>"Douzery, Emmanuel J. P.", "givenName"=>"Emmanuel J. P.", "familyName"=>"Douzery"}, {"nameType"=>"Personal", "name"=>"Arnathau, Céline", "givenName"=>"Céline", "familyName"=>"Arnathau"}, {"nameType"=>"Personal", "name"=>"Nkoghe, Dieudonné", "givenName"=>"Dieudonné", "familyName"=>"Nkoghe"}, {"nameType"=>"Personal", "name"=>"Leroy, Eric", "givenName"=>"Eric", "familyName"=>"Leroy"}, {"nameType"=>"Personal", "name"=>"Renaud, François", "givenName"=>"François", "familyName"=>"Renaud", "nameIdentifiers"=>[{"nameIdentifier"=>"https://orcid.org/0000-0003-1419-2405", "nameIdentifierScheme"=>"ORCID", "schemeUri"=>"https://orcid.org"}], "affiliation"=>[{"name"=>"DataCite", "affiliationIdentifier"=>"https://ror.org/04wxnsj81", "affiliationIdentifierScheme"=>"ROR"}]}]], "titles"=>[nil, [{"title"=>"Data from: A new malaria agent in African hominids."}]], "publisher"=>[nil, "Dryad Digital Repository"], "publication_year"=>[nil, 2011], "types"=>[nil, {"schemaOrg"=>"Dataset", "citeproc"=>"dataset", "bibtex"=>"misc", "ris"=>"DATA", "resourceTypeGeneral"=>"Dataset", "resourceType"=>"DataPackage"}], "descriptions"=>[nil, [{"description"=>"Data from: A new malaria agent in African hominids."}]], "dates"=>[nil, [{"date"=>"2011", "dateType"=>"Issued"}]], "identifiers"=>[nil, [{"identifierType"=>"publisher ID", "identifier"=>"pk-1234"}]], "related_identifiers"=>[nil, [{"relatedIdentifier"=>"10.5061/dryad.8515/1", "relatedIdentifierType"=>"DOI", "relationType"=>"HasPart"}, {"relatedIdentifier"=>"10.5061/dryad.8515/2", "relatedIdentifierType"=>"DOI", "relationType"=>"HasPart"}, {"relatedIdentifier"=>"10.1371/journal.ppat.1000446", "relatedIdentifierType"=>"DOI", "relationType"=>"IsReferencedBy"}, {"relatedIdentifier"=>"10.1371/journal.ppat.1000446", "relatedIdentifierType"=>"DOI", "relationType"=>"IsSupplementTo"}, {"relatedIdentifier"=>"19478877", "relatedIdentifierType"=>"PMID", "relationType"=>"IsReferencedBy"}, {"relatedIdentifier"=>"19478877", "relatedIdentifierType"=>"PMID", "relationType"=>"IsSupplementTo"}]], "rights_list"=>[nil, [{"rights"=>"Creative Commons Zero v1.0 Universal", "rightsUri"=>"https://creativecommons.org/publicdomain/zero/1.0/legalcode", "rightsIdentifier"=>"cc0-1.0", "rightsIdentifierScheme"=>"SPDX", "schemeUri"=>"https://spdx.org/licenses/"}]], "subjects"=>[nil, [{"subject"=>"Phylogeny"}, {"subject"=>"Malaria"}, {"subject"=>"Parasites"}, {"subject"=>"Taxonomy"}, {"subject"=>"Mitochondrial genome"}, {"subject"=>"Africa"}, {"subject"=>"Plasmodium"}]], "schema_version"=>[nil, "http://datacite.org/schema/kernel-4"], "xml"=>[nil, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<resource xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://datacite.org/schema/kernel-4\" xsi:schemaLocation=\"http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd\">\n  <identifier identifierType=\"DOI\">10.14454/6ADW4LJPGT9R</identifier>\n  <creators>\n    <creator>\n      <creatorName nameType=\"Personal\">Ollomo, Benjamin</creatorName>\n      <givenName>Benjamin</givenName>\n      <familyName>Ollomo</familyName>\n    </creator>\n    <creator>\n      <creatorName nameType=\"Personal\">Durand, Patrick</creatorName>\n      <givenName>Patrick</givenName>\n      <familyName>Durand</familyName>\n    </creator>\n    <creator>\n      <creatorName nameType=\"Personal\">Prugnolle, Franck</creatorName>\n      <givenName>Franck</givenName>\n      <familyName>Prugnolle</familyName>\n    </creator>\n    <creator>\n      <creatorName nameType=\"Personal\">Douzery, Emmanuel J. P.</creatorName>\n      <givenName>Emmanuel J. P.</givenName>\n      <familyName>Douzery</familyName>\n    </creator>\n    <creator>\n      <creatorName nameType=\"Personal\">Arnathau, Céline</creatorName>\n      <givenName>Céline</givenName>\n      <familyName>Arnathau</familyName>\n    </creator>\n    <creator>\n      <creatorName nameType=\"Personal\">Nkoghe, Dieudonné</creatorName>\n      <givenName>Dieudonné</givenName>\n      <familyName>Nkoghe</familyName>\n    </creator>\n    <creator>\n      <creatorName nameType=\"Personal\">Leroy, Eric</creatorName>\n      <givenName>Eric</givenName>\n      <familyName>Leroy</familyName>\n    </creator>\n    <creator>\n      <creatorName nameType=\"Personal\">Renaud, François</creatorName>\n      <givenName>François</givenName>\n      <familyName>Renaud</familyName>\n      <nameIdentifier nameIdentifierScheme=\"ORCID\" schemeURI=\"https://orcid.org\">https://orcid.org/0000-0003-1419-2405</nameIdentifier>\n      <affiliation affiliationIdentifier=\"https://ror.org/04wxnsj81\" affiliationIdentifierScheme=\"ROR\">DataCite</affiliation>\n    </creator>\n  </creators>\n  <titles>\n    <title>Data from: A new malaria agent in African hominids.</title>\n  </titles>\n  <publisher publisherIdentifier=\"https://ror.org/00x6h5n95\" publisherIdentifierScheme=\"ROR\" schemeURI=\"https://ror.org/\" xml:lang=\"en\">Dryad Digital Repository</publisher>\n  <publicationYear>2011</publicationYear>\n  <resourceType resourceTypeGeneral=\"Dataset\">DataPackage</resourceType>\n  <subjects>\n    <subject>Phylogeny</subject>\n    <subject>Malaria</subject>\n    <subject>Parasites</subject>\n    <subject>Taxonomy</subject>\n    <subject>Mitochondrial genome</subject>\n    <subject>Africa</subject>\n    <subject>Plasmodium</subject>\n  </subjects>\n  <dates>\n    <date dateType=\"Issued\">2011</date>\n  </dates>\n  <alternateIdentifiers>\n    <alternateIdentifier alternateIdentifierType=\"publisher ID\">pk-1234</alternateIdentifier>\n  </alternateIdentifiers>\n  <relatedIdentifiers>\n    <relatedIdentifier relatedIdentifierType=\"DOI\" relationType=\"HasPart\">10.5061/dryad.8515/1</relatedIdentifier>\n    <relatedIdentifier relatedIdentifierType=\"DOI\" relationType=\"HasPart\">10.5061/dryad.8515/2</relatedIdentifier>\n    <relatedIdentifier relatedIdentifierType=\"DOI\" relationType=\"IsReferencedBy\">10.1371/journal.ppat.1000446</relatedIdentifier>\n    <relatedIdentifier relatedIdentifierType=\"DOI\" relationType=\"IsSupplementTo\">10.1371/journal.ppat.1000446</relatedIdentifier>\n    <relatedIdentifier relatedIdentifierType=\"PMID\" relationType=\"IsReferencedBy\">19478877</relatedIdentifier>\n    <relatedIdentifier relatedIdentifierType=\"PMID\" relationType=\"IsSupplementTo\">19478877</relatedIdentifier>\n  </relatedIdentifiers>\n  <relatedItems>\n    <relatedItem relatedItemType=\"Journal\" relationType=\"IsPublishedIn\">\n      <relatedItemIdentifier relatedItemIdentifierType=\"DOI\">10.1016/j.physletb.2017.11.044</relatedItemIdentifier>\n      <titles>\n        <title>Physics letters / B</title>\n      </titles>\n      <publicationYear>2018</publicationYear>\n      <volume>776</volume>\n      <firstPage>249</firstPage>\n      <lastPage>264</lastPage>\n    </relatedItem>\n  </relatedItems>\n  <sizes/>\n  <formats/>\n  <version/>\n  <rightsList>\n    <rights rightsURI=\"https://creativecommons.org/publicdomain/zero/1.0/legalcode\" rightsIdentifier=\"cc0-1.0\" rightsIdentifierScheme=\"SPDX\" schemeURI=\"https://spdx.org/licenses/\">Creative Commons Zero v1.0 Universal</rights>\n  </rightsList>\n  <descriptions>\n    <description descriptionType=\"Abstract\">Data from: A new malaria agent in African hominids.</description>\n  </descriptions>\n</resource>\n"], "type"=>["DataCiteDoi", "DataciteDoi"], "related_items"=>[nil, [{"firstPage"=>"249", "lastPage"=>"264", "publicationYear"=>"2018", "relatedItemIdentifier"=>{"relatedItemIdentifier"=>"10.1016/j.physletb.2017.11.044", "relatedItemIdentifierType"=>"DOI"}, "relatedItemType"=>"Journal", "relationType"=>"IsPublishedIn", "titles"=>[{"title"=>"Physics letters / B"}], "volume"=>"776"}]], "publisher_obj"=>[nil, {"name"=>"Dryad Digital Repository", "lang"=>"en", "schemeUri"=>"https://ror.org/", "publisherIdentifier"=>"https://ror.org/00x6h5n95", "publisherIdentifierScheme"=>"ROR"}], "regenerate"=>[false, true]}
```

I have done the testing for following cases on staging,

1. You create a record in findable and do changes in either (related_identifiers creators funding_references aasm_state) then we send the message to event data service.
2. If we change the state from findable to register -> we do not send any message to event data service.
3. If we make changes to any other attribute other than ( related_identifiers creators funding_references aasm_state ) we do not send a message.
4. And this PR will fix the issue - where we create DOI directly in findable state, it should send a message
