### PR TITLE
Remove realtime indexing from TransferJob

### DIFF
--- a/app/jobs/transfer_job.rb
+++ b/app/jobs/transfer_job.rb
@@ -12,7 +12,7 @@ class TransferJob < ApplicationJob
     doi = Doi.where(doi: doi_id).first
 
     if doi.present? && options[:client_target_id].present?
-      __elasticsearch__.index_document if doi.update(datacentre: options[:client_target_id]) == true
+      doi.update(datacentre: options[:client_target_id])
 
       Rails.logger.info "[Transfer] Transferred DOI #{doi.doi}."
     elsif doi.present?


### PR DESCRIPTION
## Purpose
The `TransferJob` used to move all DOIs from one client to another was causing errors because it couldn't find the ElasticSearch client for some reason, and was therefore getting stuck in a loop and repeatedly retrying the job, causing the queues and the workers to back up and get stuck in an infinite loop.

Since the DOI is updated (client_id/datacenter change) it triggers the indexable concern and goes onto the queue to be indexed anyway, and we previously decided that with our current better queue management and autoscaling that the real-time indexing is no longer critical (c.f https://github.com/datacite/lupo/pull/1147), the simple fix is just to remove the real-time indexing functionality from this job.

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
