### PR TITLE
Make sure we clear the index before we reindex

### DIFF
--- a/spec/requests/datacite_dois/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois/datacite_dois_spec.rb
@@ -38,9 +38,6 @@ describe DataciteDoisController, type: :request, vcr: true do
       @dois = DataciteDoi.query(nil, page: { cursor: [], size: 10 }).results.to_a
     end
 
-    after do
-    end
-
     it "returns dois" do
       get "/dois", nil, headers
 
@@ -249,9 +246,6 @@ describe DataciteDoisController, type: :request, vcr: true do
       import_doi_index
     end
 
-    after do
-    end
-
     it "returns nil publisher when publisher param is not set" do
       get "/dois", nil, headers
 
@@ -277,11 +271,8 @@ describe DataciteDoisController, type: :request, vcr: true do
     let!(:doi) { create(:doi, client: client, publisher: nil) }
 
     before do
-      import_doi_index
-    end
-
-    after do
       clear_doi_index
+      import_doi_index
     end
 
     it "returns nil publisher when publisher param is not set" do
@@ -313,10 +304,8 @@ describe DataciteDoisController, type: :request, vcr: true do
     }
 
     before do
-      import_doi_index
-    end
-    after do
       clear_doi_index
+      import_doi_index
     end
 
     it "returns publisher hashes when publisher param is set to true" do
@@ -493,11 +482,8 @@ describe DataciteDoisController, type: :request, vcr: true do
     let!(:study_registration_doi) { create(:doi, client: client, aasm_state: "findable", types: { "resourceTypeGeneral": "StudyRegistration" }) }
 
     before do
-      import_doi_index
-    end
-
-    after do
       clear_doi_index
+      import_doi_index
     end
 
     it "filters for Instrument dois when resource-type-id is set to instrument", vcr: true do


### PR DESCRIPTION
## Purpose
Sometimes things in the after block were not getting to finish before another test started.  Make sure that the slate is clean before the test if we are not using the elasticsearch:true reset

## Approach
Moves the clear_doi_index from the after block to the before block.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
