### PR TITLE
Update datadog tracing to latest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "countries", "~> 2.1", ">= 2.1.2"
 gem "country_select", "~> 3.1"
 gem "crawler_detect"
 gem "dalli", "~> 2.7", ">= 2.7.6"
-gem "ddtrace", "~> 0.32.0"
+gem 'ddtrace', require: 'ddtrace/auto_instrument'
 gem "departure", "~> 6.2"
 gem "diffy", "~> 3.2", ">= 3.2.1"
 gem "dotenv"

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "countries", "~> 2.1", ">= 2.1.2"
 gem "country_select", "~> 3.1"
 gem "crawler_detect"
 gem "dalli", "~> 2.7", ">= 2.7.6"
-gem 'ddtrace', require: 'ddtrace/auto_instrument'
+gem "ddtrace", require: "ddtrace/auto_instrument"
 gem "departure", "~> 6.2"
 gem "diffy", "~> 3.2", ">= 3.2.1"
 gem "dotenv"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,9 +194,16 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    date (3.3.3)
-    ddtrace (0.32.0)
+    datadog-ci (0.6.0)
       msgpack
+    date (3.3.3)
+    ddtrace (1.19.0)
+      datadog-ci (~> 0.6.0)
+      debase-ruby_core_source (= 3.3.1)
+      libdatadog (~> 5.0.0.1.0)
+      libddwaf (~> 1.14.0.0.0)
+      msgpack
+    debase-ruby_core_source (3.3.1)
     debug_inspector (1.1.0)
     departure (6.5.0)
       activerecord (>= 5.2.0, < 7.1, != 7.0.0)
@@ -333,6 +340,14 @@ GEM
       mimemagic (~> 0.3.0)
       terrapin (~> 0.6.0)
     latex-decode (0.4.0)
+    libdatadog (5.0.0.1.0)
+    libdatadog (5.0.0.1.0-x86_64-linux)
+    libddwaf (1.14.0.0.0-arm64-darwin)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-darwin)
+      ffi (~> 1.0)
+    libddwaf (1.14.0.0.0-x86_64-linux)
+      ffi (~> 1.0)
     link_header (0.0.8)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -384,7 +399,7 @@ GEM
     minitest (5.18.0)
     money (6.16.0)
       i18n (>= 0.6.4, <= 2)
-    msgpack (1.6.0)
+    msgpack (1.7.2)
     multi_json (1.15.0)
     multipart-post (2.2.3)
     mysql2 (0.5.4)
@@ -668,7 +683,7 @@ DEPENDENCIES
   crawler_detect
   dalli (~> 2.7, >= 2.7.6)
   database_cleaner
-  ddtrace (~> 0.32.0)
+  ddtrace
   departure (~> 6.2)
   diffy (~> 3.2, >= 3.2.1)
   dotenv

--- a/config/application.rb
+++ b/config/application.rb
@@ -98,20 +98,6 @@ module Lupo
     # secret_key_base is not used by Rails API, as there are no sessions
     config.secret_key_base = "blipblapblup"
 
-    # enable datadog tracing here so that we can inject tracing
-    # information into logs
-    Datadog.configure do |c|
-      c.tracer hostname: "datadog.local",
-               enabled: Rails.env.production?,
-               env: Rails.env
-      c.use :rails, service_name: "client-api"
-      c.use :elasticsearch
-      c.use :active_record, analytics_enabled: false
-      # define graphql integration in app/graphql/lupo_schema.rb
-      # c.use :graphql, schemas: [LupoSchema]
-      c.analytics_enabled = true
-    end
-
     # disable ActiveJob logging, as it is very verbose at log level INFO
     config.active_job.logger = Logger.new(nil)
 
@@ -132,8 +118,7 @@ module Lupo
 
     config.lograge.custom_options = lambda do |event|
       # Retrieves trace information for current thread
-      correlation =
-        Datadog.tracer.active_correlation
+      correlation = Datadog::Tracing.correlation
 
       exceptions = %w[controller action format id]
 

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,0 +1,17 @@
+require 'ddtrace'
+
+Datadog.configure do |c|
+    # Global
+    c.agent.host = 'datadog.local'
+    c.runtime_metrics.enabled = true
+    c.service = 'client-api'
+    c.env = Rails.env
+
+    # Tracing settings
+    c.tracing.analytics.enabled = Rails.env.production?
+
+    # Instrumentation
+    c.tracing.instrument :rails
+    c.tracing.instrument :elasticsearch
+    c.tracing.instrument :shoryuken
+end

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -8,7 +8,8 @@ Datadog.configure do |c|
     c.env = Rails.env
 
     # Tracing settings
-    c.tracing.analytics.enabled = Rails.env.production?
+    c.tracing.enabled = Rails.env.production?
+    c.tracing.analytics.enabled = true
 
     # Instrumentation
     c.tracing.instrument :rails

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,18 +1,20 @@
-require 'ddtrace'
+# frozen_string_literal: true
+
+require "ddtrace"
 
 Datadog.configure do |c|
-    # Global
-    c.agent.host = 'datadog.local'
-    c.runtime_metrics.enabled = true
-    c.service = 'client-api'
-    c.env = Rails.env
+  # Global
+  c.agent.host = "datadog.local"
+  c.runtime_metrics.enabled = true
+  c.service = "client-api"
+  c.env = Rails.env
 
-    # Tracing settings
-    c.tracing.enabled = Rails.env.production?
-    c.tracing.analytics.enabled = true
+  # Tracing settings
+  c.tracing.enabled = Rails.env.production?
+  c.tracing.analytics.enabled = true
 
-    # Instrumentation
-    c.tracing.instrument :rails
-    c.tracing.instrument :elasticsearch
-    c.tracing.instrument :shoryuken
+  # Instrumentation
+  c.tracing.instrument :rails
+  c.tracing.instrument :elasticsearch
+  c.tracing.instrument :shoryuken
 end


### PR DESCRIPTION
## Purpose
This is an update to the ddtrace tracing library for datadog APM integration

## Approach
Use the very latest and followed upgrade guides to new config settings.

I  have also included shoryuken to be traced, this maybe changed but it's interesting to see what traces it can do for queue messages.

There is a possibility this will trace a few more things than before so this may need further testing.

## Learning
https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
