### PR TITLE
Update datadog to use new ruby library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "countries", "~> 2.1", ">= 2.1.2"
 gem "country_select", "~> 3.1"
 gem "crawler_detect"
 gem "dalli", "~> 3.2", ">= 3.2.8"
-gem "ddtrace", require: "ddtrace/auto_instrument"
+gem 'datadog', require: 'datadog/auto_instrument'
 gem "departure", "~> 6.2"
 gem "diffy", "~> 3.2", ">= 3.2.1"
 gem "dotenv"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,15 +217,12 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    datadog-ci (0.6.0)
-      msgpack
-    date (3.3.4)
-    ddtrace (1.19.0)
-      datadog-ci (~> 0.6.0)
+    datadog (2.3.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 5.0.0.1.0)
+      libdatadog (~> 11.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
+    date (3.3.4)
     debase-ruby_core_source (3.3.1)
     debug_inspector (1.1.0)
     departure (6.7.0)
@@ -418,9 +415,9 @@ GEM
       mime-types
       terrapin (>= 0.6.0, < 2.0)
     latex-decode (0.4.0)
-    libdatadog (5.0.0.1.0)
-    libdatadog (5.0.0.1.0-aarch64-linux)
-    libdatadog (5.0.0.1.0-x86_64-linux)
+    libdatadog (11.0.0.1.0)
+    libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)
@@ -802,7 +799,7 @@ DEPENDENCIES
   dalli (~> 3.2, >= 3.2.8)
   database_cleaner
   database_cleaner-active_record (~> 2.1)
-  ddtrace
+  datadog
   departure (~> 6.2)
   diffy (~> 3.2, >= 3.2.1)
   dotenv

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "ddtrace"
+require "datadog"
 
 Datadog.configure do |c|
   # Global
@@ -10,8 +10,10 @@ Datadog.configure do |c|
   c.env = Rails.env
 
   # Tracing settings
-  c.tracing.enabled = Rails.env.production?
-  c.tracing.analytics.enabled = true
+
+  # Enable tracing for production and staging envs
+  c.tracing.enabled = Rails.env.production? || Rails.env.stage?
+
   # We disable automatic log injection because it doesn't play nice with our formatter
   c.tracing.log_injection = false
 
@@ -19,4 +21,7 @@ Datadog.configure do |c|
   c.tracing.instrument :rails
   c.tracing.instrument :elasticsearch
   c.tracing.instrument :shoryuken
+
+  # Profiling setup
+  c.profiling.enabled = Rails.env.stage?
 end


### PR DESCRIPTION
## Purpose
This replaces the DataDog dd-trace gem with newer datadog gem for ruby.

Datadog integration should now also work for staging and profiling is enabled for that only.

closes: _Add github issue that originated this PR_

## Approach
Upgrade to new gem, add new specific options for staging env.

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
