### PR TITLE
Remove request-time indexing to ES

### DIFF
--- a/app/models/concerns/helpable.rb
+++ b/app/models/concerns/helpable.rb
@@ -68,7 +68,7 @@ module Helpable
         if minted.blank?
           update(minted: Time.zone.now, updated: Time.zone.now)
         end
-          
+        
         unless Rails.env.test?
           Rails.logger.debug "[Handle] URL for DOI " + doi + " updated to " +
             url +

--- a/app/models/concerns/helpable.rb
+++ b/app/models/concerns/helpable.rb
@@ -75,8 +75,8 @@ module Helpable
             url +
             "."
         end
-
-        __elasticsearch__.index_document if success
+        ### Disabled as this should be picked up by the after_commit hook on the main DOI model
+        # __elasticsearch__.index_document if success
       elsif response.status == 404
         Rails.logger.info "[Handle] Error updating URL for DOI " + doi +
           ": not found"

--- a/app/models/concerns/helpable.rb
+++ b/app/models/concerns/helpable.rb
@@ -65,8 +65,11 @@ module Helpable
       # update minted column after first successful registration in handle system
 
       if [200, 201].include?(response.status)
+        if minted.blank?
+          update(minted: Time.zone.now, updated: Time.zone.now)
+        end
+          
         unless Rails.env.test?
-
           Rails.logger.debug "[Handle] URL for DOI " + doi + " updated to " +
             url +
             "."

--- a/app/models/concerns/helpable.rb
+++ b/app/models/concerns/helpable.rb
@@ -65,18 +65,12 @@ module Helpable
       # update minted column after first successful registration in handle system
 
       if [200, 201].include?(response.status)
-        success = true
-        if minted.blank?
-          success = update(minted: Time.zone.now, updated: Time.zone.now)
-        end
         unless Rails.env.test?
 
           Rails.logger.debug "[Handle] URL for DOI " + doi + " updated to " +
             url +
             "."
         end
-        ### Disabled as this should be picked up by the after_commit hook on the main DOI model
-        # __elasticsearch__.index_document if success
       elsif response.status == 404
         Rails.logger.info "[Handle] Error updating URL for DOI " + doi +
           ": not found"

--- a/app/models/concerns/helpable.rb
+++ b/app/models/concerns/helpable.rb
@@ -68,7 +68,7 @@ module Helpable
         if minted.blank?
           update(minted: Time.zone.now, updated: Time.zone.now)
         end
-        
+
         unless Rails.env.test?
           Rails.logger.debug "[Handle] URL for DOI " + doi + " updated to " +
             url +


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
Stops DOI objects being reindexed _during_ the request, and leaves the work to the existing SQS queue based index job triggered by indexable concern.

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
