### PR TITLE
Schema 4.5 - Fix for "Mysql2::Error: Unknown column publisher in field list

### DIFF
--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -4,6 +4,7 @@ require "maremma"
 require "benchmark"
 
 class Doi < ApplicationRecord
+  self.ignored_columns += [:publisher]
   PUBLISHER_JSON_SCHEMA = "#{Rails.root}/app/models/schemas/doi/publisher.json"
   audited only: %i[doi url creators contributors titles publisher_obj publication_year types descriptions container sizes formats version_info language dates identifiers related_identifiers related_items funding_references geo_locations rights_list subjects schema_version content_url landing_page aasm_state source reason]
 


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: https://github.com/datacite/lupo/issues/1148

## Approach
<!--- _How does this change address the problem?_ -->

Tells ActiveRecord to ignore the currently unused DB field - publisher.   This will allow us to run the DB migration which deletes the publisher field from the dataset table without causing users to see the 'MySql2 unknown column' error on subsequent DOI ops (create/update/etc.).

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
