### PR TITLE
Shoryuken config

### DIFF
--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -1,4 +1,4 @@
-concurrency: <%= ENV.fetch('SHORYUKEN_CONCURRENCY', 15) %>
+concurrency: <%= ENV.fetch('SHORYUKEN_CONCURRENCY', 30) %>
 delay: 0
 pidfile: tmp/pids/shoryuken.pid
 queues:


### PR DESCRIPTION
## Purpose
Current shoryuken workers sit idle waiting for work.

We were using groups and concurrency limits as a proxy for priority/weighted queue.

There are other mechanisms for that.
https://github.com/ruby-shoryuken/shoryuken/wiki/Polling-strategies

closes: _Add github issue that originated this PR_

## Approach
Changes the concurrency configuration for the shroyuken workers.

 - The default polling strategy is weighted round robin
 - Drops groups and individual concurrency limits and adds weights to the queues.
 - Adds option to set total concurrency for all queues as an environment variable `SHORYUKEN_CONCURRENCY`.
 - Default `SHORYUKEN_CONCURRENCY` is 15 (the same as the previous concurrency limit).


## Learning
Using the [shoryuken docs](https://github.com/ruby-shoryuken/shoryuken/wiki/shroyuken-options) as a reference.
Specifically, the [load balancing](https://github.com/ruby-shoryuken/shoryuken/wiki/Shoryuken-options#load-balancing), [concurrency](https://github.com/ruby-shoryuken/shoryuken/wiki/Shoryuken-options#concurrency) and [polling strategies](https://github.com/ruby-shoryuken/shoryuken/wiki/Polling-strategies#weightedroundrobin) sections


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
