### PR TITLE
Fix for duplicate ids appearing in connections when events contain uppercase and lowercase source_ids and target_ids

### DIFF
--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -1296,7 +1296,7 @@ class Doi < ApplicationRecord
   # remove duplicate citing source dois,
   # then show distribution by year
   def citations_over_time
-    citation_events.map { |event| [event.occurred_at, event.source_doi.downcase] }.sort_by { |v| v[0] }.uniq { |v| v[1] }.
+    citation_events.pluck(:occurred_at, :source_doi).map { |v| [v[0], v[1].downcase] }.sort_by { |v| v[0] }.uniq { |v| v[1] }.
       group_by { |v| v[0].utc.iso8601[0..3] }.
       map { |k, v| { "year" => k, "total" => v.length } }.
       sort_by { |h| h["year"] }

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -1273,11 +1273,11 @@ class Doi < ApplicationRecord
   end
 
   def reference_ids
-    reference_events.pluck(:target_doi).compact.uniq.map(&:downcase)
+    reference_events.pluck(:target_doi).compact.map(&:downcase).uniq
   end
 
   def reference_count
-    reference_events.pluck(:target_doi).uniq.length
+    reference_events.pluck(:target_doi).compact.map(&:downcase).uniq.length
   end
 
   def indexed_references
@@ -1285,18 +1285,18 @@ class Doi < ApplicationRecord
   end
 
   def citation_ids
-    citation_events.pluck(:source_doi).compact.uniq.map(&:downcase)
+    citation_events.pluck(:source_doi).compact.map(&:downcase).uniq
   end
 
   # remove duplicate citing source dois
   def citation_count
-    citation_events.pluck(:source_doi).uniq.length
+    citation_events.pluck(:source_doi).compact.map(&:downcase).uniq.length
   end
 
   # remove duplicate citing source dois,
   # then show distribution by year
   def citations_over_time
-    citation_events.pluck(:occurred_at, :source_doi).uniq { |v| v[1] }.
+    citation_events.map { |event| [event.occurred_at, event.source_doi.downcase] }.sort_by { |v| v[0] }.uniq { |v| v[1] }.
       group_by { |v| v[0].utc.iso8601[0..3] }.
       map { |k, v| { "year" => k, "total" => v.length } }.
       sort_by { |h| h["year"] }
@@ -1307,11 +1307,11 @@ class Doi < ApplicationRecord
   end
 
   def part_ids
-    part_events.pluck(:target_doi).compact.uniq.map(&:downcase)
+    part_events.pluck(:target_doi).compact.map(&:downcase).uniq
   end
 
   def part_count
-    part_events.pluck(:target_doi).uniq.length
+    part_events.pluck(:target_doi).compact.map(&:downcase).uniq.length
   end
 
   def indexed_parts
@@ -1319,11 +1319,11 @@ class Doi < ApplicationRecord
   end
 
   def part_of_ids
-    part_of_events.pluck(:source_doi).compact.uniq.map(&:downcase)
+    part_of_events.pluck(:source_doi).compact.map(&:downcase).uniq
   end
 
   def part_of_count
-    part_of_events.pluck(:source_doi).uniq.length
+    part_of_events.pluck(:source_doi).compact.map(&:downcase).uniq.length
   end
 
   def indexed_part_of
@@ -1331,11 +1331,11 @@ class Doi < ApplicationRecord
   end
 
   def version_ids
-    version_events.pluck(:target_doi).compact.uniq.map(&:downcase)
+    version_events.pluck(:target_doi).compact.map(&:downcase).uniq
   end
 
   def version_count
-    version_events.pluck(:target_doi).uniq.length
+    version_events.pluck(:target_doi).compact.map(&:downcase).uniq.length
   end
 
   def indexed_versions
@@ -1343,11 +1343,11 @@ class Doi < ApplicationRecord
   end
 
   def version_of_ids
-    version_of_events.pluck(:source_doi).compact.uniq.map(&:downcase)
+    version_of_events.pluck(:source_doi).compact.map(&:downcase).uniq
   end
 
   def version_of_count
-    version_of_events.pluck(:source_doi).uniq.length
+    version_of_events.pluck(:source_doi).compact.map(&:downcase).uniq.length
   end
 
   def indexed_version_of
@@ -1361,11 +1361,11 @@ class Doi < ApplicationRecord
   def other_relation_ids
     other_relation_events.map do |e|
       e.doi
-    end.flatten.uniq - [doi.downcase]
+    end.flatten.compact.map(&:downcase).uniq - [doi.downcase]
   end
 
   def other_relation_count
-    other_relation_ids.length
+    other_relation_ids.compact.map(&:downcase).length
   end
 
   def xml_encoded

--- a/spec/models/doi_related_spec.rb
+++ b/spec/models/doi_related_spec.rb
@@ -83,9 +83,29 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
     let(:client) { create(:client) }
     let(:doi) { create(:doi, client: client, aasm_state: "findable") }
     let(:target_doi) { create(:doi, client: client, aasm_state: "findable") }
-    let!(:reference_events) { create(:event_for_crossref, subj_id: "https://doi.org/#{doi.doi}", obj_id: "https://doi.org/#{target_doi.doi}", relation_type_id: "references") }
+    let!(:reference_event) do
+      create(:event_for_crossref, {
+        subj_id: "https://doi.org/#{doi.doi}",
+        obj_id: "https://doi.org/#{target_doi.doi}",
+        relation_type_id: "references",
+        occurred_at: "2015-06-13T16:14:19Z",
+      })
+    end
+    let!(:reference_event2) do
+      create(:event_for_crossref, {
+        subj_id: "https://doi.org/#{target_doi.doi}",
+        obj_id: "https://doi.org/#{doi.doi}",
+        occurred_at: "2016-06-13T16:14:19Z",
+        relation_type_id: "is-referenced-by",
+      })
+    end
 
     it "has references" do
+      # Some older events have downcased source_doi and target_doi
+      reference_event2.target_doi = target_doi.doi.downcase
+      reference_event2.source_doi = doi.doi.downcase
+      reference_event2.save
+
       expect(doi.references.count).to eq(1)
       expect(doi.reference_ids.count).to eq(1)
       expect(doi.reference_count).to eq(1)
@@ -124,10 +144,24 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
         occurred_at: "2016-06-13T16:14:19Z"
       })
     end
+    let!(:citation_event4) do
+      create(:event_for_datacite_crossref, {
+        subj_id: "https://doi.org/#{source_doi2.doi}",
+        obj_id: "https://doi.org/#{doi.doi}",
+        relation_type_id: "cites",
+        source_id: "crossref",
+        occurred_at: "2017-06-13T16:14:19Z"
+      })
+    end
 
     # removing duplicate dois in citation_ids, citation_count and citations_over_time (different relation_type_id)
     it "has citations" do
-      expect(doi.citations.count).to eq(3)
+      # Some older events have downcased source_doi and target_doi
+      citation_event4.source_doi = source_doi2.doi.downcase
+      citation_event4.target_doi = doi.doi.downcase
+      citation_event4.save
+
+      expect(doi.citations.count).to eq(4)
       expect(doi.citation_ids.count).to eq(2)
       expect(doi.citation_count).to eq(2)
       expect(doi.citations_over_time).to eq([{ "total" => 1, "year" => "2015" }, { "total" => 1, "year" => "2016" }])

--- a/spec/models/doi_related_spec.rb
+++ b/spec/models/doi_related_spec.rb
@@ -106,7 +106,7 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
       reference_event2.source_doi = doi.doi.downcase
       reference_event2.save
 
-      expect(doi.references.count).to eq(1)
+      expect(doi.references.count).to eq(2)
       expect(doi.reference_ids.count).to eq(1)
       expect(doi.reference_count).to eq(1)
 


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Addresses issue where uppercase and lowercase ids in an Event's `source_id` or `target_id` would duplicate connections in a Doi record, like citations and thus `citation_ids`, `citation_count`. See the `citations` attribute here: https://api.datacite.org/dois/10.17632/579pxjyjz8.1 

```
"citations": {
"data": [
{
"id": "10.32725/jab.2020.004",
"type": "dois"
},
{
"id": "10.32725/jab.2020.004",
"type": "dois"
}
]
},
```

closes: datacite/datacite#2195 

## Approach
<!--- _How does this change address the problem?_ -->

Adds `.compact.map(&:downcase)` before `.uniq` when calculating connections. Slightly refactors `citations_over_time` method.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

Would require a re-index to be reflected on every record in the REST API. 

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
