### PR TITLE
Populate `schema_version` based on namespace of `current_metadata`

### DIFF
--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -154,6 +154,7 @@ class Doi < ApplicationRecord
   before_validation :update_identifiers
   before_validation :update_types
   before_save :set_defaults, :save_metadata
+  before_save :update_schema_version
   before_create { self.created = Time.zone.now.utc.iso8601 }
 
   FIELD_OF_SCIENCE_SCHEME = "Fields of Science and Technology (FOS)"
@@ -2330,6 +2331,12 @@ class Doi < ApplicationRecord
       "bibtex" => Bolognese::Utils::CR_TO_BIB_TRANSLATIONS[res] || Bolognese::Utils::SO_TO_BIB_TRANSLATIONS[schema_org] || "misc",
       "ris" => Bolognese::Utils::CR_TO_RIS_TRANSLATIONS[res] || Bolognese::Utils::DC_TO_RIS_TRANSLATIONS[resgen] || "GEN",
     ).compact
+  end
+
+  def update_schema_version
+    if current_metadata.present? && current_metadata.valid?
+      self.schema_version = current_metadata.namespace
+    end
   end
 
   def update_publisher

--- a/spec/requests/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois_spec.rb
@@ -1996,7 +1996,7 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(json.dig("data", "attributes", "creators")).to eq([{ "affiliation" => [], "familyName" => "Fenner", "givenName" => "Martin", "nameIdentifiers" => [{ "nameIdentifier" => "https://orcid.org/0000-0003-1419-2405", "nameIdentifierScheme" => "ORCID", "schemeUri" => "https://orcid.org" }], "name" => "Fenner, Martin", "nameType" => "Personal" }])
         expect(json.dig("data", "attributes", "publisher")).to eq("DataCite")
         expect(json.dig("data", "attributes", "publicationYear")).to eq(2016)
-        expect(json.dig('data', 'attributes', 'schemaVersion')).to eq("http://datacite.org/schema/kernel-4")
+        expect(json.dig("data", "attributes", "schemaVersion")).to eq("http://datacite.org/schema/kernel-4")
         expect(json.dig("data", "attributes", "source")).to eq("test")
         expect(json.dig("data", "attributes", "types")).to eq("bibtex" => "article", "citeproc" => "article-journal", "resourceType" => "BlogPosting", "resourceTypeGeneral" => "Text", "ris" => "RPRT", "schemaOrg" => "ScholarlyArticle")
         expect(json.dig("data", "attributes", "state")).to eq("findable")
@@ -2004,7 +2004,7 @@ describe DataciteDoisController, type: :request, vcr: true do
         doc = Nokogiri::XML(Base64.decode64(json.dig("data", "attributes", "xml")), nil, "UTF-8", &:noblanks)
         expect(doc.at_css("identifier").content).to eq("10.14454/10703")
 
-        doi = Doi.where(doi:"10.14454/10703").first
+        doi = Doi.where(doi: "10.14454/10703").first
         expect(doi.publisher).to eq(
           {
             "name" => "DataCite"
@@ -2090,7 +2090,7 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(json.dig("data", "attributes", "relatedIdentifiers")).to eq([{ "relatedIdentifier" => "10.5438/55e5-t5c0", "relatedIdentifierType" => "DOI", "relationType" => "References" }])
         expect(json.dig("data", "attributes", "descriptions", 0, "description")).to start_with("Diet and physical activity")
         expect(json.dig("data", "attributes", "geoLocations")).to eq([{ "geoLocationPoint" => { "pointLatitude" => "49.0850736", "pointLongitude" => "-123.3300992" } }])
-        expect(json.dig('data', 'attributes', 'schemaVersion')).to eq("http://datacite.org/schema/kernel-4")
+        expect(json.dig("data", "attributes", "schemaVersion")).to eq("http://datacite.org/schema/kernel-4")
         expect(json.dig("data", "attributes", "source")).to eq("test")
         expect(json.dig("data", "attributes", "types")).to eq("bibtex" => "article", "citeproc" => "article-journal", "resourceType" => "BlogPosting", "resourceTypeGeneral" => "Text", "ris" => "RPRT", "schemaOrg" => "ScholarlyArticle")
         expect(json.dig("data", "attributes", "state")).to eq("findable")
@@ -2104,7 +2104,7 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(doc.at_css("descriptions").content).to start_with("Diet and physical activity")
         expect(doc.at_css("geoLocations").content).to eq("49.0850736-123.3300992")
 
-        doi = Doi.where(doi:"10.14454/10703").first
+        doi = Doi.where(doi: "10.14454/10703").first
         expect(doi.schema_version).to eq("http://datacite.org/schema/kernel-4")
       end
     end
@@ -2172,7 +2172,7 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(json.dig("data", "attributes", "creators")).to eq([{ "affiliation" => [], "familyName" => "Fenner", "givenName" => "Martin", "nameIdentifiers" => [{ "nameIdentifier" => "https://orcid.org/0000-0003-1419-2405", "nameIdentifierScheme" => "ORCID", "schemeUri" => "https://orcid.org" }], "name" => "Fenner, Martin", "nameType" => "Personal" }])
         expect(json.dig("data", "attributes", "publisher")).to eq("DataCite")
         expect(json.dig("data", "attributes", "publicationYear")).to eq(2016)
-        expect(json.dig('data', 'attributes', 'schemaVersion')).to eq("http://datacite.org/schema/kernel-4")
+        expect(json.dig("data", "attributes", "schemaVersion")).to eq("http://datacite.org/schema/kernel-4")
         expect(json.dig("data", "attributes", "language")).to eq("en")
         expect(json.dig("data", "attributes", "identifiers")).to eq([{ "identifier" => "123", "identifierType" => "Repository ID" }])
         expect(json.dig("data", "attributes", "alternateIdentifiers")).to eq([{ "alternateIdentifier" => "123", "alternateIdentifierType" => "Repository ID" }])
@@ -2221,7 +2221,7 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(doc.at_css("version").content).to eq("1.1")
         expect(doc.at_css("fundingReferences").content).to eq("The Wellcome Trust DBT India Alliancehttps://doi.org/10.13039/501100009053")
 
-        doi = Doi.where(doi:"10.14454/10703").first
+        doi = Doi.where(doi: "10.14454/10703").first
         expect(doi.schema_version).to eq("http://datacite.org/schema/kernel-4")
       end
     end
@@ -2715,7 +2715,7 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(json.dig("data", "attributes", "schemaVersion")).to eq("http://datacite.org/schema/kernel-3")
         expect(json.dig("data", "attributes", "state")).to eq("findable")
 
-        doi = Doi.where(doi:"10.14454/10703").first
+        doi = Doi.where(doi: "10.14454/10703").first
         expect(doi.schema_version).to eq("http://datacite.org/schema/kernel-3")
       end
     end
@@ -3720,10 +3720,10 @@ describe DataciteDoisController, type: :request, vcr: true do
 
       it "updates a Doi" do
         put "/dois/10.14454/10703", update_attributes, headers
-        
+
         expect(json.dig("data", "attributes", "schemaVersion")).to eq("http://datacite.org/schema/kernel-4")
 
-        doi = Doi.where(doi:"10.14454/10703").first
+        doi = Doi.where(doi: "10.14454/10703").first
         expect(doi.schema_version).to eq("http://datacite.org/schema/kernel-4")
       end
     end

--- a/spec/requests/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois_spec.rb
@@ -1996,7 +1996,7 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(json.dig("data", "attributes", "creators")).to eq([{ "affiliation" => [], "familyName" => "Fenner", "givenName" => "Martin", "nameIdentifiers" => [{ "nameIdentifier" => "https://orcid.org/0000-0003-1419-2405", "nameIdentifierScheme" => "ORCID", "schemeUri" => "https://orcid.org" }], "name" => "Fenner, Martin", "nameType" => "Personal" }])
         expect(json.dig("data", "attributes", "publisher")).to eq("DataCite")
         expect(json.dig("data", "attributes", "publicationYear")).to eq(2016)
-        # expect(json.dig('data', 'attributes', 'schemaVersion')).to eq("http://datacite.org/schema/kernel-4")
+        expect(json.dig('data', 'attributes', 'schemaVersion')).to eq("http://datacite.org/schema/kernel-4")
         expect(json.dig("data", "attributes", "source")).to eq("test")
         expect(json.dig("data", "attributes", "types")).to eq("bibtex" => "article", "citeproc" => "article-journal", "resourceType" => "BlogPosting", "resourceTypeGeneral" => "Text", "ris" => "RPRT", "schemaOrg" => "ScholarlyArticle")
         expect(json.dig("data", "attributes", "state")).to eq("findable")
@@ -2004,11 +2004,13 @@ describe DataciteDoisController, type: :request, vcr: true do
         doc = Nokogiri::XML(Base64.decode64(json.dig("data", "attributes", "xml")), nil, "UTF-8", &:noblanks)
         expect(doc.at_css("identifier").content).to eq("10.14454/10703")
 
-        expect(Doi.where(doi: "10.14454/10703").first.publisher).to eq(
+        doi = Doi.where(doi:"10.14454/10703").first
+        expect(doi.publisher).to eq(
           {
             "name" => "DataCite"
           }
         )
+        expect(doi.schema_version).to eq("http://datacite.org/schema/kernel-4")
       end
     end
 
@@ -2088,6 +2090,7 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(json.dig("data", "attributes", "relatedIdentifiers")).to eq([{ "relatedIdentifier" => "10.5438/55e5-t5c0", "relatedIdentifierType" => "DOI", "relationType" => "References" }])
         expect(json.dig("data", "attributes", "descriptions", 0, "description")).to start_with("Diet and physical activity")
         expect(json.dig("data", "attributes", "geoLocations")).to eq([{ "geoLocationPoint" => { "pointLatitude" => "49.0850736", "pointLongitude" => "-123.3300992" } }])
+        expect(json.dig('data', 'attributes', 'schemaVersion')).to eq("http://datacite.org/schema/kernel-4")
         expect(json.dig("data", "attributes", "source")).to eq("test")
         expect(json.dig("data", "attributes", "types")).to eq("bibtex" => "article", "citeproc" => "article-journal", "resourceType" => "BlogPosting", "resourceTypeGeneral" => "Text", "ris" => "RPRT", "schemaOrg" => "ScholarlyArticle")
         expect(json.dig("data", "attributes", "state")).to eq("findable")
@@ -2100,6 +2103,9 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(doc.at_css("relatedIdentifiers").content).to eq("10.5438/55e5-t5c0")
         expect(doc.at_css("descriptions").content).to start_with("Diet and physical activity")
         expect(doc.at_css("geoLocations").content).to eq("49.0850736-123.3300992")
+
+        doi = Doi.where(doi:"10.14454/10703").first
+        expect(doi.schema_version).to eq("http://datacite.org/schema/kernel-4")
       end
     end
 
@@ -2166,7 +2172,7 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(json.dig("data", "attributes", "creators")).to eq([{ "affiliation" => [], "familyName" => "Fenner", "givenName" => "Martin", "nameIdentifiers" => [{ "nameIdentifier" => "https://orcid.org/0000-0003-1419-2405", "nameIdentifierScheme" => "ORCID", "schemeUri" => "https://orcid.org" }], "name" => "Fenner, Martin", "nameType" => "Personal" }])
         expect(json.dig("data", "attributes", "publisher")).to eq("DataCite")
         expect(json.dig("data", "attributes", "publicationYear")).to eq(2016)
-        # expect(json.dig('data', 'attributes', 'schemaVersion')).to eq("http://datacite.org/schema/kernel-4")
+        expect(json.dig('data', 'attributes', 'schemaVersion')).to eq("http://datacite.org/schema/kernel-4")
         expect(json.dig("data", "attributes", "language")).to eq("en")
         expect(json.dig("data", "attributes", "identifiers")).to eq([{ "identifier" => "123", "identifierType" => "Repository ID" }])
         expect(json.dig("data", "attributes", "alternateIdentifiers")).to eq([{ "alternateIdentifier" => "123", "alternateIdentifierType" => "Repository ID" }])
@@ -2214,6 +2220,9 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(doc.at_css("formats").content).to eq("application/pdftext/csv")
         expect(doc.at_css("version").content).to eq("1.1")
         expect(doc.at_css("fundingReferences").content).to eq("The Wellcome Trust DBT India Alliancehttps://doi.org/10.13039/501100009053")
+
+        doi = Doi.where(doi:"10.14454/10703").first
+        expect(doi.schema_version).to eq("http://datacite.org/schema/kernel-4")
       end
     end
 
@@ -2705,6 +2714,9 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(json.dig("data", "attributes", "source")).to eq("test")
         expect(json.dig("data", "attributes", "schemaVersion")).to eq("http://datacite.org/schema/kernel-3")
         expect(json.dig("data", "attributes", "state")).to eq("findable")
+
+        doi = Doi.where(doi:"10.14454/10703").first
+        expect(doi.schema_version).to eq("http://datacite.org/schema/kernel-3")
       end
     end
 
@@ -3690,7 +3702,6 @@ describe DataciteDoisController, type: :request, vcr: true do
             "type" => "dois",
             "attributes" => {
               "schemaVersion" => "http://datacite.org/schema/kernel-4",
-              "regenerate" => true,
             },
           },
         }
@@ -3705,6 +3716,15 @@ describe DataciteDoisController, type: :request, vcr: true do
 
         doc = Nokogiri::XML(Base64.decode64(json.dig("data", "attributes", "xml")), nil, "UTF-8", &:noblanks)
         expect(doc.collect_namespaces).to eq("xmlns" => "http://datacite.org/schema/kernel-3", "xmlns:dim" => "http://www.dspace.org/xmlns/dspace/dim", "xmlns:dryad" => "http://purl.org/dryad/terms/", "xmlns:dspace" => "http://www.dspace.org/xmlns/dspace/dim", "xmlns:mets" => "http://www.loc.gov/METS/", "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance")
+      end
+
+      it "updates a Doi" do
+        put "/dois/10.14454/10703", update_attributes, headers
+        
+        expect(json.dig("data", "attributes", "schemaVersion")).to eq("http://datacite.org/schema/kernel-4")
+
+        doi = Doi.where(doi:"10.14454/10703").first
+        expect(doi.schema_version).to eq("http://datacite.org/schema/kernel-4")
       end
     end
 


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Currently, `schema_version` is sometimes not populated, and users can send arbitrary values in a `schemaVersion` attribute that are then written to the column. This confuses what schema version a given DOI is using, causing issues with reporting as well as with display in the REST API, in Fabrica, and elsewhere. See the issues listed below. This PR intends to use the XML namespace of the most current metadata object to write `schema_version` deterministically upon saving a record. 

closes: #1179 datacite/datacite#1855

## Approach
<!--- _How does this change address the problem?_ -->

Adds a `before_save` callback in Doi model to retrieve `current_metadata.namespace` and set `schema_version` to the result. Once validated, the Metadata model `namespace` contains the current schema version via the `set_namespace` method: https://github.com/datacite/lupo/blob/c861f12d286a21a59e06eb28c762e2661282e72c/app/models/metadata.rb#L82-L91

This method retrieves the xmlns value of the XML, which by nature must contain a valid namespace value. In other words, inaccurate values and sub-version values like http://datacite.org/schema/kernel-4.5 will not validate if in the xmlns value of the source XML and thus cannot appear as the saved `schema_version` value. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
