### PR TITLE
Change ES_HOST lookup for config swiching to just match on datacite.org

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -3,8 +3,7 @@
 require "faraday"
 require "faraday_middleware/aws_sigv4"
 
-if ENV["ES_HOST"] == "elasticsearch.test.datacite.org" ||
-    ENV["ES_HOST"] == "elasticsearch.datacite.org"
+if ENV["ES_HOST"].end_with?(".datacite.org")
   Elasticsearch::Model.client =
     Elasticsearch::Client.new(
       host: ENV["ES_HOST"],


### PR DESCRIPTION
## Purpose
This is to support elasticsearch.stage.datacite.org as a domain url when configuring the AWS part of ES connection.
This is part of work to add a specific stage search cluster.

## Approach
By just checking we end with .datacite.org we can assume that it's a hosted domain and not local and therefore use the AWS config as required.

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
