### PR TITLE
Use SQS_PREFIX not ES_PREFIX for queues

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -146,7 +146,7 @@ class User
       )
     url = ENV["BRACCO_URL"] + "?jwt=" + jwt
     reset_url = ENV["BRACCO_URL"] + "/reset"
-    title = ENV["BRACCO_TITLE"] 
+    title = ENV["BRACCO_TITLE"]
     subject = "#{title}: Password Reset Request"
     account_type =
       if user.instance_of?(Provider)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -146,15 +146,7 @@ class User
       )
     url = ENV["BRACCO_URL"] + "?jwt=" + jwt
     reset_url = ENV["BRACCO_URL"] + "/reset"
-    title = if Rails.env.stage?
-      if ENV["ES_PREFIX"].present?
-        "DataCite Fabrica Stage"
-      else
-        "DataCite Fabrica Test"
-      end
-    else
-      "DataCite Fabrica"
-    end
+    title = ENV["BRACCO_TITLE"] 
     subject = "#{title}: Password Reset Request"
     account_type =
       if user.instance_of?(Provider)

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,7 @@ ENV["CONCURRENCY"] ||= "25"
 ENV["API_URL"] ||= "https://api.stage.datacite.org"
 ENV["CDN_URL"] ||= "https://assets.datacite.org"
 ENV["BRACCO_URL"] ||= "https://doi.datacite.org"
+ENV["BRACCO_TITLE"] ||= "DataCite Fabrica"
 ENV["GITHUB_URL"] ||= "https://github.com/datacite/lupo"
 ENV["SEARCH_URL"] ||= "https://search.datacite.org/"
 ENV["VOLPINO_URL"] ||= "https://profiles.datacite.org/api"
@@ -63,6 +64,7 @@ ENV["MG_FROM"] ||= "support@datacite.org"
 ENV["MG_DOMAIN"] ||= "mg.datacite.org"
 ENV["HANDLES_MINTED"] ||= "10132"
 ENV["REALM"] ||= ENV["API_URL"]
+ENV["SQS_PREFIX"] || = ""
 
 module Lupo
   class Application < Rails::Application
@@ -171,13 +173,8 @@ module Lupo
     # set Active Job queueing backend
     config.active_job.queue_adapter = ENV["AWS_REGION"] ? :shoryuken : :inline
 
-    # use SQS based on environment, use "test" prefix for test system
-    if Rails.env.stage?
-      config.active_job.queue_name_prefix =
-        ENV["ES_PREFIX"].present? ? "stage" : "test"
-    else
-      config.active_job.queue_name_prefix = Rails.env
-    end
+    # use SQS based on environment or what has been defined
+    config.active_job.queue_name_prefix = ENV["SQS_PREFIX"].present? ? ENV["SQS_PREFIX"] : Rails.env
 
     config.generators { |g| g.fixture_replacement :factory_bot }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,7 +64,7 @@ ENV["MG_FROM"] ||= "support@datacite.org"
 ENV["MG_DOMAIN"] ||= "mg.datacite.org"
 ENV["HANDLES_MINTED"] ||= "10132"
 ENV["REALM"] ||= ENV["API_URL"]
-ENV["SQS_PREFIX"] || = ""
+ENV["SQS_PREFIX"] ||= ""
 
 module Lupo
   class Application < Rails::Application


### PR DESCRIPTION
## Purpose
Now that I want to remove the use of ES_PREFIX as we have a specific new ES server domain.
Then some detection needs to change, namely as ES_PREFIX will now be empty we need a way to choose queues.

## Approach

The way im working this is to add a new SQS_QUEUE which I will then set configured in terraform.
You will note that I'm still use a weird detection for some salesforce message part, this is because this entire code is very strange and I'm not sure I want to break it further, so for now I just use SQS_QUEUE as the way to identify here.

I do note that while Rails has technically two separate environments setup for stage and test, we're not actually using this properly, I'm afraid of making that change as it seems more involved, but is probably ideally the better solution for identifying the environment.

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
