### PR TITLE
Adds allRelated dois option to graphql works/doi_item.

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -111,6 +111,16 @@ type Affiliation {
 
 type Audiovisual implements DoiItem {
   """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
+  """
   Metadata in bibtex format
   """
   bibtex: String!
@@ -446,6 +456,16 @@ type AudiovisualEdge {
 
 type Book implements DoiItem {
   """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
+  """
   Metadata in bibtex format
   """
   bibtex: String!
@@ -729,6 +749,16 @@ type Book implements DoiItem {
 }
 
 type BookChapter implements DoiItem {
+  """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
   """
   Metadata in bibtex format
   """
@@ -1164,6 +1194,16 @@ type Claim {
 
 type Collection implements DoiItem {
   """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
+  """
   Metadata in bibtex format
   """
   bibtex: String!
@@ -1498,6 +1538,16 @@ type CollectionEdge {
 }
 
 type ConferencePaper implements DoiItem {
+  """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
   """
   Metadata in bibtex format
   """
@@ -2126,6 +2176,16 @@ type DataCatalogEdge {
 
 type DataManagementPlan implements DoiItem {
   """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
+  """
   Metadata in bibtex format
   """
   bibtex: String!
@@ -2461,6 +2521,16 @@ type DataManagementPlanEdge {
 
 type DataPaper implements DoiItem {
   """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
+  """
   Metadata in bibtex format
   """
   bibtex: String!
@@ -2795,6 +2865,16 @@ type DataPaperEdge {
 }
 
 type Dataset implements DoiItem {
+  """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
   """
   Metadata in bibtex format
   """
@@ -3249,6 +3329,16 @@ type Description {
 
 type Dissertation implements DoiItem {
   """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
+  """
   Metadata in bibtex format
   """
   bibtex: String!
@@ -3587,6 +3677,16 @@ Information about DOIs
 """
 interface DoiItem {
   """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
+  """
   Metadata in bibtex format
   """
   bibtex: String!
@@ -3921,6 +4021,16 @@ type Error {
 
 type Event implements DoiItem {
   """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
+  """
   Metadata in bibtex format
   """
   bibtex: String!
@@ -4233,6 +4343,16 @@ type EventConnectionWithTotal {
 }
 
 type EventData implements DoiItem {
+  """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
   """
   Metadata in bibtex format
   """
@@ -4843,6 +4963,16 @@ type Identifier {
 
 type Image implements DoiItem {
   """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
+  """
   Metadata in bibtex format
   """
   bibtex: String!
@@ -5178,6 +5308,16 @@ type ImageEdge {
 
 type Instrument implements DoiItem {
   """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
+  """
   Metadata in bibtex format
   """
   bibtex: String!
@@ -5512,6 +5652,16 @@ type InstrumentEdge {
 }
 
 type InteractiveResource implements DoiItem {
+  """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
   """
   Metadata in bibtex format
   """
@@ -5852,6 +6002,16 @@ Represents untyped JSON
 scalar JSON
 
 type JournalArticle implements DoiItem {
+  """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
   """
   Metadata in bibtex format
   """
@@ -6484,6 +6644,16 @@ type MemberRole {
 
 type Model implements DoiItem {
   """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
+  """
   Metadata in bibtex format
   """
   bibtex: String!
@@ -7016,6 +7186,16 @@ type OrganizationEdge {
 
 type Other implements DoiItem {
   """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
+  """
   Metadata in bibtex format
   """
   bibtex: String!
@@ -7375,6 +7555,16 @@ type PageInfo {
 }
 
 type PeerReview implements DoiItem {
+  """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
   """
   Metadata in bibtex format
   """
@@ -7848,6 +8038,16 @@ type PersonEdge {
 
 type PhysicalObject implements DoiItem {
   """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
+  """
   Metadata in bibtex format
   """
   bibtex: String!
@@ -8236,6 +8436,16 @@ type PrefixEdge {
 
 type Preprint implements DoiItem {
   """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
+  """
   Metadata in bibtex format
   """
   bibtex: String!
@@ -8570,6 +8780,16 @@ type PreprintEdge {
 }
 
 type Publication implements DoiItem {
+  """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
   """
   Metadata in bibtex format
   """
@@ -9581,6 +9801,16 @@ type Rights {
 
 type Service implements DoiItem {
   """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
+  """
   Metadata in bibtex format
   """
   bibtex: String!
@@ -9916,6 +10146,16 @@ type ServiceEdge {
 }
 
 type Software implements DoiItem {
+  """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
   """
   Metadata in bibtex format
   """
@@ -10282,6 +10522,16 @@ type SoftwareEdge {
 }
 
 type Sound implements DoiItem {
+  """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
   """
   Metadata in bibtex format
   """
@@ -10829,6 +11079,16 @@ type User {
 
 type Work implements DoiItem {
   """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
+  """
   Metadata in bibtex format
   """
   bibtex: String!
@@ -11185,6 +11445,16 @@ interface WorkFacetsInterface {
 }
 
 type Workflow implements DoiItem {
+  """
+  All works related to this DOI.
+  """
+  allRelated(affiliationId: String, after: String, fieldOfScience: String, first: Int = 25, funderId: String, hasAffiliation: Boolean, hasCitations: Int, hasDownloads: Int, hasFunder: Boolean, hasOrganization: Boolean, hasParts: Int, hasPerson: Boolean, hasVersions: Int, hasViews: Int, ids: [String!], language: String, license: String, memberId: String, organizationId: String, published: String, query: String, registrationAgency: String, repositoryId: String, resourceTypeId: String, userId: String): WorkConnectionWithTotal
+
+  """
+  Total number of DOIs related to the resource via any relation
+  """
+  allRelatedCount: Int
+
   """
   Metadata in bibtex format
   """

--- a/app/graphql/types/doi_item.rb
+++ b/app/graphql/types/doi_item.rb
@@ -206,6 +206,10 @@ module DoiItem
         Int,
         null: true,
         description: "Total number of DOIs the resource is a part of"
+  field :all_related_count,
+        Int,
+        null: true,
+        description: "Total number of DOIs related to the resource via any relation"
   field :other_related_count,
         Int,
         null: true,
@@ -332,6 +336,49 @@ module DoiItem
     Event.events_involving(_doi, relations_types=_relation_types).map do |e|
       e.doi
     end.flatten.uniq - [_doi.downcase, nil]
+  end
+
+  field :all_related,
+       WorkConnectionWithTotalType,
+       null: true,
+       max_page_size: 100,
+       description: "All works related to this DOI." do
+    argument :query, String, required: false
+    argument :ids, [String], required: false
+    argument :published, String, required: false
+    argument :user_id, String, required: false
+    argument :funder_id, String, required: false
+    argument :repository_id, String, required: false
+    argument :member_id, String, required: false
+    argument :affiliation_id, String, required: false
+    argument :organization_id, String, required: false
+    argument :registration_agency, String, required: false
+    argument :resource_type_id, String, required: false
+    argument :license, String, required: false
+    argument :language, String, required: false
+    argument :has_person, Boolean, required: false
+    argument :has_funder, Boolean, required: false
+    argument :has_organization, Boolean, required: false
+    argument :has_affiliation, Boolean, required: false
+    argument :has_citations, Int, required: false
+    argument :has_parts, Int, required: false
+    argument :has_versions, Int, required: false
+    argument :has_views, Int, required: false
+    argument :has_downloads, Int, required: false
+    argument :field_of_science, String, required: false
+    argument :first, Int, required: false, default_value: 25
+    argument :after, String, required: false
+  end
+
+  def all_related(**args)
+    args[:ids] = get_related_ids(object.doi, relations_types=Event::ALL_RELATION_TYPES)
+    ElasticsearchModelResponseConnection.new(
+      response(**args),
+      context: context, first: args[:first], after: args[:after],
+    )
+  end
+  def all_related_count
+    get_related_ids(object.doi, relation_types=Event::ALL_RELATION_TYPES).count
   end
 
 

--- a/app/graphql/types/doi_item.rb
+++ b/app/graphql/types/doi_item.rb
@@ -337,7 +337,7 @@ module DoiItem
   end
 
   def get_related_ids(_doi, _relation_types = Event::ALL_RELATION_TYPES)
-    Event.events_involving(_doi, relations_types: _relation_types).map do |e|
+    Event.events_involving(_doi, _relation_types).map do |e|
       e.doi
     end.flatten.uniq - [_doi.downcase, nil]
   end

--- a/app/graphql/types/doi_item.rb
+++ b/app/graphql/types/doi_item.rb
@@ -332,8 +332,8 @@ module DoiItem
     get_related_ids(object.doi, Event::OTHER_RELATION_TYPES).count
   end
 
-  def get_related_ids(_doi, _relation_types=Event::ALL_RELATION_TYPES)
-    Event.events_involving(_doi, relations_types=_relation_types).map do |e|
+  def get_related_ids(_doi, _relation_types = Event::ALL_RELATION_TYPES)
+    Event.events_involving(_doi, relations_types = _relation_types).map do |e|
       e.doi
     end.flatten.uniq - [_doi.downcase, nil]
   end
@@ -371,14 +371,14 @@ module DoiItem
   end
 
   def all_related(**args)
-    args[:ids] = get_related_ids(object.doi, relations_types=Event::ALL_RELATION_TYPES)
+    args[:ids] = get_related_ids(object.doi, relations_types = Event::ALL_RELATION_TYPES)
     ElasticsearchModelResponseConnection.new(
       response(**args),
       context: context, first: args[:first], after: args[:after],
     )
   end
   def all_related_count
-    get_related_ids(object.doi, relation_types=Event::ALL_RELATION_TYPES).count
+    get_related_ids(object.doi, relation_types = Event::ALL_RELATION_TYPES).count
   end
 
 

--- a/app/graphql/types/doi_item.rb
+++ b/app/graphql/types/doi_item.rb
@@ -317,7 +317,7 @@ module DoiItem
   end
 
   def other_related(**args)
-    args[:ids] = get_other_related_ids(object.doi)
+    args[:ids] = get_related_ids(object.doi, Event::OTHER_RELATION_TYPES)
     ElasticsearchModelResponseConnection.new(
       response(**args),
       context: context, first: args[:first], after: args[:after],
@@ -325,11 +325,11 @@ module DoiItem
   end
 
   def other_related_count
-    get_other_related_ids(object.doi).count
+    get_related_ids(object.doi, Event::OTHER_RELATION_TYPES).count
   end
 
-  def get_other_related_ids(_doi)
-    Event.events_involving(_doi).map do |e|
+  def get_related_ids(_doi, _relation_types=Event::ALL_RELATION_TYPES)
+    Event.events_involving(_doi, relations_types=_relation_types).map do |e|
       e.doi
     end.flatten.uniq - [_doi.downcase, nil]
   end

--- a/app/graphql/types/doi_item.rb
+++ b/app/graphql/types/doi_item.rb
@@ -321,7 +321,7 @@ module DoiItem
   end
 
   def other_related(**args)
-    args[:ids] = get_related_ids(object.doi, Event::OTHER_RELATION_TYPES)
+    args[:ids] = _other_related_ids
     ElasticsearchModelResponseConnection.new(
       response(**args),
       context: context, first: args[:first], after: args[:after],
@@ -329,11 +329,15 @@ module DoiItem
   end
 
   def other_related_count
-    get_related_ids(object.doi, Event::OTHER_RELATION_TYPES).count
+    _other_related_ids.count
+  end
+
+  def _other_related_ids
+    @other_related_ids ||= get_related_ids(object.doi, Event::OTHER_RELATION_TYPES)
   end
 
   def get_related_ids(_doi, _relation_types = Event::ALL_RELATION_TYPES)
-    Event.events_involving(_doi, relations_types = _relation_types).map do |e|
+    Event.events_involving(_doi, relations_types: _relation_types).map do |e|
       e.doi
     end.flatten.uniq - [_doi.downcase, nil]
   end
@@ -370,15 +374,20 @@ module DoiItem
     argument :after, String, required: false
   end
 
+  def _all_related_ids
+    @all_related_ids ||= get_related_ids(object.doi, Event::ALL_RELATION_TYPES)
+  end
+
   def all_related(**args)
-    args[:ids] = get_related_ids(object.doi, relations_types = Event::ALL_RELATION_TYPES)
+    args[:ids] = _all_related_ids
     ElasticsearchModelResponseConnection.new(
       response(**args),
       context: context, first: args[:first], after: args[:after],
     )
   end
+
   def all_related_count
-    get_related_ids(object.doi, relation_types = Event::ALL_RELATION_TYPES).count
+    _all_related_ids.count
   end
 
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1060,7 +1060,6 @@ class Event < ApplicationRecord
 
   def self.events_involving(_doi, relation_types = ALL_RELATION_TYPES)
     Enumerator.new do |yielder|
-
       all_results = []
       page_number = 1
       page_size = 500

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -75,8 +75,8 @@ FactoryBot.define do
     end
 
     factory :event_for_datacite_crossref do
-      source_id { "datacite_crossref" }
-      source_token { "datacite_crossref_123" }
+      source_id { "datacite-crossref" }
+      source_token { "datacite-crossref_123" }
       sequence(:subj_id) { |n| "https://doi.org/10.5061/DRYAD.47SD5e/#{n}" }
       subj { { "datePublished" => "2006-06-13T16:14:19Z" } }
       obj_id { "https://doi.org/10.1371/journal.pbio.2001414" }

--- a/spec/graphql/types/work_type_spec.rb
+++ b/spec/graphql/types/work_type_spec.rb
@@ -2068,13 +2068,13 @@ describe WorkType do
 
     it "all_relations should include citations,parts,references,versions, and other relationships" do
       all_related = @response.dig("data", "work", "allRelated", "nodes")
-      all_related_ids = all_related.map{ |node| node["id"] }.sort.uniq
+      all_related_ids = all_related.map { |node| node["id"] }.sort.uniq
       all_works = (@response.dig("data", "work", "references", "nodes") |
-        @response.dig("data", "work", "citations", "nodes")|
+        @response.dig("data", "work", "citations", "nodes") |
         @response.dig("data", "work", "parts", "nodes") |
         @response.dig("data", "work", "versions", "nodes") |
         @response.dig("data", "work", "otherRelated", "nodes"))
-      all_work_ids = all_works.map{ |node| node["id"] }.sort.uniq
+      all_work_ids = all_works.map { |node| node["id"] }.sort.uniq
       expect(all_related_ids).to eq(all_work_ids)
       expect(@response.dig("data", "work", "allRelatedCount")).to eq(24)
       expect(@response.dig("data", "work", "allRelated", "nodes").length).to eq(24)

--- a/spec/graphql/types/work_type_spec.rb
+++ b/spec/graphql/types/work_type_spec.rb
@@ -1971,7 +1971,7 @@ describe WorkType do
       version_target_dois.each do |version_target_doi|
         create(:event_for_datacite_versions, {
           subj_id: "https://doi.org/#{doi.doi}",
-          obj_id: "https://doi.org/#{version_target_doi.doi}"
+          obj_id: "https://doi.org/#{version_target_doi.doi}",
         })
       end
     end
@@ -2031,6 +2031,12 @@ describe WorkType do
               id
             }
           }
+          allRelatedCount
+          allRelated{
+            nodes{
+              id
+            }
+          }
         }
       }"
     end
@@ -2058,6 +2064,20 @@ describe WorkType do
     it "other_relations should not include citations,parts,references" do
       expect(@response.dig("data", "work", "otherRelatedCount")).to eq(3)
       expect(@response.dig("data", "work", "otherRelated", "nodes").length).to eq(3)
+    end
+
+    it "all_relations should include citations,parts,references,versions, and other relationships" do
+      all_related = @response.dig("data", "work", "allRelated", "nodes")
+      all_related_ids = all_related.map{ |node| node["id"] }.sort.uniq
+      all_works = (@response.dig("data", "work", "references", "nodes") |
+        @response.dig("data", "work", "citations", "nodes")|
+        @response.dig("data", "work", "parts", "nodes") |
+        @response.dig("data", "work", "versions", "nodes") |
+        @response.dig("data", "work", "otherRelated", "nodes"))
+      all_work_ids = all_works.map{ |node| node["id"] }.sort.uniq
+      expect(all_related_ids).to eq(all_work_ids)
+      expect(@response.dig("data", "work", "allRelatedCount")).to eq(24)
+      expect(@response.dig("data", "work", "allRelated", "nodes").length).to eq(24)
     end
   end
 end


### PR DESCRIPTION
## Purpose
Previously a user could query for related dois of specific relation types (references/citations/parts...etc).  This adds provides an additional avenue to query for all related dois. 

closes: datacite/datacite#2176

## Approach
Adds an additional GQL endpoint for allRelations.
Use the previously-established Events::events_involving function but with an expanded list of relations.

## Notes
NO DB changes
NO search index changes.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
