### PR TITLE
Faster tests 1 - ability_spec.rb

### DIFF
--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :user do
-    sequence(:name) { |_n| "Josiah Carberry{n}" }
+    sequence(:name) { |_n| "Josiah Carberry#{_n}" }
     provider { "globus" }
     role_id { "user" }
     sequence(:uid) { |n| "0000-0002-1825-000#{n}" }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -3,38 +3,60 @@
 require "rails_helper"
 require "cancan/matchers"
 
-describe User, type: :model, elasticsearch: true do
+describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
   let(:token) { User.generate_token }
   let(:user) { User.new(token) }
-  let!(:consortium) { create(:provider, role_name: "ROLE_CONSORTIUM") }
-  let!(:provider) do
-    create(
+  let(:consortium) { build_stubbed(:provider, role_name: "ROLE_CONSORTIUM") }
+  let(:provider) do
+    build_stubbed(
       :provider,
       consortium: consortium, role_name: "ROLE_CONSORTIUM_ORGANIZATION",
     )
   end
-  let(:contact) { create(:contact, provider: provider) }
-  let(:consortium_contact) { create(:contact, provider: consortium) }
-  let!(:prefix) { create(:prefix, uid: "10.14454") }
-  let!(:client) { create(:client, provider: provider) }
-  let!(:provider_prefix) do
-    create(:provider_prefix, provider: provider, prefix: prefix)
+  let(:contact) { build_stubbed(:contact, provider: provider) }
+  let(:consortium_contact) { build_stubbed(:contact, provider: consortium) }
+  let(:prefix) { build_stubbed(:prefix, uid: "10.14454") }
+  let(:client) { build(:client, provider: provider) }
+  let(:provider_prefix) do
+    build_stubbed(:provider_prefix, provider: provider, prefix: prefix)
   end
-  let!(:client_prefix) do
-    create(:client_prefix, client: client, prefix: prefix)
+  let(:client_prefix) do
+    build_stubbed(:client_prefix, client: client, prefix: prefix)
   end
-  let(:doi) { create(:doi, client: client) }
-  let(:media) { create(:media, doi: doi) }
+  let(:doi) { build_stubbed(:doi, client: client) }
+  let(:media) { build_stubbed(:media, doi: doi) }
   let(:xml) { file_fixture("datacite.xml").read }
-  let(:metadata) { create(:metadata, xml: xml, doi: doi) }
+  let(:metadata) { build_stubbed(:metadata, xml: xml, doi: doi) }
 
-  describe "User attributes", order: :defined do
+  before(:all) do
+    @consortium = create( :provider,
+      role_name: "ROLE_CONSORTIUM")
+    @provider = create(:provider,
+      consortium: @consortium,
+      role_name: "ROLE_CONSORTIUM_ORGANIZATION"
+    )
+    @prefix = create(:prefix, uid: "10.14454")
+    @client = create(:client, provider: @provider)
+    @provider_prefix = create(
+      :provider_prefix,
+      provider: @provider,
+      prefix: @prefix
+    )
+    @client_prefix = create(
+      :client_prefix,
+      client: @client,
+      prefix: @prefix
+    )
+    @doi = create(:doi, client: @client)
+  end
+
+  describe "User attributes", order: :defined, skip_prefix_pool: true do
     it "is valid with valid attributes" do
       expect(user.name).to eq("Josiah Carberry")
     end
   end
 
-  describe "abilities", vcr: true do
+  describe "abilities", vcr: true,  skip_prefix_pool: true do
     subject { Ability.new(user) }
 
     context "when is a user" do
@@ -75,62 +97,85 @@ describe User, type: :model, elasticsearch: true do
     end
 
     context "when is a client admin" do
-      let(:token) do
-        User.generate_token(
+
+      before(:all) do
+        @token = User.generate_token(
           role_id: "client_admin",
-          provider_id: provider.symbol.downcase,
-          client_id: client.symbol.downcase,
+          provider_id: @provider.symbol.downcase,
+          client_id: @client.symbol.downcase,
+
         )
       end
 
-      it { is_expected.to be_able_to(:read, user) }
-      it { is_expected.to be_able_to(:read, provider) }
+      let(:token) { @token }
 
-      it { is_expected.not_to be_able_to(:create, provider) }
-      it { is_expected.not_to be_able_to(:update, provider) }
-      it { is_expected.not_to be_able_to(:destroy, provider) }
-      it { is_expected.not_to be_able_to(:read_billing_information, provider) }
-      it { is_expected.not_to be_able_to(:read_contact_information, provider) }
+      it { is_expected.to be_able_to(:read, user) }
+      it { is_expected.to be_able_to(:read, @provider) }
+
+      it { is_expected.not_to be_able_to(:create, @provider) }
+      it { is_expected.not_to be_able_to(:update, @provider) }
+      it { is_expected.not_to be_able_to(:destroy, @provider) }
+      it { is_expected.not_to be_able_to(:read_billing_information, @provider) }
+      it { is_expected.not_to be_able_to(:read_contact_information, @provider) }
 
       it { is_expected.not_to be_able_to(:read, contact) }
       it { is_expected.not_to be_able_to(:create, contact) }
       it { is_expected.not_to be_able_to(:update, contact) }
       it { is_expected.not_to be_able_to(:destroy, contact) }
 
-      it { is_expected.to be_able_to(:read, client) }
-      it { is_expected.not_to be_able_to(:create, client) }
-      it { is_expected.to be_able_to(:update, client) }
-      it { is_expected.not_to be_able_to(:destroy, client) }
-      it { is_expected.not_to be_able_to(:transfer, client) }
-      it { is_expected.to be_able_to(:read_contact_information, client) }
-      it { is_expected.to be_able_to(:read_analytics, client) }
+      it { is_expected.to be_able_to(:read, @client) }
+      it { is_expected.not_to be_able_to(:create, @client) }
+      it { is_expected.to be_able_to(:update, @client) }
+      it { is_expected.not_to be_able_to(:destroy, @client) }
+      it { is_expected.not_to be_able_to(:transfer, @client) }
+      it { is_expected.to be_able_to(:read_contact_information, @client) }
+      it { is_expected.to be_able_to(:read_analytics, @client) }
 
-      it { is_expected.not_to be_able_to(:read, prefix) }
-      it { is_expected.not_to be_able_to(:create, prefix) }
-      it { is_expected.not_to be_able_to(:update, prefix) }
-      it { is_expected.not_to be_able_to(:destroy, prefix) }
+      it { is_expected.not_to be_able_to(:read, @prefix) }
+      it { is_expected.not_to be_able_to(:create, @prefix) }
+      it { is_expected.not_to be_able_to(:update, @prefix) }
+      it { is_expected.not_to be_able_to(:destroy, @prefix) }
 
-      it { is_expected.to be_able_to(:read, client_prefix) }
-      it { is_expected.not_to be_able_to(:create, client_prefix) }
-      it { is_expected.not_to be_able_to(:update, client_prefix) }
-      it { is_expected.not_to be_able_to(:destroy, client_prefix) }
+      it { is_expected.to be_able_to(:read, @client_prefix) }
+      it { is_expected.not_to be_able_to(:create, @client_prefix) }
+      it { is_expected.not_to be_able_to(:update, @client_prefix) }
+      it { is_expected.not_to be_able_to(:destroy, @client_prefix) }
 
-      it { is_expected.to be_able_to(:read, doi) }
-      it { is_expected.not_to be_able_to(:transfer, doi) }
-      it { is_expected.to be_able_to(:create, doi) }
-      it { is_expected.to be_able_to(:update, doi) }
-      it { is_expected.to be_able_to(:destroy, doi) }
+      it { is_expected.to be_able_to(:read, @doi) }
+      it { is_expected.not_to be_able_to(:transfer, @doi) }
+      it { is_expected.to be_able_to(:create, @doi) }
+      it { is_expected.to be_able_to(:update, @doi) }
+      it { is_expected.to be_able_to(:destroy, @doi) }
     end
 
     context "when is a client admin inactive" do
-      let(:client) { create(:client, provider: provider, is_active: false) }
-      let(:token) do
-        User.generate_token(
+      before(:all) do
+        @prefix = create(:prefix, uid: "10.14455")
+        @client = create(
+          :client,
+          provider: @provider,
+          is_active: false
+        )
+        @provider_prefix = create(
+          :provider_prefix,
+          provider: @provider,
+          prefix: @prefix
+        )
+        @client_prefix = create(
+          :client_prefix,
+          client: @client,
+          prefix: @prefix
+        )
+        @doi = create(:doi, client: @client)
+        @token = User.generate_token(
           role_id: "client_admin",
-          provider_id: provider.symbol.downcase,
-          client_id: client.symbol.downcase,
+          provider_id: @provider.symbol.downcase,
+          client_id: @client.symbol.downcase,
+
         )
       end
+
+      let(:token) { @token }
 
       it { is_expected.to be_able_to(:read, user) }
       it { is_expected.to be_able_to(:read, provider) }
@@ -146,39 +191,41 @@ describe User, type: :model, elasticsearch: true do
       it { is_expected.not_to be_able_to(:update, contact) }
       it { is_expected.not_to be_able_to(:destroy, contact) }
 
-      it { is_expected.to be_able_to(:read, client) }
-      it { is_expected.not_to be_able_to(:create, client) }
-      it { is_expected.not_to be_able_to(:update, client) }
-      it { is_expected.not_to be_able_to(:destroy, client) }
-      it { is_expected.not_to be_able_to(:transfer, client) }
-      it { is_expected.to be_able_to(:read_contact_information, client) }
-      it { is_expected.to be_able_to(:read_analytics, client) }
+      it { is_expected.to be_able_to(:read, @client) }
+      it { is_expected.not_to be_able_to(:create, @client) }
+      it { is_expected.not_to be_able_to(:update, @client) }
+      it { is_expected.not_to be_able_to(:destroy, @client) }
+      it { is_expected.not_to be_able_to(:transfer, @client) }
+      it { is_expected.to be_able_to(:read_contact_information, @client) }
+      it { is_expected.to be_able_to(:read_analytics, @client) }
 
       it { is_expected.not_to be_able_to(:read, prefix) }
       it { is_expected.not_to be_able_to(:create, prefix) }
       it { is_expected.not_to be_able_to(:update, prefix) }
       it { is_expected.not_to be_able_to(:destroy, prefix) }
 
-      it { is_expected.to be_able_to(:read, client_prefix) }
-      it { is_expected.not_to be_able_to(:create, client_prefix) }
-      it { is_expected.not_to be_able_to(:update, client_prefix) }
-      it { is_expected.not_to be_able_to(:destroy, client_prefix) }
+      it { is_expected.to be_able_to(:read, @client_prefix) }
+      it { is_expected.not_to be_able_to(:create, @client_prefix) }
+      it { is_expected.not_to be_able_to(:update, @client_prefix) }
+      it { is_expected.not_to be_able_to(:destroy, @client_prefix) }
 
-      it { is_expected.to be_able_to(:read, doi) }
-      it { is_expected.not_to be_able_to(:transfer, doi) }
-      it { is_expected.not_to be_able_to(:create, doi) }
-      it { is_expected.not_to be_able_to(:update, doi) }
-      it { is_expected.not_to be_able_to(:destroy, doi) }
+      it { is_expected.to be_able_to(:read, @doi) }
+      it { is_expected.not_to be_able_to(:transfer, @doi) }
+      it { is_expected.not_to be_able_to(:create, @doi) }
+      it { is_expected.not_to be_able_to(:update, @doi) }
+      it { is_expected.not_to be_able_to(:destroy, @doi) }
     end
 
     context "when is a client user" do
-      let(:token) do
-        User.generate_token(
+      before(:all) do
+        @token = User.generate_token(
           role_id: "client_user",
-          provider_id: provider.symbol.downcase,
-          client_id: client.symbol.downcase,
+          provider_id: @provider.symbol.downcase,
+          client_id: @client.symbol.downcase,
+
         )
       end
+      let(:token) { @token }
 
       it { is_expected.to be_able_to(:read, user) }
       it { is_expected.to be_able_to(:read, provider) }
@@ -194,23 +241,23 @@ describe User, type: :model, elasticsearch: true do
       it { is_expected.not_to be_able_to(:update, contact) }
       it { is_expected.not_to be_able_to(:destroy, contact) }
 
-      it { is_expected.to be_able_to(:read, client) }
-      it { is_expected.not_to be_able_to(:create, client) }
-      it { is_expected.not_to be_able_to(:update, client) }
-      it { is_expected.not_to be_able_to(:destroy, client) }
-      it { is_expected.not_to be_able_to(:transfer, client) }
-      it { is_expected.to be_able_to(:read_contact_information, client) }
-      it { is_expected.to be_able_to(:read_analytics, client) }
+      it { is_expected.to be_able_to(:read, @client) }
+      it { is_expected.not_to be_able_to(:create, @client) }
+      it { is_expected.not_to be_able_to(:update, @client) }
+      it { is_expected.not_to be_able_to(:destroy, @client) }
+      it { is_expected.not_to be_able_to(:transfer, @client) }
+      it { is_expected.to be_able_to(:read_contact_information, @client) }
+      it { is_expected.to be_able_to(:read_analytics, @client) }
 
       it { is_expected.not_to be_able_to(:read, prefix) }
       it { is_expected.not_to be_able_to(:create, prefix) }
       it { is_expected.not_to be_able_to(:update, prefix) }
       it { is_expected.not_to be_able_to(:destroy, prefix) }
 
-      it { is_expected.to be_able_to(:read, client_prefix) }
-      it { is_expected.not_to be_able_to(:create, client_prefix) }
-      it { is_expected.not_to be_able_to(:update, client_prefix) }
-      it { is_expected.not_to be_able_to(:destroy, client_prefix) }
+      it { is_expected.to be_able_to(:read, @client_prefix) }
+      it { is_expected.not_to be_able_to(:create, @client_prefix) }
+      it { is_expected.not_to be_able_to(:update, @client_prefix) }
+      it { is_expected.not_to be_able_to(:destroy, @client_prefix) }
 
       it { is_expected.to be_able_to(:read, doi) }
       it { is_expected.not_to be_able_to(:transfer, doi) }
@@ -368,33 +415,43 @@ describe User, type: :model, elasticsearch: true do
     end
 
     context "when is a staff admin" do
+      before(:all) do
+        @token = User.generate_token(
+          role_id: "staff_admin",
+          provider_id: @provider.symbol.downcase,
+          client_id: @client.symbol.downcase,
+
+        )
+      end
+      let(:token) { @token }
+
       it { is_expected.to be_able_to(:read, user) }
 
-      it { is_expected.to be_able_to(:read, provider) }
-      it { is_expected.to be_able_to(:create, provider) }
-      it { is_expected.to be_able_to(:update, provider) }
-      it { is_expected.to be_able_to(:destroy, provider) }
-      it { is_expected.to be_able_to(:transfer, client) }
-      it { is_expected.to be_able_to(:read_billing_information, provider) }
-      it { is_expected.to be_able_to(:read_contact_information, provider) }
+      it { is_expected.to be_able_to(:read, @provider) }
+      it { is_expected.to be_able_to(:create, @provider) }
+      it { is_expected.to be_able_to(:update, @provider) }
+      it { is_expected.to be_able_to(:destroy, @provider) }
+      it { is_expected.to be_able_to(:transfer, @client) }
+      it { is_expected.to be_able_to(:read_billing_information, @provider) }
+      it { is_expected.to be_able_to(:read_contact_information, @provider) }
 
       it { is_expected.to be_able_to(:read, contact) }
       it { is_expected.to be_able_to(:create, contact) }
       it { is_expected.to be_able_to(:update, contact) }
       it { is_expected.to be_able_to(:destroy, contact) }
 
-      it { is_expected.to be_able_to(:read, client) }
-      it { is_expected.to be_able_to(:create, client) }
-      it { is_expected.to be_able_to(:update, client) }
-      it { is_expected.to be_able_to(:destroy, client) }
-      it { is_expected.to be_able_to(:read_contact_information, client) }
-      it { is_expected.to be_able_to(:read_analytics, client) }
+      it { is_expected.to be_able_to(:read, @client) }
+      it { is_expected.to be_able_to(:create, @client) }
+      it { is_expected.to be_able_to(:update, @client) }
+      it { is_expected.to be_able_to(:destroy, @client) }
+      it { is_expected.to be_able_to(:read_contact_information, @client) }
+      it { is_expected.to be_able_to(:read_analytics, @client) }
 
-      it { is_expected.to be_able_to(:read, doi) }
-      it { is_expected.to be_able_to(:transfer, doi) }
-      it { is_expected.to be_able_to(:create, doi) }
-      it { is_expected.to be_able_to(:update, doi) }
-      it { is_expected.to be_able_to(:destroy, doi) }
+      it { is_expected.to be_able_to(:read, @doi) }
+      it { is_expected.to be_able_to(:transfer, @doi) }
+      it { is_expected.to be_able_to(:create, @doi) }
+      it { is_expected.to be_able_to(:update, @doi) }
+      it { is_expected.to be_able_to(:destroy, @doi) }
     end
 
     context "when is a staff user" do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -29,7 +29,7 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
   let(:metadata) { build_stubbed(:metadata, xml: xml, doi: doi) }
 
   before(:all) do
-    @consortium = create( :provider,
+    @consortium = create(:provider,
       role_name: "ROLE_CONSORTIUM")
     @provider = create(:provider,
       consortium: @consortium,
@@ -97,7 +97,6 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
     end
 
     context "when is a client admin" do
-
       before(:all) do
         @token = User.generate_token(
           role_id: "client_admin",


### PR DESCRIPTION
## Purpose
Reduces the total clock time for ability_spec.rb from 21 minutes on a local dev environment, down to 10 seconds in a local dev environment.  Hopefully this will reduce the amount of time spent on the parallel test suite as well as the overall test runtime.

closes: #1243

## Approach
There are three parts to this:

1. Skip elasticsearch setup-teardown where not used
2. Skip prefix allocation setup-teardown where not used
3. Use fixtures with `build` instead of `create` where possible to skip db connections and post-creation hooks. 

## Learning
This is a great blogpost that lead me to several of the insights in this PR.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
