### PR TITLE
Correct allowed values for affiliation in POST/PUT dois

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2022,21 +2022,17 @@ components:
                   type: string
                 affiliation:
                   description: Set `affiliation=true` to see additional affiliation information such as the affiliation identifier.
-                  oneOf:
-                    - type: array
-                      items:
-                        type: object
-                        properties:
-                          affiliationIdentifier:
-                            type: string
-                          affiliationIdentifierScheme:
-                            type: string
-                          name:
-                            type: string
-                          schemeUri:
-                            type: string
-                    - type: array
-                      items:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      affiliationIdentifier:
+                        type: string
+                      affiliationIdentifierScheme:
+                        type: string
+                      name:
+                        type: string
+                      schemeUri:
                         type: string
                 lang:
                   type: string


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
affiliation only accepts a list of objects, not a list of strings; reverses the error introduced in  https://github.com/datacite/lupo/commit/d3f329ac6eaaa3b1c9ad30ac15d8dcec71192111

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
