### PR TITLE
Move index jobs for dois to their own queue.

### DIFF
--- a/app/jobs/index_job_doi_registration.rb
+++ b/app/jobs/index_job_doi_registration.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class IndexJobDoiRegistration < ApplicationJob
+  queue_as :lupo_doi_registration
+
+  rescue_from ActiveJob::DeserializationError,
+              SocketError,
+              Elasticsearch::Transport::Transport::Errors::BadRequest,
+              Elasticsearch::Transport::Transport::Error do |error|
+    Rails.logger.error error.message
+  end
+
+  def perform(obj)
+    response = obj.__elasticsearch__.index_document
+    Rails.logger.error "[Elasticsearch] Error #{response.inspect}" unless %w(created updated).include?(response["result"])
+  end
+end

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -8,7 +8,7 @@ module Indexable
   included do
     after_commit on: %i[create update] do
       # use index_document instead of update_document to also update virtual attributes
-      unless %w[Prefix ProviderPrefix ClientPrefix Doi].include?(self.class.name)
+      if not %w[Prefix ProviderPrefix ClientPrefix Doi].include?(self.class.name)
         IndexJob.perform_later(self)
       elsif instance_of?(Doi)
         IndexJobDoiRegistration.perform_later(self)

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -8,8 +8,10 @@ module Indexable
   included do
     after_commit on: %i[create update] do
       # use index_document instead of update_document to also update virtual attributes
-      unless %w[Prefix ProviderPrefix ClientPrefix].include?(self.class.name)
+      unless %w[Prefix ProviderPrefix ClientPrefix Doi].include?(self.class.name)
         IndexJob.perform_later(self)
+      elsif instance_of?(Doi)
+        IndexJobDoiRegistration.perform_later(self)
       else
         __elasticsearch__.index_document
         # This is due to the order of indexing, we want to always ensure


### PR DESCRIPTION
Adds new specific import job which uses new queue.

## Purpose
DOI Indexing for newly registered dois get put on same queue as other indexing jobs for say events.
When we are overloaded with event based indexing this causes regular doi indexing to be slowed down.

## Approach

Adds a new import worker to use new queue.
Note new queue has already been created via infrastructure code see: https://github.com/datacite/mastino/commit/8d194aa9032af69c2ba2fe8728dee607190975d1

I think long term this needs tidying up more but this is easy change to make.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
