### PR TITLE
Fix check for data import exclusion

### DIFF
--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -26,7 +26,7 @@ module Indexable
         if aasm_state == "findable"
           changed_attributes = saved_changes
           relevant_changes = changed_attributes.keys & %w[related_identifiers creators funding_references aasm_state]
-          if relevant_changes.any? || (created == updated) && !ENV["EXCLUDE_PREFIXES_FROM_DATA_IMPORT"].to_s.split(",").include?(prefix)
+          if (relevant_changes.any? || (created == updated)) && !ENV["EXCLUDE_PREFIXES_FROM_DATA_IMPORT"].to_s.split(",").include?(prefix)
             send_import_message(to_jsonapi)
             Rails.logger.info "[Event Data Import Message] State: #{aasm_state} Params: #{to_jsonapi} message sent to Event Data service."
           end

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -84,6 +84,13 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
 
         expect(new_doi).not_to receive(:send_import_message)
       end
+
+      it "does not send import message when environment variable EXCLUDE_PREFIXES_FROM_DATA_IMPORT is set to prefix of doi" do
+        ENV["EXCLUDE_PREFIXES_FROM_DATA_IMPORT"] = "10.18730"
+        new_doi = create(:doi, doi: "10.18730/nvb5=", aasm_state: "findable")
+
+        expect(new_doi).not_to receive(:send_import_message)
+      end
     end
 
     context "On Create event" do


### PR DESCRIPTION
## Purpose
Fix the logic, should check the first condition of does it have relevant changes or is it a new DOI (created same as updated date) then it should additionally check that it's not one of the prefixes we're trying to exclude.

## Approach
Add spec.

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
