### PR TITLE
Fix for issue where unexpected `publisher` and `publisher_obj` values when using `doi:import_one` rake task

### DIFF
--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -2508,15 +2508,16 @@ class Doi < ApplicationRecord
 
   private
     def update_publisher_from_hash
-      if !publisher_before_type_cast.values.all?(nil)
+      symbolized_publisher_hash = publisher_before_type_cast.symbolize_keys
+      if !symbolized_publisher_hash.values.all?(nil)
         self.publisher_obj = {
-          name: publisher_before_type_cast.fetch(:name, nil),
-          lang: publisher_before_type_cast.fetch(:lang, nil),
-          schemeUri: publisher_before_type_cast.fetch(:schemeUri, nil),
-          publisherIdentifier: publisher_before_type_cast.fetch(:publisherIdentifier, nil),
-          publisherIdentifierScheme: publisher_before_type_cast.fetch(:publisherIdentifierScheme, nil)
+          name: symbolized_publisher_hash.fetch(:name, nil),
+          lang: symbolized_publisher_hash.fetch(:lang, nil),
+          schemeUri: symbolized_publisher_hash.fetch(:schemeUri, nil),
+          publisherIdentifier: symbolized_publisher_hash.fetch(:publisherIdentifier, nil),
+          publisherIdentifierScheme: symbolized_publisher_hash.fetch(:publisherIdentifierScheme, nil)
         }.compact
-        self.publisher = publisher_before_type_cast.dig(:name)
+        self.publisher = symbolized_publisher_hash.dig(:name)
       else
         reset_publishers
       end

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -2000,4 +2000,22 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
       expect(doi.as_indexed_json.dig("primary_title")).to eq([])
     end
   end
+
+  describe "update publisher" do
+    let(:doi) { create(:doi) }
+
+    it "with string key hash updates publisher" do
+      doi.update(:publisher: { "name" => "Plazi.org taxonomic treatments database" })
+      expect(doi.publisher).to eq(
+        { "name" => "Plazi.org taxonomic treatments database" }
+      )
+    end
+
+    it "with symbol key hash updates publisher" do
+      doi.update(:publisher: { :name: "Plazi.org taxonomic treatments database" })
+      expect(doi.publisher).to eq(
+        { "name" => "Plazi.org taxonomic treatments database" }
+      )
+    end
+  end
 end

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -2005,14 +2005,14 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
     let(:doi) { create(:doi) }
 
     it "with string key hash updates publisher" do
-      doi.update(:publisher: { "name" => "Plazi.org taxonomic treatments database" })
+      doi.update(publisher: { "name" => "Plazi.org taxonomic treatments database" })
       expect(doi.publisher).to eq(
         { "name" => "Plazi.org taxonomic treatments database" }
       )
     end
 
     it "with symbol key hash updates publisher" do
-      doi.update(:publisher: { :name: "Plazi.org taxonomic treatments database" })
+      doi.update(publisher: { name: "Plazi.org taxonomic treatments database" })
       expect(doi.publisher).to eq(
         { "name" => "Plazi.org taxonomic treatments database" }
       )


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Fixes issue where unexpected `publisher` and `publisher_obj` values when using `doi:import_one` rake task.

closes: #1103

## Approach
<!--- _How does this change address the problem?_ -->

Accounts for string and key symbols in `update_publisher_from_hash` method. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
