### PR TITLE
Chang default DOI search order

### DIFF
--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -50,7 +50,7 @@ class DataciteDoisController < ApplicationController
       when "relevance"
         { "_score": { "order": "desc" } }
       else
-        { updated: { order: "desc" } }
+        { "_score": { "order": "desc" } }
       end
 
     page = page_from_params(params)

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -2518,7 +2518,7 @@ class Doi < ApplicationRecord
 
     def update_publisher_from_string
       self.publisher_obj = { name: publisher_before_type_cast }
-     end
+    end
 
     def reset_publishers
       self.publisher_obj = nil

--- a/app/models/doi/graphql_query.rb
+++ b/app/models/doi/graphql_query.rb
@@ -4,7 +4,7 @@ module Doi::GraphqlQuery
   class Builder
     include Modelable
 
-    DEFAULT_CURSOR = [0, ""]
+    DEFAULT_CURSOR = ["Infinity", 0]
     DEFAULT_PAGE_SIZE = 0
     DEFAULT_FACET_COUNT = 10
 
@@ -29,7 +29,7 @@ module Doi::GraphqlQuery
     end
 
     def sort
-      [{ created: "asc", uid: "asc" }]
+      [{ _score: "desc", uid: "asc" }]
     end
 
     def query_fields
@@ -47,16 +47,16 @@ module Doi::GraphqlQuery
 
     def cursor
       tmp_cursor = @options.dig(:page, :cursor)
-      if tmp_cursor.nil?
+      if tmp_cursor.blank?
         return DEFAULT_CURSOR
       end
 
       if tmp_cursor.is_a?(Array)
-        timestamp, uid = tmp_cursor
+        tmp_score, uid = tmp_cursor
       elsif tmp_cursor.is_a?(String)
-        timestamp, uid = tmp_cursor.split(",")
+        tmp_score, uid = tmp_cursor.split(",")
       end
-      [timestamp.to_i, uid.to_s]
+      [tmp_score.to_f, uid.to_s]
     end
 
     def search_after


### PR DESCRIPTION
## Purpose
Users reported that the search results were coming back in an order they were not expecting.  It turns out that the default search order had been set to the date of last update in the database.  This was discussed and determined that the relevancy of the search results or _score in ES/OS should have been the default (with other sort options available if specified in the API call).

closes: datacite/datacite/issues/2206

## Approach
Sets the default sort to be based on _score of search results, descending.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
