### PR TITLE
Allow multiple values in the resource-type-id parameter

### DIFF
--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -962,7 +962,7 @@ class Doi < ApplicationRecord
     minimum_should_match = 0
 
     filter << { terms: { doi: options[:ids].map(&:upcase) } } if options[:ids].present?
-    filter << { term: { resource_type_id: options[:resource_type_id].underscore.dasherize } } if options[:resource_type_id].present?
+    filter << { terms: { resource_type_id: options[:resource_type_id].split(",").map(&:underscore).map(&:dasherize } } if options[:resource_type_id].present?
     filter << { terms: { "types.resourceType": options[:resource_type].split(",") } } if options[:resource_type].present?
     if options[:provider_id].present?
       options[:provider_id].split(",").each { |id|

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -962,7 +962,7 @@ class Doi < ApplicationRecord
     minimum_should_match = 0
 
     filter << { terms: { doi: options[:ids].map(&:upcase) } } if options[:ids].present?
-    filter << { terms: { resource_type_id: options[:resource_type_id].split(",").map(&:underscore).map(&:dasherize) } if options[:resource_type_id].present?
+    filter << { terms: { resource_type_id: options[:resource_type_id].split(",").map(&:underscore).map(&:dasherize) } } if options[:resource_type_id].present?
     filter << { terms: { "types.resourceType": options[:resource_type].split(",") } } if options[:resource_type].present?
     if options[:provider_id].present?
       options[:provider_id].split(",").each { |id|

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -962,7 +962,12 @@ class Doi < ApplicationRecord
     minimum_should_match = 0
 
     filter << { terms: { doi: options[:ids].map(&:upcase) } } if options[:ids].present?
-    filter << { terms: { resource_type_id: options[:resource_type_id].split(",").map(&:underscore).map(&:dasherize) } } if options[:resource_type_id].present?
+    if options[:resource_type_id].present?
+      resource_type_ids = options[:resource_type_id]
+                            .split(",")
+                            .map { |id| id.strip.underscore.dasherize }
+      filter << { terms: { resource_type_id: resource_type_ids } }
+    end
     filter << { terms: { "types.resourceType": options[:resource_type].split(",") } } if options[:resource_type].present?
     if options[:provider_id].present?
       options[:provider_id].split(",").each { |id|

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -962,7 +962,7 @@ class Doi < ApplicationRecord
     minimum_should_match = 0
 
     filter << { terms: { doi: options[:ids].map(&:upcase) } } if options[:ids].present?
-    filter << { terms: { resource_type_id: options[:resource_type_id].split(",").map(&:underscore).map(&:dasherize } } if options[:resource_type_id].present?
+    filter << { terms: { resource_type_id: options[:resource_type_id].split(",").map(&:underscore).map(&:dasherize) } if options[:resource_type_id].present?
     filter << { terms: { "types.resourceType": options[:resource_type].split(",") } } if options[:resource_type].present?
     if options[:provider_id].present?
       options[:provider_id].split(",").each { |id|


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
We allow querying against multiple values for `resourceType`, but not `resourceTypeGeneral`. Since `resourceTypeGeneral` is a controlled list, it seems useful to allow multiple queries in a single API call, as this uses the much more efficient `filter` approach in ES (vs doing `?query=types.resourceTypeGeneral:x OR types.resourceTypeGeneral:y`)

This PR adds support for multiple values in the `resource_type_id` parameter, which ultimately uses the value from `resourceTypeGeneral` via https://github.com/datacite/lupo/blob/master/app/models/doi.rb#L1232-L1237 and https://github.com/datacite/lupo/blob/master/app/models/doi.rb#L2489-L2495

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
