### PR TITLE
Return dois from other registration agencies through REST API (optionally)

### DIFF
--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -75,6 +75,12 @@ class DataciteDoisController < ApplicationController
     # facets are enabled by default
     disable_facets = params[:disable_facets]
 
+    # registration agencies are disabled by default
+    exclude_registration_agencies = true
+    if params[:include_other_registration_agencies].present?
+      exclude_registration_agencies = false
+    end
+
     if params[:id].present?
       response = DataciteDoi.find_by_id(params[:id])
     elsif params[:ids].present?
@@ -84,7 +90,7 @@ class DataciteDoisController < ApplicationController
         DataciteDoi.query(
           params[:query],
           state: params[:state],
-          exclude_registration_agencies: true,
+          exclude_registration_agencies: exclude_registration_agencies,
           published: params[:published],
           created: params[:created],
           registered: params[:registered],


### PR DESCRIPTION
## Purpose
There are many dois in the database and elasticsearch that are not originally registered by datacite.
These are unavailable through the current REST API.  They are available through the GraphQL api.
We would like to make these available as read-only through the REST api.


## Approach
Add an optional parameter that enables the inclusion of dois from other registration agencies.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
