### PR TITLE
Schema-4.5 cleanup. (DOI model)

### DIFF
--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -2504,7 +2504,6 @@ class Doi < ApplicationRecord
           publisherIdentifier: symbolized_publisher_hash.fetch(:publisherIdentifier, nil),
           publisherIdentifierScheme: symbolized_publisher_hash.fetch(:publisherIdentifierScheme, nil)
         }.compact
-        #self.publisher = symbolized_publisher_hash.dig(:name)
       else
         reset_publishers
       end


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Related to: Issue #1016, [PR#1112](https://github.com/datacite/lupo/pull/1112)

## Approach
<!--- _How does this change address the problem?_ -->
STEP 1 - This PR which obsoletes the publisher column from the database by making it an active record virtual attribute.  To preserve backward compatibility, 'publisher' is still accepted by the API as either a string or a hash, but is saved to the DB or read from the DB as publisher_obj.  Also, the API publisher='true' flag still works as documented to return either a string or hash in the response.

STEP 2 - A second PR ([PR#1112](https://github.com/datacite/lupo/pull/1112)) which has the rake task to remove the publisher column from the DB, and contains the new schema.rb file.


#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
