### PR TITLE
Refactors `/dois` faceting and adds support for on-demand facets

### DIFF
--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -84,7 +84,7 @@ class DataciteDoisController < ApplicationController
     if params[:id].present?
       response = DataciteDoi.find_by_id(params[:id])
     elsif params[:ids].present?
-      response = DataciteDoi.find_by_ids(params[:ids], page: page, sort: sort)
+      response = DataciteDoi.find_by_ids(params[:ids], disable_facets: params[:disable_facets], facets: params[:facets], page: page, sort: sort)
     else
       response =
         DataciteDoi.query(

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -801,13 +801,10 @@ class Doi < ApplicationRecord
   end
 
   def self.query_aggregations(disable_facets: false, facets: nil)
-    requested_facets = facets.respond_to?(:split) ? facets.split(",").map(&:strip).map(&:underscore).map(&:to_sym).uniq : default_doi_query_facets
+    return {} if disable_facets
 
-    if disable_facets
-      {}
-    else
-      requested_facets.map { |facet| [facet, all_doi_aggregations.dig(facet)] }.to_h.compact
-    end
+    requested_facets = facets.respond_to?(:split) ? facets.split(",").map(&:strip).map(&:underscore).map(&:to_sym).uniq : default_doi_query_facets
+    requested_facets.index_with { |facet| all_doi_aggregations.dig(facet) }.compact
   end
 
   def self.provider_aggregations

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -1929,6 +1929,91 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
     end
   end
 
+  describe "query_aggregations" do
+    default_aggregations = Doi.default_doi_query_facets
+
+    it "returns default aggregations when disable_facets and facets are not set" do
+      aggregations = Doi.query_aggregations
+
+      expect(aggregations.keys).to match_array(default_aggregations)
+    end
+
+    it "returns default aggregations when disable_facets is set to false" do
+      aggregations = Doi.query_aggregations(disable_facets: false)
+
+      expect(aggregations.keys).to match_array(default_aggregations)
+    end
+
+    it "returns blank aggregations when disable_facets is true" do
+      aggregations = Doi.query_aggregations(disable_facets: true)
+
+      expect(aggregations).to eq({})
+    end
+
+    it "returns blank aggregations when disable_facets is true string" do
+      aggregations = Doi.query_aggregations(disable_facets: "true")
+
+      expect(aggregations).to eq({})
+    end
+
+    it "returns default aggregations when disable_facets is false" do
+      aggregations = Doi.query_aggregations(disable_facets: false)
+
+      expect(aggregations.keys).to match_array(default_aggregations)
+    end
+
+    it "returns default aggregations when disable_facets is false string" do
+      aggregations = Doi.query_aggregations(disable_facets: "false")
+
+      expect(aggregations.keys).to match_array(default_aggregations)
+    end
+
+    it "returns selected aggregations when facets is a string" do
+      facets_string = "creators_and_contributors, registrationAgencies,made_up_facet,states,registration_agencies"
+      aggregations = Doi.query_aggregations(facets: facets_string)
+      expected_aggregations = [:creators_and_contributors, :registration_agencies, :states]
+
+      expect(aggregations.keys).to match_array(expected_aggregations)
+    end
+
+    it "returns blank aggregations when facets is a blank string" do
+      facets_string = ""
+      aggregations = Doi.query_aggregations(facets: facets_string)
+
+      expect(aggregations).to eq({})
+    end
+
+    it "returns selected aggregations when facets is an array of symbols" do
+      facets_array = [:creators_and_contributors, :registration_agencies, :states, :made_up_facet, :registration_agencies]
+      aggregations = Doi.query_aggregations(facets: facets_array)
+      expected_aggregations = [:creators_and_contributors, :registration_agencies, :states]
+
+      expect(aggregations.keys).to match_array(expected_aggregations)
+    end
+
+    it "returns blank aggregations when facets is a blank array" do
+      facets_array = []
+      aggregations = Doi.query_aggregations(facets: facets_array)
+
+      expect(aggregations).to eq({})
+    end
+
+    it "returns selected aggregations when facets are an array of symbols and disable_facets is false" do
+      facets_array = [:creators_and_contributors, :registration_agencies, :states, :made_up_facet, :registration_agencies]
+      aggregations = Doi.query_aggregations(facets: facets_array, disable_facets: false)
+      expected_aggregations = [:creators_and_contributors, :registration_agencies, :states]
+
+      expect(aggregations.keys).to match_array(expected_aggregations)
+    end
+
+    it "returns blank aggregations when facets are an array of symbols and disable_facets is true" do
+      facets_array = [:creators_and_contributors, :registration_agencies, :states, :made_up_facet, :registration_agencies]
+      aggregations = Doi.query_aggregations(facets: facets_array, disable_facets: true)
+
+      expect(aggregations).to eq({})
+    end
+  end
+
   describe "formats" do
     content_url = [
       "https://redivis.com/datasets/rt7m-4ndqm48zf/tables/1dgp-0rkbx6ahe?v=1.2",

--- a/spec/requests/datacite_dois/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois/datacite_dois_spec.rb
@@ -236,6 +236,65 @@ describe DataciteDoisController, type: :request, vcr: true do
       next_link = next_link_absolute.path + "?" + next_link_absolute.query
       expect(next_link).to eq("/dois?fields%5Bdois%5D=id%2Csubjects&page%5Bnumber%5D=2&page%5Bsize%5D=2")
     end
+
+    it "returns default facets" do
+      get "/dois", nil, headers
+
+      expect(last_response.status).to eq(200)
+      expect(json["data"].size).to eq(10)
+      expect(json.dig("meta", "total")).to eq(10)
+
+      expect(json.dig("meta").length).to eq(21)
+      expect(json.dig("meta", "states")).to be_truthy
+      expect(json.dig("meta", "resourceTypes")).to be_truthy
+      expect(json.dig("meta", "created")).to be_truthy
+      expect(json.dig("meta", "published")).to be_truthy
+      expect(json.dig("meta", "registered")).to be_truthy
+      expect(json.dig("meta", "providers")).to be_truthy
+      expect(json.dig("meta", "clients")).to be_truthy
+      expect(json.dig("meta", "affiliations")).to be_truthy
+      expect(json.dig("meta", "prefixes")).to be_truthy
+      expect(json.dig("meta", "certificates")).to be_truthy
+      expect(json.dig("meta", "licenses")).to be_truthy
+      expect(json.dig("meta", "schemaVersions")).to be_truthy
+      expect(json.dig("meta", "linkChecksStatus")).to be_truthy
+      expect(json.dig("meta", "subjects")).to be_truthy
+      expect(json.dig("meta", "fieldsOfScience")).to be_truthy
+      expect(json.dig("meta", "citations")).to be_truthy
+      expect(json.dig("meta", "views")).to be_truthy
+      expect(json.dig("meta", "downloads")).to be_truthy
+
+      expect(json.dig("meta", "clientTypes")).to eq(nil)
+      expect(json.dig("meta", "languages")).to eq(nil)
+      expect(json.dig("meta", "creatorsAndContributors")).to eq(nil)
+    end
+
+    it "returns no facets when disable-facets is set" do
+      get "/dois?disable-facets=true", nil, headers
+
+      expect(last_response.status).to eq(200)
+      expect(json["data"].size).to eq(10)
+      expect(json.dig("meta", "total")).to eq(10)
+      expect(json.dig("meta").length).to eq(3)
+      expect(json.dig("meta", "states")).to eq(nil)
+    end
+
+    it "returns specified facets when facets is set" do
+      get "/dois?facets=client_types,registrationAgencies, clients,languages,creators_and_contributors,made_up_facet", nil, headers
+
+      expect(last_response.status).to eq(200)
+      expect(json["data"].size).to eq(10)
+      expect(json.dig("meta", "total")).to eq(10)
+      expect(json.dig("meta").length).to eq(8)
+      expect(json.dig("meta", "states")).to eq(nil)
+      expect(json.dig("meta", "clientTypes")).to be_truthy
+      expect(json.dig("meta", "registrationAgencies")).to be_truthy
+      expect(json.dig("meta", "clients")).to be_truthy
+      expect(json.dig("meta", "languages")).to be_truthy
+      expect(json.dig("meta", "creatorsAndContributors")).to be_truthy
+      expect(json.dig("meta", "madeUpFacet")).to eq(nil)
+      expect(json.dig("meta", "made_up_facet")).to eq(nil)
+    end
   end
 
   describe "GET /dois with nil publisher values", elsasticsearch: true, prefix_pool_size: 1 do

--- a/spec/requests/datacite_dois/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois/datacite_dois_spec.rb
@@ -13,6 +13,26 @@ def clear_doi_index
   DataciteDoi.__elasticsearch__.client.indices.refresh(index: DataciteDoi.index_name)
 end
 
+DEFAULT_DOIS_FACETS = [
+  "states",
+  "resourceTypes",
+  "created",
+  "published",
+  "registered",
+  "providers",
+  "clients",
+  "affiliations",
+  "prefixes",
+  "certificates",
+  "licenses",
+  "schemaVersions",
+  "linkChecksStatus",
+  "subjects",
+  "fieldsOfScience",
+  "citations",
+  "views",
+  "downloads"
+]
 
 describe DataciteDoisController, type: :request, vcr: true do
   let(:admin) { create(:provider, symbol: "ADMIN") }
@@ -244,39 +264,43 @@ describe DataciteDoisController, type: :request, vcr: true do
       expect(json["data"].size).to eq(10)
       expect(json.dig("meta", "total")).to eq(10)
 
-      expect(json.dig("meta").length).to eq(21)
-      expect(json.dig("meta", "states")).to be_truthy
-      expect(json.dig("meta", "resourceTypes")).to be_truthy
-      expect(json.dig("meta", "created")).to be_truthy
-      expect(json.dig("meta", "published")).to be_truthy
-      expect(json.dig("meta", "registered")).to be_truthy
-      expect(json.dig("meta", "providers")).to be_truthy
-      expect(json.dig("meta", "clients")).to be_truthy
-      expect(json.dig("meta", "affiliations")).to be_truthy
-      expect(json.dig("meta", "prefixes")).to be_truthy
-      expect(json.dig("meta", "certificates")).to be_truthy
-      expect(json.dig("meta", "licenses")).to be_truthy
-      expect(json.dig("meta", "schemaVersions")).to be_truthy
-      expect(json.dig("meta", "linkChecksStatus")).to be_truthy
-      expect(json.dig("meta", "subjects")).to be_truthy
-      expect(json.dig("meta", "fieldsOfScience")).to be_truthy
-      expect(json.dig("meta", "citations")).to be_truthy
-      expect(json.dig("meta", "views")).to be_truthy
-      expect(json.dig("meta", "downloads")).to be_truthy
-
-      expect(json.dig("meta", "clientTypes")).to eq(nil)
-      expect(json.dig("meta", "languages")).to eq(nil)
-      expect(json.dig("meta", "creatorsAndContributors")).to eq(nil)
+      expect(json.dig("meta").length).to eq(DEFAULT_DOIS_FACETS.length + 3)
+      expect(json.dig("meta").keys).to match_array(DEFAULT_DOIS_FACETS + ["total", "totalPages", "page"])
     end
 
-    it "returns no facets when disable-facets is set" do
+    it "returns default facets when disable-facets is set to false" do
+      get "/dois?disable-facets=false", nil, headers
+
+      expect(last_response.status).to eq(200)
+      expect(json["data"].size).to eq(10)
+      expect(json.dig("meta", "total")).to eq(10)
+
+      expect(json.dig("meta").length).to eq(DEFAULT_DOIS_FACETS.length + 3)
+      expect(json.dig("meta").keys).to match_array(DEFAULT_DOIS_FACETS + ["total", "totalPages", "page"])
+    end
+
+    it "returns no facets when disable-facets is set to true" do
       get "/dois?disable-facets=true", nil, headers
 
       expect(last_response.status).to eq(200)
       expect(json["data"].size).to eq(10)
       expect(json.dig("meta", "total")).to eq(10)
       expect(json.dig("meta").length).to eq(3)
-      expect(json.dig("meta", "states")).to eq(nil)
+      DEFAULT_DOIS_FACETS.each do |facet|
+        expect(json.dig("meta", facet)).to eq(nil)
+      end
+    end
+
+    it "returns no facets when facets is empty" do
+      get "/dois?facets=", nil, headers
+
+      expect(last_response.status).to eq(200)
+      expect(json["data"].size).to eq(10)
+      expect(json.dig("meta", "total")).to eq(10)
+      expect(json.dig("meta").length).to eq(3)
+      DEFAULT_DOIS_FACETS.each do |facet|
+        expect(json.dig("meta", facet)).to eq(nil)
+      end
     end
 
     it "returns specified facets when facets is set" do


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Refactors approach to OpenSearch aggregations and serialized faceting at `/dois` to reduce calls to OpenSearch for unused facets. Implements new `facets=` URL param that allows the requestor to select from the possible facets. 

closes: https://github.com/datacite/product-backlog/issues/127 https://github.com/datacite/lupo/issues/1301

## Approach
<!--- _How does this change address the problem?_ -->

Builds the aggregations based on the requested facets, default or otherwise, before assembling the OpenSearch query. Accepts comma-separated values via a new `facets=` URL param that selects from the possible facets. Facets are serialized based on supported and available aggregations in the OpenSearch response. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
