### PR TITLE
Rework ability_spec.rb so it doesn't spill over into other specs

### DIFF
--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -43,37 +43,47 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
       let(:token) { User.generate_token(role_id: "user") }
 
       it { is_expected.to be_able_to(:read, user) }
-      it { is_expected.to be_able_to(:read, provider) }
 
-      it { is_expected.not_to be_able_to(:create, provider) }
-      it { is_expected.not_to be_able_to(:update, provider) }
-      it { is_expected.not_to be_able_to(:destroy, provider) }
-      it { is_expected.not_to be_able_to(:read_billing_information, provider) }
-      it { is_expected.not_to be_able_to(:read_contact_information, provider) }
+      it "can read but not create/update/destroy/read_billing_information/read_contact_information the provider" do
+        is_expected.to be_able_to(:read, provider)
+        is_expected.not_to be_able_to(:create, provider)
+        is_expected.not_to be_able_to(:update, provider)
+        is_expected.not_to be_able_to(:destroy, provider)
+        is_expected.not_to be_able_to(:read_billing_information, provider)
+        is_expected.not_to be_able_to(:read_contact_information, provider)
+      end
 
-      it { is_expected.not_to be_able_to(:read, contact) }
-      it { is_expected.not_to be_able_to(:create, contact) }
-      it { is_expected.not_to be_able_to(:update, contact) }
-      it { is_expected.not_to be_able_to(:destroy, contact) }
+      it "can not read/create/update/destroy the contact"do
+        is_expected.not_to be_able_to(:read, contact)
+        is_expected.not_to be_able_to(:create, contact)
+        is_expected.not_to be_able_to(:update, contact)
+        is_expected.not_to be_able_to(:destroy, contact)
+      end
 
-      it { is_expected.not_to be_able_to(:read, client) }
-      it { is_expected.not_to be_able_to(:create, client) }
-      it { is_expected.not_to be_able_to(:update, client) }
-      it { is_expected.not_to be_able_to(:destroy, client) }
-      it { is_expected.not_to be_able_to(:transfer, client) }
-      it { is_expected.not_to be_able_to(:read_contact_information, client) }
-      it { is_expected.not_to be_able_to(:read_analytics, client) }
+      it "can not read/create/update/destroy/transfer/read_contact_information/read_analytics the client"do
+        is_expected.not_to be_able_to(:read, client)
+        is_expected.not_to be_able_to(:create, client)
+        is_expected.not_to be_able_to(:update, client)
+        is_expected.not_to be_able_to(:destroy, client)
+        is_expected.not_to be_able_to(:transfer, client)
+        is_expected.not_to be_able_to(:read_contact_information, client)
+        is_expected.not_to be_able_to(:read_analytics, client)
+      end
 
-      it { is_expected.not_to be_able_to(:read, prefix) }
-      it { is_expected.not_to be_able_to(:create, prefix) }
-      it { is_expected.not_to be_able_to(:update, prefix) }
-      it { is_expected.not_to be_able_to(:destroy, prefix) }
+      it "can not read/create/update/destroy the prefix" do
+        is_expected.not_to be_able_to(:read, prefix)
+        is_expected.not_to be_able_to(:create, prefix)
+        is_expected.not_to be_able_to(:update, prefix)
+        is_expected.not_to be_able_to(:destroy, prefix)
+      end
 
-      it { is_expected.to be_able_to(:read, doi) }
-      it { is_expected.not_to be_able_to(:transfer, doi) }
-      it { is_expected.not_to be_able_to(:create, doi) }
-      it { is_expected.not_to be_able_to(:update, doi) }
-      it { is_expected.not_to be_able_to(:destroy, doi) }
+      it "can read but not transfer/create/update/destroy the doi"do
+        is_expected.to be_able_to(:read, doi)
+        is_expected.not_to be_able_to(:transfer, doi)
+        is_expected.not_to be_able_to(:create, doi)
+        is_expected.not_to be_able_to(:update, doi)
+        is_expected.not_to be_able_to(:destroy, doi)
+      end
     end
 
     context "when is a client admin" do
@@ -101,7 +111,7 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         is_expected.to be_able_to(:read, user)
       end
 
-      it "can read, but not create/update/destroy/read_billing_information/read_contact_information of a provider" do
+      it "can read, but not create/update/destroy/read_billing_information/read_contact_information the provider" do
         is_expected.to be_able_to(:read, provider)
         is_expected.not_to be_able_to(:create, provider)
         is_expected.not_to be_able_to(:update, provider)
@@ -182,7 +192,7 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         is_expected.to be_able_to(:read, user)
       end
 
-      it "can read, but not create/update/destroy/read_billing_information/read_contact_information of a provider" do
+      it "can read, but not create/update/destroy/read_billing_information/read_contact_information the provider" do
         is_expected.to be_able_to(:read, provider)
         is_expected.not_to be_able_to(:create, provider)
         is_expected.not_to be_able_to(:update, provider)
@@ -252,11 +262,11 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         })
       end
 
-      it do
+      it "can read the user"do
         is_expected.to be_able_to(:read, user)
       end
 
-      it do
+      it "can read, but not create/update/destroy/read_billing_information/read_contact_information the provider"do
         is_expected.to be_able_to(:read, provider)
         is_expected.not_to be_able_to(:create, provider)
         is_expected.not_to be_able_to(:update, provider)
@@ -265,14 +275,14 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         is_expected.not_to be_able_to(:read_contact_information, provider)
       end
 
-      it do
+      it "can not read/create/update/destroy a contact"do
         is_expected.not_to be_able_to(:read, contact)
         is_expected.not_to be_able_to(:create, contact)
         is_expected.not_to be_able_to(:update, contact)
         is_expected.not_to be_able_to(:destroy, contact)
       end
 
-      it do
+      it "can read/read_contact_information/read_analytics but not create/update/destroy/transfer the client" do
         is_expected.to be_able_to(:read, client)
         is_expected.not_to be_able_to(:create, client)
         is_expected.not_to be_able_to(:update, client)
@@ -282,21 +292,21 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         is_expected.to be_able_to(:read_analytics, client)
       end
 
-      it do
+      it "can not read/create/update/destroy the prefix" do
         is_expected.not_to be_able_to(:read, prefix)
         is_expected.not_to be_able_to(:create, prefix)
         is_expected.not_to be_able_to(:update, prefix)
         is_expected.not_to be_able_to(:destroy, prefix)
       end
 
-      it do
+      it "can read but not create/update/destroy the client prefix" do
         is_expected.to be_able_to(:read, client_prefix)
         is_expected.not_to be_able_to(:create, client_prefix)
         is_expected.not_to be_able_to(:update, client_prefix)
         is_expected.not_to be_able_to(:destroy, client_prefix)
       end
 
-      it do
+      it "can read but not transfer/create/update/destroy the doi" do
         is_expected.to be_able_to(:read, doi)
         is_expected.not_to be_able_to(:transfer, doi)
         is_expected.not_to be_able_to(:create, doi)
@@ -313,43 +323,57 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         )
       end
 
-      it { is_expected.to be_able_to(:read, user) }
+      it "can read the user" do
+        is_expected.to be_able_to(:read, user)
+      end
 
-      it { is_expected.to be_able_to(:read, provider) }
-      it { is_expected.not_to be_able_to(:create, provider) }
-      it { is_expected.to be_able_to(:update, provider) }
-      it { is_expected.not_to be_able_to(:destroy, provider) }
-      it { is_expected.to be_able_to(:read_billing_information, provider) }
-      it { is_expected.to be_able_to(:read_contact_information, provider) }
+      it "can read/update/read_billing_information/read_contact_information but not create/destroy the provider" do
+        is_expected.to be_able_to(:read, provider)
+        is_expected.to be_able_to(:update, provider)
+        is_expected.to be_able_to(:read_billing_information, provider)
+        is_expected.to be_able_to(:read_contact_information, provider)
+        is_expected.not_to be_able_to(:create, provider)
+        is_expected.not_to be_able_to(:destroy, provider)
+      end
 
-      it { is_expected.to be_able_to(:read, contact) }
-      it { is_expected.to be_able_to(:create, contact) }
-      it { is_expected.to be_able_to(:update, contact) }
-      it { is_expected.to be_able_to(:destroy, contact) }
+      it "can read/create/update/destroy the contact" do
+        is_expected.to be_able_to(:read, contact)
+        is_expected.to be_able_to(:create, contact)
+        is_expected.to be_able_to(:update, contact)
+        is_expected.to be_able_to(:destroy, contact)
+      end
 
-      it { is_expected.to be_able_to(:read, client) }
-      it { is_expected.to be_able_to(:create, client) }
-      it { is_expected.to be_able_to(:update, client) }
-      it { is_expected.to be_able_to(:destroy, client) }
-      it { is_expected.not_to be_able_to(:transfer, client) }
-      it { is_expected.to be_able_to(:read_contact_information, client) }
-      it { is_expected.to be_able_to(:read_analytics, client) }
+      it "can read/create/update/destroy/read_contact_information/read_analytics but not transfer the client" do
+        is_expected.to be_able_to(:read, client)
+        is_expected.to be_able_to(:create, client)
+        is_expected.to be_able_to(:update, client)
+        is_expected.to be_able_to(:destroy, client)
+        is_expected.to be_able_to(:read_contact_information, client)
+        is_expected.to be_able_to(:read_analytics, client)
+        is_expected.not_to be_able_to(:transfer, client)
+      end
 
-      it { is_expected.not_to be_able_to(:read, prefix) }
-      it { is_expected.not_to be_able_to(:create, prefix) }
-      it { is_expected.not_to be_able_to(:update, prefix) }
-      it { is_expected.not_to be_able_to(:destroy, prefix) }
+      it "can not read/create/update/destroy the prefix" do
+        is_expected.not_to be_able_to(:read, prefix)
+        is_expected.not_to be_able_to(:create, prefix)
+        is_expected.not_to be_able_to(:update, prefix)
+        is_expected.not_to be_able_to(:destroy, prefix)
+      end
 
-      it { is_expected.to be_able_to(:read, provider_prefix) }
-      it { is_expected.to be_able_to(:create, provider_prefix) }
-      it { is_expected.to be_able_to(:update, provider_prefix) }
-      it { is_expected.to be_able_to(:destroy, provider_prefix) }
+      it "can read/create/update/destroy the provider prefix" do
+        is_expected.to be_able_to(:read, provider_prefix)
+        is_expected.to be_able_to(:create, provider_prefix)
+        is_expected.to be_able_to(:update, provider_prefix)
+        is_expected.to be_able_to(:destroy, provider_prefix)
+      end
 
-      it { is_expected.to be_able_to(:read, doi) }
-      it { is_expected.to be_able_to(:transfer, doi) }
-      it { is_expected.not_to be_able_to(:create, doi) }
-      it { is_expected.not_to be_able_to(:update, doi) }
-      it { is_expected.not_to be_able_to(:destroy, doi) }
+      it "can read/transfer but not create/update/destroy the doi" do
+        is_expected.to be_able_to(:read, doi)
+        is_expected.to be_able_to(:transfer, doi)
+        is_expected.not_to be_able_to(:create, doi)
+        is_expected.not_to be_able_to(:update, doi)
+        is_expected.not_to be_able_to(:destroy, doi)
+      end
     end
 
     context "when is a consortium admin" do
@@ -359,53 +383,74 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         )
       end
 
-      it { is_expected.to be_able_to(:read, user) }
+      it "can read the user" do
+        is_expected.to be_able_to(:read, user)
+      end
 
-      it { is_expected.to be_able_to(:read, consortium) }
-      it { is_expected.not_to be_able_to(:create, consortium) }
-      it { is_expected.to be_able_to(:update, consortium) }
-      it { is_expected.not_to be_able_to(:destroy, consortium) }
-      it { is_expected.to be_able_to(:read_billing_information, provider) }
-      it { is_expected.to be_able_to(:read_contact_information, provider) }
+      it "can read/update but not create/destroy the consortium" do
+        is_expected.to be_able_to(:read, consortium)
+        is_expected.to be_able_to(:update, consortium)
+        is_expected.not_to be_able_to(:create, consortium)
+        is_expected.not_to be_able_to(:destroy, consortium)
+      end
 
-      it { is_expected.to be_able_to(:read, contact) }
-      it { is_expected.to be_able_to(:create, contact) }
-      it { is_expected.to be_able_to(:update, contact) }
-      it { is_expected.to be_able_to(:destroy, contact) }
+      it "can read_billing_information/read_contact_information the provider" do
+        is_expected.to be_able_to(:read_billing_information, provider)
+        is_expected.to be_able_to(:read_contact_information, provider)
+      end
 
-      it { is_expected.to be_able_to(:read, consortium_contact) }
-      it { is_expected.to be_able_to(:create, consortium_contact) }
-      it { is_expected.to be_able_to(:update, consortium_contact) }
-      it { is_expected.to be_able_to(:destroy, consortium_contact) }
+      it "can read/create/update/destroy the contact" do
+        is_expected.to be_able_to(:read, contact)
+        is_expected.to be_able_to(:create, contact)
+        is_expected.to be_able_to(:update, contact)
+        is_expected.to be_able_to(:destroy, contact)
+      end
 
-      it { is_expected.to be_able_to(:read, provider) }
-      it { is_expected.to be_able_to(:create, provider) }
-      it { is_expected.to be_able_to(:update, provider) }
-      it { is_expected.to be_able_to(:destroy, provider) }
-      it { is_expected.to be_able_to(:transfer, client) }
+      it "can read/create/update/destroy the consortium_contact" do
+        is_expected.to be_able_to(:read, consortium_contact)
+        is_expected.to be_able_to(:create, consortium_contact)
+        is_expected.to be_able_to(:update, consortium_contact)
+        is_expected.to be_able_to(:destroy, consortium_contact)
+      end
 
-      it { is_expected.to be_able_to(:read, client) }
-      it { is_expected.to be_able_to(:create, client) }
-      it { is_expected.to be_able_to(:update, client) }
-      it { is_expected.to be_able_to(:destroy, client) }
-      it { is_expected.to be_able_to(:read_contact_information, client) }
-      it { is_expected.to be_able_to(:read_analytics, client) }
+      it "can read/create/update/destroy the provider"do
+        is_expected.to be_able_to(:read, provider)
+        is_expected.to be_able_to(:create, provider)
+        is_expected.to be_able_to(:update, provider)
+        is_expected.to be_able_to(:destroy, provider)
+      end
 
-      it { is_expected.not_to be_able_to(:read, prefix) }
-      it { is_expected.not_to be_able_to(:create, prefix) }
-      it { is_expected.not_to be_able_to(:update, prefix) }
-      it { is_expected.not_to be_able_to(:destroy, prefix) }
+      it "can read/create/update/destroy/read_contact_information/read_analytics/transfer the client" do
+        is_expected.to be_able_to(:read, client)
+        is_expected.to be_able_to(:create, client)
+        is_expected.to be_able_to(:update, client)
+        is_expected.to be_able_to(:destroy, client)
+        is_expected.to be_able_to(:read_contact_information, client)
+        is_expected.to be_able_to(:read_analytics, client)
+        is_expected.to be_able_to(:transfer, client)
+      end
 
-      it { is_expected.to be_able_to(:read, provider_prefix) }
-      it { is_expected.to be_able_to(:create, provider_prefix) }
-      it { is_expected.to be_able_to(:update, provider_prefix) }
-      it { is_expected.to be_able_to(:destroy, provider_prefix) }
+      it "can not read/create/update/destroy the prefix" do
+        is_expected.not_to be_able_to(:read, prefix)
+        is_expected.not_to be_able_to(:create, prefix)
+        is_expected.not_to be_able_to(:update, prefix)
+        is_expected.not_to be_able_to(:destroy, prefix)
+      end
 
-      it { is_expected.to be_able_to(:read, doi) }
-      it { is_expected.to be_able_to(:transfer, doi) }
-      it { is_expected.not_to be_able_to(:create, doi) }
-      it { is_expected.not_to be_able_to(:update, doi) }
-      it { is_expected.not_to be_able_to(:destroy, doi) }
+      it "can read/create/update/destroy the provider prefix" do
+        is_expected.to be_able_to(:read, provider_prefix)
+        is_expected.to be_able_to(:create, provider_prefix)
+        is_expected.to be_able_to(:update, provider_prefix)
+        is_expected.to be_able_to(:destroy, provider_prefix)
+      end
+
+      it 'can read/transfer but not create/update/destroy the doi' do
+        is_expected.to be_able_to(:read, doi)
+        is_expected.to be_able_to(:transfer, doi)
+        is_expected.not_to be_able_to(:create, doi)
+        is_expected.not_to be_able_to(:update, doi)
+        is_expected.not_to be_able_to(:destroy, doi)
+      end
     end
 
     context "when is a provider user" do
@@ -416,43 +461,58 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         )
       end
 
-      it { is_expected.to be_able_to(:read, user) }
+      it "can read the user" do
+        is_expected.to be_able_to(:read, user)
+      end
 
-      it { is_expected.to be_able_to(:read, provider) }
-      it { is_expected.not_to be_able_to(:create, provider) }
-      it { is_expected.not_to be_able_to(:update, provider) }
-      it { is_expected.not_to be_able_to(:destroy, provider) }
-      it { is_expected.to be_able_to(:read_billing_information, provider) }
-      it { is_expected.to be_able_to(:read_contact_information, provider) }
+      it "can read/read_billing_information/read_contact_information but not create/update/destroy the provider" do
+        is_expected.to be_able_to(:read, provider)
+        is_expected.to be_able_to(:read_billing_information, provider)
+        is_expected.to be_able_to(:read_contact_information, provider)
+        is_expected.not_to be_able_to(:create, provider)
+        is_expected.not_to be_able_to(:update, provider)
+        is_expected.not_to be_able_to(:destroy, provider)
+      end
 
-      it { is_expected.to be_able_to(:read, contact) }
-      it { is_expected.not_to be_able_to(:create, contact) }
-      it { is_expected.not_to be_able_to(:update, contact) }
-      it { is_expected.not_to be_able_to(:destroy, contact) }
+      it "can read but not create/update/destroy the contact" do
+        is_expected.to be_able_to(:read, contact)
+        is_expected.not_to be_able_to(:create, contact)
+        is_expected.not_to be_able_to(:update, contact)
+        is_expected.not_to be_able_to(:destroy, contact)
+      end
 
-      it { is_expected.to be_able_to(:read, client) }
-      it { is_expected.not_to be_able_to(:create, client) }
-      it { is_expected.not_to be_able_to(:update, client) }
-      it { is_expected.not_to be_able_to(:destroy, client) }
-      it { is_expected.not_to be_able_to(:transfer, client) }
-      it { is_expected.to be_able_to(:read_contact_information, client) }
-      it { is_expected.to be_able_to(:read_analytics, client) }
+      it "can read/read_contact_information/read_analytics but not create/update/destroy/transfer the client" do
+        is_expected.to be_able_to(:read, client)
+        is_expected.to be_able_to(:read_contact_information, client)
+        is_expected.to be_able_to(:read_analytics, client)
 
-      it { is_expected.not_to be_able_to(:read, prefix) }
-      it { is_expected.not_to be_able_to(:create, prefix) }
-      it { is_expected.not_to be_able_to(:update, prefix) }
-      it { is_expected.not_to be_able_to(:destroy, prefix) }
+        is_expected.not_to be_able_to(:create, client)
+        is_expected.not_to be_able_to(:update, client)
+        is_expected.not_to be_able_to(:destroy, client)
+        is_expected.not_to be_able_to(:transfer, client)
+      end
 
-      it { is_expected.to be_able_to(:read, provider_prefix) }
-      it { is_expected.not_to be_able_to(:create, provider_prefix) }
-      it { is_expected.not_to be_able_to(:update, provider_prefix) }
-      it { is_expected.not_to be_able_to(:destroy, provider_prefix) }
+      it "can not read/create/update/destroy the prefix" do
+        is_expected.not_to be_able_to(:read, prefix)
+        is_expected.not_to be_able_to(:create, prefix)
+        is_expected.not_to be_able_to(:update, prefix)
+        is_expected.not_to be_able_to(:destroy, prefix)
+      end
 
-      it { is_expected.to be_able_to(:read, doi) }
-      it { is_expected.not_to be_able_to(:transfer, doi) }
-      it { is_expected.not_to be_able_to(:create, doi) }
-      it { is_expected.not_to be_able_to(:update, doi) }
-      it { is_expected.not_to be_able_to(:destroy, doi) }
+      it "can read but not create/update/destroy the provider prefix" do
+        is_expected.to be_able_to(:read, provider_prefix)
+        is_expected.not_to be_able_to(:create, provider_prefix)
+        is_expected.not_to be_able_to(:update, provider_prefix)
+        is_expected.not_to be_able_to(:destroy, provider_prefix)
+      end
+
+      it "can read but not transfer/create/update/destroy the doi" do
+        is_expected.to be_able_to(:read, doi)
+        is_expected.not_to be_able_to(:transfer, doi)
+        is_expected.not_to be_able_to(:create, doi)
+        is_expected.not_to be_able_to(:update, doi)
+        is_expected.not_to be_able_to(:destroy, doi)
+      end
     end
 
     context "when is a staff admin" do
@@ -514,33 +574,43 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
 
       let(:token) { User.generate_token(role_id: "staff_user") }
 
-      it { is_expected.to be_able_to(:read, user) }
+      it "can read the user" do
+        is_expected.to be_able_to(:read, user)
+      end
 
-      it { is_expected.to be_able_to(:read, provider) }
-      it { is_expected.not_to be_able_to(:create, provider) }
-      it { is_expected.not_to be_able_to(:update, provider) }
-      it { is_expected.not_to be_able_to(:destroy, provider) }
-      it { is_expected.to be_able_to(:read_billing_information, provider) }
-      it { is_expected.to be_able_to(:read_contact_information, provider) }
+      it "can read/read_billing_information/read_contact_information but not create/update/destroy the provider" do
+        is_expected.to be_able_to(:read, provider)
+        is_expected.to be_able_to(:read_billing_information, provider)
+        is_expected.to be_able_to(:read_contact_information, provider)
+        is_expected.not_to be_able_to(:create, provider)
+        is_expected.not_to be_able_to(:update, provider)
+        is_expected.not_to be_able_to(:destroy, provider)
+      end
 
-      it { is_expected.to be_able_to(:read, contact) }
-      it { is_expected.not_to be_able_to(:create, contact) }
-      it { is_expected.not_to be_able_to(:update, contact) }
-      it { is_expected.not_to be_able_to(:destroy, contact) }
+      it "can read but not create/update/destroy the contact" do
+        is_expected.to be_able_to(:read, contact)
+        is_expected.not_to be_able_to(:create, contact)
+        is_expected.not_to be_able_to(:update, contact)
+        is_expected.not_to be_able_to(:destroy, contact)
+      end
 
-      it { is_expected.to be_able_to(:read, client) }
-      it { is_expected.not_to be_able_to(:create, client) }
-      it { is_expected.not_to be_able_to(:update, client) }
-      it { is_expected.not_to be_able_to(:destroy, client) }
-      it { is_expected.not_to be_able_to(:transfer, client) }
-      it { is_expected.to be_able_to(:read_contact_information, client) }
-      it { is_expected.to be_able_to(:read_analytics, client) }
+      it "can read/read_contact_information/read_analytics but not create/update/destroy/transfer the client" do
+        is_expected.to be_able_to(:read, client)
+        is_expected.to be_able_to(:read_contact_information, client)
+        is_expected.to be_able_to(:read_analytics, client)
+        is_expected.not_to be_able_to(:create, client)
+        is_expected.not_to be_able_to(:update, client)
+        is_expected.not_to be_able_to(:destroy, client)
+        is_expected.not_to be_able_to(:transfer, client)
+      end
 
-      it { is_expected.to be_able_to(:read, doi) }
-      it { is_expected.not_to be_able_to(:transfer, doi) }
-      it { is_expected.not_to be_able_to(:create, doi) }
-      it { is_expected.not_to be_able_to(:update, doi) }
-      it { is_expected.not_to be_able_to(:destroy, doi) }
+      it "can read but cannot transfer/create/update/destroy the doi" do
+        is_expected.to be_able_to(:read, doi)
+        is_expected.not_to be_able_to(:transfer, doi)
+        is_expected.not_to be_able_to(:create, doi)
+        is_expected.not_to be_able_to(:update, doi)
+        is_expected.not_to be_able_to(:destroy, doi)
+      end
     end
 
     context "when is temporary" do
@@ -552,66 +622,86 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         })
       end
 
-      it { is_expected.to be_able_to(:read, user) }
+      it do
+        is_expected.to be_able_to(:read, user)
+      end
 
-      it { is_expected.to be_able_to(:read, provider) }
-      it { is_expected.not_to be_able_to(:create, provider) }
-      it { is_expected.to be_able_to(:update, provider) }
-      it { is_expected.not_to be_able_to(:destroy, provider) }
-      it { is_expected.not_to be_able_to(:read_billing_information, provider) }
-      it { is_expected.to be_able_to(:read_contact_information, provider) }
+      it "can read/update/read_contact_information but cannot create/destroy/read_billing_information the provider" do
+        is_expected.to be_able_to(:read, provider)
+        is_expected.to be_able_to(:update, provider)
+        is_expected.to be_able_to(:read_contact_information, provider)
+        is_expected.not_to be_able_to(:create, provider)
+        is_expected.not_to be_able_to(:destroy, provider)
+        is_expected.not_to be_able_to(:read_billing_information, provider)
+      end
 
-      it { is_expected.not_to be_able_to(:read, contact) }
-      it { is_expected.not_to be_able_to(:create, contact) }
-      it { is_expected.not_to be_able_to(:update, contact) }
-      it { is_expected.not_to be_able_to(:destroy, contact) }
+      it "can not read/create/update/destroy the contact" do
+        is_expected.not_to be_able_to(:read, contact)
+        is_expected.not_to be_able_to(:create, contact)
+        is_expected.not_to be_able_to(:update, contact)
+        is_expected.not_to be_able_to(:destroy, contact)
+      end
 
-      it { is_expected.to be_able_to(:read, client) }
-      it { is_expected.not_to be_able_to(:create, client) }
-      it { is_expected.to be_able_to(:update, client) }
-      it { is_expected.not_to be_able_to(:destroy, client) }
-      it { is_expected.not_to be_able_to(:transfer, client) }
-      it { is_expected.to be_able_to(:read_contact_information, client) }
+      it "can read/update/read_contact_information but cannot create/destroy/transfer the client" do
+        is_expected.to be_able_to(:read, client)
+        is_expected.to be_able_to(:update, client)
+        is_expected.to be_able_to(:read_contact_information, client)
+        is_expected.not_to be_able_to(:create, client)
+        is_expected.not_to be_able_to(:destroy, client)
+        is_expected.not_to be_able_to(:transfer, client)
+      end
 
-      it { is_expected.to be_able_to(:read, doi) }
-      it { is_expected.not_to be_able_to(:transfer, doi) }
-      it { is_expected.not_to be_able_to(:create, doi) }
-      it { is_expected.not_to be_able_to(:update, doi) }
-      it { is_expected.not_to be_able_to(:destroy, doi) }
+      it "can read but can not transfer/create/update/destroy the doi" do
+        is_expected.to be_able_to(:read, doi)
+        is_expected.not_to be_able_to(:transfer, doi)
+        is_expected.not_to be_able_to(:create, doi)
+        is_expected.not_to be_able_to(:update, doi)
+        is_expected.not_to be_able_to(:destroy, doi)
+      end
     end
 
     context "when is anonymous" do
       let(:token) { nil }
 
-      it { is_expected.not_to be_able_to(:create, provider) }
-      it { is_expected.not_to be_able_to(:update, provider) }
-      it { is_expected.not_to be_able_to(:destroy, provider) }
-      it { is_expected.not_to be_able_to(:read_billing_information, provider) }
-      it { is_expected.not_to be_able_to(:read_contact_information, provider) }
+      it "can not create/update/destroy/read_billing_information/read_contact_information of the provider" do
+        is_expected.not_to be_able_to(:create, provider)
+        is_expected.not_to be_able_to(:update, provider)
+        is_expected.not_to be_able_to(:destroy, provider)
+        is_expected.not_to be_able_to(:read_billing_information, provider)
+        is_expected.not_to be_able_to(:read_contact_information, provider)
+      end
 
-      it { is_expected.not_to be_able_to(:read, contact) }
-      it { is_expected.not_to be_able_to(:create, contact) }
-      it { is_expected.not_to be_able_to(:update, contact) }
-      it { is_expected.not_to be_able_to(:destroy, contact) }
+      it "can not read/create/update/destroy the contact" do
+        is_expected.not_to be_able_to(:read, contact)
+        is_expected.not_to be_able_to(:create, contact)
+        is_expected.not_to be_able_to(:update, contact)
+        is_expected.not_to be_able_to(:destroy, contact)
+      end
 
-      it { is_expected.not_to be_able_to(:read, client) }
-      it { is_expected.not_to be_able_to(:create, client) }
-      it { is_expected.not_to be_able_to(:update, client) }
-      it { is_expected.not_to be_able_to(:destroy, client) }
-      it { is_expected.not_to be_able_to(:transfer, client) }
-      it { is_expected.not_to be_able_to(:read_contact_information, client) }
-      it { is_expected.not_to be_able_to(:read_analytics, client) }
+      it "can not read/create/update/destroy/transfer/read_contact_information/read_analytics the client" do
+        is_expected.not_to be_able_to(:read, client)
+        is_expected.not_to be_able_to(:create, client)
+        is_expected.not_to be_able_to(:update, client)
+        is_expected.not_to be_able_to(:destroy, client)
+        is_expected.not_to be_able_to(:transfer, client)
+        is_expected.not_to be_able_to(:read_contact_information, client)
+        is_expected.not_to be_able_to(:read_analytics, client)
+      end
 
-      it { is_expected.to be_able_to(:read, doi) }
-      it { is_expected.not_to be_able_to(:transfer, doi) }
-      it { is_expected.not_to be_able_to(:create, doi) }
-      it { is_expected.not_to be_able_to(:update, doi) }
-      it { is_expected.not_to be_able_to(:destroy, doi) }
+      it "can read but can not transfer/create/update/destroy the doi" do
+        is_expected.to be_able_to(:read, doi)
+        is_expected.not_to be_able_to(:transfer, doi)
+        is_expected.not_to be_able_to(:create, doi)
+        is_expected.not_to be_able_to(:update, doi)
+        is_expected.not_to be_able_to(:destroy, doi)
+      end
 
-      it { is_expected.not_to be_able_to(:read, prefix) }
-      it { is_expected.not_to be_able_to(:create, prefix) }
-      it { is_expected.not_to be_able_to(:update, prefix) }
-      it { is_expected.not_to be_able_to(:destroy, prefix) }
+      it "can not read/create/update/destroy the prefix" do
+        is_expected.not_to be_able_to(:read, prefix)
+        is_expected.not_to be_able_to(:create, prefix)
+        is_expected.not_to be_able_to(:update, prefix)
+        is_expected.not_to be_able_to(:destroy, prefix)
+      end
     end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -28,31 +28,10 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
   let(:xml) { file_fixture("datacite.xml").read }
   let(:metadata) { build_stubbed(:metadata, xml: xml, doi: doi) }
 
-  before(:all) do
-    @consortium = create(:provider,
-      role_name: "ROLE_CONSORTIUM")
-    @provider = create(:provider,
-      consortium: @consortium,
-      role_name: "ROLE_CONSORTIUM_ORGANIZATION"
-    )
-    @prefix = create(:prefix, uid: "10.14454")
-    @client = create(:client, provider: @provider)
-    @provider_prefix = create(
-      :provider_prefix,
-      provider: @provider,
-      prefix: @prefix
-    )
-    @client_prefix = create(
-      :client_prefix,
-      client: @client,
-      prefix: @prefix
-    )
-    @doi = create(:doi, client: @client)
-  end
-
   describe "User attributes", order: :defined, skip_prefix_pool: true do
     it "is valid with valid attributes" do
       expect(user.name).to eq("Josiah Carberry")
+      expect(user.role_id).to eq("staff_admin")
     end
   end
 
@@ -60,6 +39,7 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
     subject { Ability.new(user) }
 
     context "when is a user" do
+
       let(:token) { User.generate_token(role_id: "user") }
 
       it { is_expected.to be_able_to(:read, user) }
@@ -97,175 +77,236 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
     end
 
     context "when is a client admin" do
-      before(:all) do
-        @token = User.generate_token(
-          role_id: "client_admin",
-          provider_id: @provider.symbol.downcase,
-          client_id: @client.symbol.downcase,
 
+      let(:consortium) { create(:provider, role_name: "ROLE_CONSORTIUM") }
+      let(:provider) do
+        create(
+          :provider,
+          consortium: consortium, role_name: "ROLE_CONSORTIUM_ORGANIZATION",
         )
       end
+      let!(:prefix) { create(:prefix, uid: "10.14454") }
+      let!(:provider_prefix) { create(:provider_prefix, provider: provider, prefix: prefix) }
+      let(:client) { create(:client, provider: provider) }
+      let!(:client_prefix) { create(:client_prefix, client: client, prefix: prefix) }
+      let(:token) do
+        User.generate_token({
+          role_id: "client_admin",
+          provider_id: provider.symbol.downcase,
+          client_id: client.symbol.downcase,
+        })
+      end
 
-      let(:token) { @token }
+      it "can read the user" do
+        is_expected.to be_able_to(:read, user)
+      end
 
-      it { is_expected.to be_able_to(:read, user) }
-      it { is_expected.to be_able_to(:read, @provider) }
+      it "can read, but not create/update/destroy/read_billing_information/read_contact_information of a provider" do
+        is_expected.to be_able_to(:read, provider)
+        is_expected.not_to be_able_to(:create, provider)
+        is_expected.not_to be_able_to(:update, provider)
+        is_expected.not_to be_able_to(:destroy, provider)
+        is_expected.not_to be_able_to(:read_billing_information, provider)
+        is_expected.not_to be_able_to(:read_contact_information, provider)
+      end
 
-      it { is_expected.not_to be_able_to(:create, @provider) }
-      it { is_expected.not_to be_able_to(:update, @provider) }
-      it { is_expected.not_to be_able_to(:destroy, @provider) }
-      it { is_expected.not_to be_able_to(:read_billing_information, @provider) }
-      it { is_expected.not_to be_able_to(:read_contact_information, @provider) }
+      it "can not read/create/update/destroy a contact" do
+        is_expected.not_to be_able_to(:read, contact)
+        is_expected.not_to be_able_to(:create, contact)
+        is_expected.not_to be_able_to(:update, contact)
+        is_expected.not_to be_able_to(:destroy, contact)
+      end
 
-      it { is_expected.not_to be_able_to(:read, contact) }
-      it { is_expected.not_to be_able_to(:create, contact) }
-      it { is_expected.not_to be_able_to(:update, contact) }
-      it { is_expected.not_to be_able_to(:destroy, contact) }
 
-      it { is_expected.to be_able_to(:read, @client) }
-      it { is_expected.not_to be_able_to(:create, @client) }
-      it { is_expected.to be_able_to(:update, @client) }
-      it { is_expected.not_to be_able_to(:destroy, @client) }
-      it { is_expected.not_to be_able_to(:transfer, @client) }
-      it { is_expected.to be_able_to(:read_contact_information, @client) }
-      it { is_expected.to be_able_to(:read_analytics, @client) }
+      it "can read/update/read_contact_information/read_analytics but not create/destroy/transfer the client" do
+        is_expected.to be_able_to(:read, client)
+        is_expected.to be_able_to(:update, client)
+        is_expected.to be_able_to(:read_contact_information, client)
+        is_expected.to be_able_to(:read_analytics, client)
+        is_expected.not_to be_able_to(:create, client)
+        is_expected.not_to be_able_to(:destroy, client)
+        is_expected.not_to be_able_to(:transfer, client)
+      end
 
-      it { is_expected.not_to be_able_to(:read, @prefix) }
-      it { is_expected.not_to be_able_to(:create, @prefix) }
-      it { is_expected.not_to be_able_to(:update, @prefix) }
-      it { is_expected.not_to be_able_to(:destroy, @prefix) }
+      it "can not read/create/update/destroy the prefix" do
+        is_expected.not_to be_able_to(:read, prefix)
+        is_expected.not_to be_able_to(:create, prefix)
+        is_expected.not_to be_able_to(:update, prefix)
+        is_expected.not_to be_able_to(:destroy, prefix)
+      end
 
-      it { is_expected.to be_able_to(:read, @client_prefix) }
-      it { is_expected.not_to be_able_to(:create, @client_prefix) }
-      it { is_expected.not_to be_able_to(:update, @client_prefix) }
-      it { is_expected.not_to be_able_to(:destroy, @client_prefix) }
+      it "can read but not create/update/destroy the client prefix" do
+        is_expected.to be_able_to(:read, client_prefix)
+        is_expected.not_to be_able_to(:create, client_prefix)
+        is_expected.not_to be_able_to(:update, client_prefix)
+        is_expected.not_to be_able_to(:destroy, client_prefix)
+      end
 
-      it { is_expected.to be_able_to(:read, @doi) }
-      it { is_expected.not_to be_able_to(:transfer, @doi) }
-      it { is_expected.to be_able_to(:create, @doi) }
-      it { is_expected.to be_able_to(:update, @doi) }
-      it { is_expected.to be_able_to(:destroy, @doi) }
+      it "can read/create/update/destroy but not transfer the doi" do
+        is_expected.to be_able_to(:read, doi)
+        is_expected.to be_able_to(:create, doi)
+        is_expected.to be_able_to(:update, doi)
+        is_expected.to be_able_to(:destroy, doi)
+        is_expected.not_to be_able_to(:transfer, doi)
+      end
     end
 
     context "when is a client admin inactive" do
-      before(:all) do
-        @prefix = create(:prefix, uid: "10.14455")
-        @client = create(
-          :client,
-          provider: @provider,
-          is_active: false
-        )
-        @provider_prefix = create(
-          :provider_prefix,
-          provider: @provider,
-          prefix: @prefix
-        )
-        @client_prefix = create(
-          :client_prefix,
-          client: @client,
-          prefix: @prefix
-        )
-        @doi = create(:doi, client: @client)
-        @token = User.generate_token(
-          role_id: "client_admin",
-          provider_id: @provider.symbol.downcase,
-          client_id: @client.symbol.downcase,
 
+      let(:consortium) { create(:provider, role_name: "ROLE_CONSORTIUM") }
+      let(:provider) do
+        create(
+          :provider,
+          consortium: consortium, role_name: "ROLE_CONSORTIUM_ORGANIZATION",
         )
       end
+      let!(:prefix) { create(:prefix, uid: "10.14454") }
+      let!(:provider_prefix) { create(:provider_prefix, provider: provider, prefix: prefix) }
+      let(:client) do
+        create(:client, {
+          provider: provider,
+          is_active: false
+        })
 
-      let(:token) { @token }
+      end
+      let!(:client_prefix) { create(:client_prefix, client: client, prefix: prefix) }
+      let(:token) do
+        User.generate_token({
+          role_id: "client_admin",
+          provider_id: provider.symbol.downcase,
+          client_id: client.symbol.downcase,
+        })
+      end
 
-      it { is_expected.to be_able_to(:read, user) }
-      it { is_expected.to be_able_to(:read, provider) }
+      it "can read the user" do
+        is_expected.to be_able_to(:read, user)
+      end
 
-      it { is_expected.not_to be_able_to(:create, provider) }
-      it { is_expected.not_to be_able_to(:update, provider) }
-      it { is_expected.not_to be_able_to(:destroy, provider) }
-      it { is_expected.not_to be_able_to(:read_billing_information, provider) }
-      it { is_expected.not_to be_able_to(:read_contact_information, provider) }
+      it "can read, but not create/update/destroy/read_billing_information/read_contact_information of a provider" do
+        is_expected.to be_able_to(:read, provider)
+        is_expected.not_to be_able_to(:create, provider)
+        is_expected.not_to be_able_to(:update, provider)
+        is_expected.not_to be_able_to(:destroy, provider)
+        is_expected.not_to be_able_to(:read_billing_information, provider)
+        is_expected.not_to be_able_to(:read_contact_information, provider)
+      end
 
-      it { is_expected.not_to be_able_to(:read, contact) }
-      it { is_expected.not_to be_able_to(:create, contact) }
-      it { is_expected.not_to be_able_to(:update, contact) }
-      it { is_expected.not_to be_able_to(:destroy, contact) }
+      it "can not read/create/update/destroy a contact" do
+        is_expected.not_to be_able_to(:read, contact)
+        is_expected.not_to be_able_to(:create, contact)
+        is_expected.not_to be_able_to(:update, contact)
+        is_expected.not_to be_able_to(:destroy, contact)
+      end
 
-      it { is_expected.to be_able_to(:read, @client) }
-      it { is_expected.not_to be_able_to(:create, @client) }
-      it { is_expected.not_to be_able_to(:update, @client) }
-      it { is_expected.not_to be_able_to(:destroy, @client) }
-      it { is_expected.not_to be_able_to(:transfer, @client) }
-      it { is_expected.to be_able_to(:read_contact_information, @client) }
-      it { is_expected.to be_able_to(:read_analytics, @client) }
+      it "can read/read_contact_information/read_analytics but not create/update/destroy/transfer the client" do
+        is_expected.to be_able_to(:read, client)
+        is_expected.not_to be_able_to(:create, client)
+        is_expected.not_to be_able_to(:update, client)
+        is_expected.not_to be_able_to(:destroy, client)
+        is_expected.not_to be_able_to(:transfer, client)
+        is_expected.to be_able_to(:read_contact_information, client)
+        is_expected.to be_able_to(:read_analytics, client)
+      end
 
-      it { is_expected.not_to be_able_to(:read, prefix) }
-      it { is_expected.not_to be_able_to(:create, prefix) }
-      it { is_expected.not_to be_able_to(:update, prefix) }
-      it { is_expected.not_to be_able_to(:destroy, prefix) }
+      it "can not read/create/update/destroy the prefix" do
+        is_expected.not_to be_able_to(:read, prefix)
+        is_expected.not_to be_able_to(:create, prefix)
+        is_expected.not_to be_able_to(:update, prefix)
+        is_expected.not_to be_able_to(:destroy, prefix)
+      end
 
-      it { is_expected.to be_able_to(:read, @client_prefix) }
-      it { is_expected.not_to be_able_to(:create, @client_prefix) }
-      it { is_expected.not_to be_able_to(:update, @client_prefix) }
-      it { is_expected.not_to be_able_to(:destroy, @client_prefix) }
+      it "can read but not create/update/destroy the client prefix"do
+        is_expected.to be_able_to(:read, client_prefix)
+        is_expected.not_to be_able_to(:create, client_prefix)
+        is_expected.not_to be_able_to(:update, client_prefix)
+        is_expected.not_to be_able_to(:destroy, client_prefix)
+      end
 
-      it { is_expected.to be_able_to(:read, @doi) }
-      it { is_expected.not_to be_able_to(:transfer, @doi) }
-      it { is_expected.not_to be_able_to(:create, @doi) }
-      it { is_expected.not_to be_able_to(:update, @doi) }
-      it { is_expected.not_to be_able_to(:destroy, @doi) }
+      it "can read but not transfer/create/update/destroy the doi" do
+        is_expected.to be_able_to(:read, doi)
+        is_expected.not_to be_able_to(:transfer, doi)
+        is_expected.not_to be_able_to(:create, doi)
+        is_expected.not_to be_able_to(:update, doi)
+        is_expected.not_to be_able_to(:destroy, doi)
+      end
     end
 
     context "when is a client user" do
-      before(:all) do
-        @token = User.generate_token(
-          role_id: "client_user",
-          provider_id: @provider.symbol.downcase,
-          client_id: @client.symbol.downcase,
 
+      let(:consortium) { create(:provider, role_name: "ROLE_CONSORTIUM") }
+      let(:provider) do
+        create(
+          :provider,
+          consortium: consortium, role_name: "ROLE_CONSORTIUM_ORGANIZATION",
         )
       end
-      let(:token) { @token }
+      let!(:prefix) { create(:prefix, uid: "10.14454") }
+      let!(:provider_prefix) { create(:provider_prefix, provider: provider, prefix: prefix) }
+      let(:client) { create(:client, provider: provider) }
+      let!(:client_prefix) { create(:client_prefix, client: client, prefix: prefix) }
+      let(:token) do
+        User.generate_token({
+          role_id: "client_user",
+          provider_id: provider.symbol.downcase,
+          client_id: client.symbol.downcase,
+        })
+      end
 
-      it { is_expected.to be_able_to(:read, user) }
-      it { is_expected.to be_able_to(:read, provider) }
+      it do
+        is_expected.to be_able_to(:read, user)
+      end
 
-      it { is_expected.not_to be_able_to(:create, provider) }
-      it { is_expected.not_to be_able_to(:update, provider) }
-      it { is_expected.not_to be_able_to(:destroy, provider) }
-      it { is_expected.not_to be_able_to(:read_billing_information, provider) }
-      it { is_expected.not_to be_able_to(:read_contact_information, provider) }
+      it do
+        is_expected.to be_able_to(:read, provider)
+        is_expected.not_to be_able_to(:create, provider)
+        is_expected.not_to be_able_to(:update, provider)
+        is_expected.not_to be_able_to(:destroy, provider)
+        is_expected.not_to be_able_to(:read_billing_information, provider)
+        is_expected.not_to be_able_to(:read_contact_information, provider)
+      end
 
-      it { is_expected.not_to be_able_to(:read, contact) }
-      it { is_expected.not_to be_able_to(:create, contact) }
-      it { is_expected.not_to be_able_to(:update, contact) }
-      it { is_expected.not_to be_able_to(:destroy, contact) }
+      it do
+        is_expected.not_to be_able_to(:read, contact)
+        is_expected.not_to be_able_to(:create, contact)
+        is_expected.not_to be_able_to(:update, contact)
+        is_expected.not_to be_able_to(:destroy, contact)
+      end
 
-      it { is_expected.to be_able_to(:read, @client) }
-      it { is_expected.not_to be_able_to(:create, @client) }
-      it { is_expected.not_to be_able_to(:update, @client) }
-      it { is_expected.not_to be_able_to(:destroy, @client) }
-      it { is_expected.not_to be_able_to(:transfer, @client) }
-      it { is_expected.to be_able_to(:read_contact_information, @client) }
-      it { is_expected.to be_able_to(:read_analytics, @client) }
+      it do
+        is_expected.to be_able_to(:read, client)
+        is_expected.not_to be_able_to(:create, client)
+        is_expected.not_to be_able_to(:update, client)
+        is_expected.not_to be_able_to(:destroy, client)
+        is_expected.not_to be_able_to(:transfer, client)
+        is_expected.to be_able_to(:read_contact_information, client)
+        is_expected.to be_able_to(:read_analytics, client)
+      end
 
-      it { is_expected.not_to be_able_to(:read, prefix) }
-      it { is_expected.not_to be_able_to(:create, prefix) }
-      it { is_expected.not_to be_able_to(:update, prefix) }
-      it { is_expected.not_to be_able_to(:destroy, prefix) }
+      it do
+        is_expected.not_to be_able_to(:read, prefix)
+        is_expected.not_to be_able_to(:create, prefix)
+        is_expected.not_to be_able_to(:update, prefix)
+        is_expected.not_to be_able_to(:destroy, prefix)
+      end
 
-      it { is_expected.to be_able_to(:read, @client_prefix) }
-      it { is_expected.not_to be_able_to(:create, @client_prefix) }
-      it { is_expected.not_to be_able_to(:update, @client_prefix) }
-      it { is_expected.not_to be_able_to(:destroy, @client_prefix) }
+      it do
+        is_expected.to be_able_to(:read, client_prefix)
+        is_expected.not_to be_able_to(:create, client_prefix)
+        is_expected.not_to be_able_to(:update, client_prefix)
+        is_expected.not_to be_able_to(:destroy, client_prefix)
+      end
 
-      it { is_expected.to be_able_to(:read, doi) }
-      it { is_expected.not_to be_able_to(:transfer, doi) }
-      it { is_expected.not_to be_able_to(:create, doi) }
-      it { is_expected.not_to be_able_to(:update, doi) }
-      it { is_expected.not_to be_able_to(:destroy, doi) }
+      it do
+        is_expected.to be_able_to(:read, doi)
+        is_expected.not_to be_able_to(:transfer, doi)
+        is_expected.not_to be_able_to(:create, doi)
+        is_expected.not_to be_able_to(:update, doi)
+        is_expected.not_to be_able_to(:destroy, doi)
+      end
     end
 
     context "when is a provider admin" do
+
       let(:token) do
         User.generate_token(
           role_id: "provider_admin", provider_id: provider.symbol.downcase,
@@ -370,7 +411,8 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
     context "when is a provider user" do
       let(:token) do
         User.generate_token(
-          role_id: "provider_user", provider_id: provider.symbol.downcase,
+          role_id: "provider_user",
+          provider_id: provider.symbol.downcase,
         )
       end
 
@@ -414,46 +456,62 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
     end
 
     context "when is a staff admin" do
-      before(:all) do
-        @token = User.generate_token(
-          role_id: "staff_admin",
-          provider_id: @provider.symbol.downcase,
-          client_id: @client.symbol.downcase,
 
+      let(:consortium) { create(:provider, role_name: "ROLE_CONSORTIUM") }
+      let(:provider) { create(:provider, consortium: consortium, role_name: "ROLE_CONSORTIUM_ORGANIZATION") }
+      let!(:prefix) { create(:prefix, uid: "10.14454") }
+      let!(:provider_prefix) { create(:provider_prefix, provider: provider, prefix: prefix) }
+      let(:client) { create(:client, provider: provider) }
+      let!(:client_prefix) { create(:client_prefix, client: client, prefix: prefix) }
+      let(:token) do
+        User.generate_token(
+          role_id: "staff_admin",
+          provider_id: provider.symbol.downcase,
+          client_id: client.symbol.downcase,
         )
       end
-      let(:token) { @token }
 
-      it { is_expected.to be_able_to(:read, user) }
+      it "can read the user" do
+        is_expected.to be_able_to(:read, user)
+      end
 
-      it { is_expected.to be_able_to(:read, @provider) }
-      it { is_expected.to be_able_to(:create, @provider) }
-      it { is_expected.to be_able_to(:update, @provider) }
-      it { is_expected.to be_able_to(:destroy, @provider) }
-      it { is_expected.to be_able_to(:transfer, @client) }
-      it { is_expected.to be_able_to(:read_billing_information, @provider) }
-      it { is_expected.to be_able_to(:read_contact_information, @provider) }
+      it 'can read/create/update/destroy/transfer/read_billing_information/read_contact_information the provider' do
+        is_expected.to be_able_to(:read, provider)
+        is_expected.to be_able_to(:create, provider)
+        is_expected.to be_able_to(:update, provider)
+        is_expected.to be_able_to(:destroy, provider)
+        is_expected.to be_able_to(:transfer, client)
+        is_expected.to be_able_to(:read_billing_information, provider)
+        is_expected.to be_able_to(:read_contact_information, provider)
+      end
 
-      it { is_expected.to be_able_to(:read, contact) }
-      it { is_expected.to be_able_to(:create, contact) }
-      it { is_expected.to be_able_to(:update, contact) }
-      it { is_expected.to be_able_to(:destroy, contact) }
+      it "can read/create/update/destroy the contact" do
+        is_expected.to be_able_to(:read, contact)
+        is_expected.to be_able_to(:create, contact)
+        is_expected.to be_able_to(:update, contact)
+        is_expected.to be_able_to(:destroy, contact)
+      end
 
-      it { is_expected.to be_able_to(:read, @client) }
-      it { is_expected.to be_able_to(:create, @client) }
-      it { is_expected.to be_able_to(:update, @client) }
-      it { is_expected.to be_able_to(:destroy, @client) }
-      it { is_expected.to be_able_to(:read_contact_information, @client) }
-      it { is_expected.to be_able_to(:read_analytics, @client) }
+      it "can read/create/update/destroy/read_contact_information/read_analytics the client" do
+        is_expected.to be_able_to(:read, client)
+        is_expected.to be_able_to(:create, client)
+        is_expected.to be_able_to(:update, client)
+        is_expected.to be_able_to(:destroy, client)
+        is_expected.to be_able_to(:read_contact_information, client)
+        is_expected.to be_able_to(:read_analytics, client)
+      end
 
-      it { is_expected.to be_able_to(:read, @doi) }
-      it { is_expected.to be_able_to(:transfer, @doi) }
-      it { is_expected.to be_able_to(:create, @doi) }
-      it { is_expected.to be_able_to(:update, @doi) }
-      it { is_expected.to be_able_to(:destroy, @doi) }
+      it "can read/transfer/create/update/destroy doi" do
+        is_expected.to be_able_to(:read, doi)
+        is_expected.to be_able_to(:transfer, doi)
+        is_expected.to be_able_to(:create, doi)
+        is_expected.to be_able_to(:update, doi)
+        is_expected.to be_able_to(:destroy, doi)
+      end
     end
 
     context "when is a staff user" do
+
       let(:token) { User.generate_token(role_id: "staff_user") }
 
       it { is_expected.to be_able_to(:read, user) }
@@ -486,7 +544,13 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
     end
 
     context "when is temporary" do
-      let(:token) { User.generate_token(role_id: "temporary", provider_id: provider.symbol.downcase, client_id: client.symbol.downcase) }
+      let(:token) do
+        User.generate_token({
+          role_id: "temporary",
+          provider_id: provider.symbol.downcase,
+          client_id: client.symbol.downcase,
+        })
+      end
 
       it { is_expected.to be_able_to(:read, user) }
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -39,7 +39,6 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
     subject { Ability.new(user) }
 
     context "when is a user" do
-
       let(:token) { User.generate_token(role_id: "user") }
 
       it { is_expected.to be_able_to(:read, user) }
@@ -53,14 +52,14 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         is_expected.not_to be_able_to(:read_contact_information, provider)
       end
 
-      it "can not read/create/update/destroy the contact"do
+      it "can not read/create/update/destroy the contact" do
         is_expected.not_to be_able_to(:read, contact)
         is_expected.not_to be_able_to(:create, contact)
         is_expected.not_to be_able_to(:update, contact)
         is_expected.not_to be_able_to(:destroy, contact)
       end
 
-      it "can not read/create/update/destroy/transfer/read_contact_information/read_analytics the client"do
+      it "can not read/create/update/destroy/transfer/read_contact_information/read_analytics the client" do
         is_expected.not_to be_able_to(:read, client)
         is_expected.not_to be_able_to(:create, client)
         is_expected.not_to be_able_to(:update, client)
@@ -77,7 +76,7 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         is_expected.not_to be_able_to(:destroy, prefix)
       end
 
-      it "can read but not transfer/create/update/destroy the doi"do
+      it "can read but not transfer/create/update/destroy the doi" do
         is_expected.to be_able_to(:read, doi)
         is_expected.not_to be_able_to(:transfer, doi)
         is_expected.not_to be_able_to(:create, doi)
@@ -87,7 +86,6 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
     end
 
     context "when is a client admin" do
-
       let(:consortium) { create(:provider, role_name: "ROLE_CONSORTIUM") }
       let(:provider) do
         create(
@@ -162,7 +160,6 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
     end
 
     context "when is a client admin inactive" do
-
       let(:consortium) { create(:provider, role_name: "ROLE_CONSORTIUM") }
       let(:provider) do
         create(
@@ -177,7 +174,6 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
           provider: provider,
           is_active: false
         })
-
       end
       let!(:client_prefix) { create(:client_prefix, client: client, prefix: prefix) }
       let(:token) do
@@ -225,7 +221,7 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         is_expected.not_to be_able_to(:destroy, prefix)
       end
 
-      it "can read but not create/update/destroy the client prefix"do
+      it "can read but not create/update/destroy the client prefix" do
         is_expected.to be_able_to(:read, client_prefix)
         is_expected.not_to be_able_to(:create, client_prefix)
         is_expected.not_to be_able_to(:update, client_prefix)
@@ -242,7 +238,6 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
     end
 
     context "when is a client user" do
-
       let(:consortium) { create(:provider, role_name: "ROLE_CONSORTIUM") }
       let(:provider) do
         create(
@@ -262,11 +257,11 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         })
       end
 
-      it "can read the user"do
+      it "can read the user" do
         is_expected.to be_able_to(:read, user)
       end
 
-      it "can read, but not create/update/destroy/read_billing_information/read_contact_information the provider"do
+      it "can read, but not create/update/destroy/read_billing_information/read_contact_information the provider" do
         is_expected.to be_able_to(:read, provider)
         is_expected.not_to be_able_to(:create, provider)
         is_expected.not_to be_able_to(:update, provider)
@@ -275,7 +270,7 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         is_expected.not_to be_able_to(:read_contact_information, provider)
       end
 
-      it "can not read/create/update/destroy a contact"do
+      it "can not read/create/update/destroy a contact" do
         is_expected.not_to be_able_to(:read, contact)
         is_expected.not_to be_able_to(:create, contact)
         is_expected.not_to be_able_to(:update, contact)
@@ -316,7 +311,6 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
     end
 
     context "when is a provider admin" do
-
       let(:token) do
         User.generate_token(
           role_id: "provider_admin", provider_id: provider.symbol.downcase,
@@ -413,7 +407,7 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         is_expected.to be_able_to(:destroy, consortium_contact)
       end
 
-      it "can read/create/update/destroy the provider"do
+      it "can read/create/update/destroy the provider" do
         is_expected.to be_able_to(:read, provider)
         is_expected.to be_able_to(:create, provider)
         is_expected.to be_able_to(:update, provider)
@@ -444,7 +438,7 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         is_expected.to be_able_to(:destroy, provider_prefix)
       end
 
-      it 'can read/transfer but not create/update/destroy the doi' do
+      it "can read/transfer but not create/update/destroy the doi" do
         is_expected.to be_able_to(:read, doi)
         is_expected.to be_able_to(:transfer, doi)
         is_expected.not_to be_able_to(:create, doi)
@@ -516,7 +510,6 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
     end
 
     context "when is a staff admin" do
-
       let(:consortium) { create(:provider, role_name: "ROLE_CONSORTIUM") }
       let(:provider) { create(:provider, consortium: consortium, role_name: "ROLE_CONSORTIUM_ORGANIZATION") }
       let!(:prefix) { create(:prefix, uid: "10.14454") }
@@ -535,7 +528,7 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         is_expected.to be_able_to(:read, user)
       end
 
-      it 'can read/create/update/destroy/transfer/read_billing_information/read_contact_information the provider' do
+      it "can read/create/update/destroy/transfer/read_billing_information/read_contact_information the provider" do
         is_expected.to be_able_to(:read, provider)
         is_expected.to be_able_to(:create, provider)
         is_expected.to be_able_to(:update, provider)
@@ -571,7 +564,6 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
     end
 
     context "when is a staff user" do
-
       let(:token) { User.generate_token(role_id: "staff_user") }
 
       it "can read the user" do


### PR DESCRIPTION
## Purpose
Isolate ability spec so that it does not affect other specs in the suite.

## Approach
Remove `before(:all)` and `after(:all)` blocks and replace them with localized let statements that adhere to transactions and auto-delete whenever the individual test is finished.

Many tests have been consolidated in to larger blocks to limit the number of times a DB call must be made.
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
