### PR TITLE
Remove alternateIdentifiers from XML when alternateIdentifiers parameter is blank or nil

### DIFF
--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -757,16 +757,19 @@ class DataciteDoisController < ApplicationController
       # alternateIdentifiers as alias for identifiers
       # easier before strong_parameters are checked
       if params.dig(:data, :attributes).present? &&
-          params.dig(:data, :attributes, :identifiers).blank? &&
-          !params.dig(:data, :attributes, :alternateIdentifiers).blank?
+         !params.dig(:data, :attributes)&.key?(:identifiers) &&
+         params.dig(:data, :attributes)&.key?(:alternateIdentifiers)
+
+        alternate_identifiers = params.dig(:data, :attributes, :alternateIdentifiers)
+
         params[:data][:attributes][:identifiers] =
-          Array.wrap(params.dig(:data, :attributes, :alternateIdentifiers)).
-            map do |a|
-            {
-              identifier: a[:alternateIdentifier],
-              identifierType: a[:alternateIdentifierType],
-            }
-          end
+          alternate_identifiers.nil? ? nil :
+            Array.wrap(alternate_identifiers).map do |a|
+              {
+                identifier: a.fetch(:alternateIdentifier),
+                identifierType: a.fetch(:alternateIdentifierType),
+              }
+            end
       end
 
       ParamsSanitizer.sanitize_nameIdentifiers(params[:creators])

--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -757,20 +757,24 @@ class DataciteDoisController < ApplicationController
       # alternateIdentifiers as alias for identifiers
       # easier before strong_parameters are checked
       if params.dig(:data, :attributes).present? &&
-         !params.dig(:data, :attributes)&.key?(:identifiers) &&
-         params.dig(:data, :attributes)&.key?(:alternateIdentifiers)
+          !params.dig(:data, :attributes)&.key?(:identifiers) &&
+          params.dig(:data, :attributes)&.key?(:alternateIdentifiers)
 
-        alternate_identifiers = params.dig(:data, :attributes, :alternateIdentifiers)
+          alternate_identifiers = params.dig(:data, :attributes, :alternateIdentifiers)
 
-        params[:data][:attributes][:identifiers] =
-          alternate_identifiers.nil? ? nil :
-            Array.wrap(alternate_identifiers).map do |a|
-              {
-                identifier: a.fetch(:alternateIdentifier),
-                identifierType: a.fetch(:alternateIdentifierType),
-              }
-            end
-      end
+          params[:data][:attributes][:identifiers] =
+            alternate_identifiers.nil? ? nil :
+              Array.wrap(alternate_identifiers).map do |a|
+                if a.respond_to?(:fetch)
+                  {
+                    identifier: a.fetch(:alternateIdentifier),
+                    identifierType: a.fetch(:alternateIdentifierType),
+                  }
+                else
+                  a
+                end
+              end
+        end
 
       ParamsSanitizer.sanitize_nameIdentifiers(params[:creators])
       ParamsSanitizer.sanitize_nameIdentifiers(params[:contributors])

--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -760,21 +760,21 @@ class DataciteDoisController < ApplicationController
           !params.dig(:data, :attributes)&.key?(:identifiers) &&
           params.dig(:data, :attributes)&.key?(:alternateIdentifiers)
 
-          alternate_identifiers = params.dig(:data, :attributes, :alternateIdentifiers)
+        alternate_identifiers = params.dig(:data, :attributes, :alternateIdentifiers)
 
-          params[:data][:attributes][:identifiers] =
-            alternate_identifiers.nil? ? nil :
-              Array.wrap(alternate_identifiers).map do |a|
-                if a.respond_to?(:fetch)
-                  {
-                    identifier: a.fetch(:alternateIdentifier),
-                    identifierType: a.fetch(:alternateIdentifierType),
-                  }
-                else
-                  a
-                end
+        params[:data][:attributes][:identifiers] =
+          alternate_identifiers.nil? ? nil :
+            Array.wrap(alternate_identifiers).map do |a|
+              if a.respond_to?(:fetch)
+                {
+                  identifier: a.fetch(:alternateIdentifier),
+                  identifierType: a.fetch(:alternateIdentifierType),
+                }
+              else
+                a
               end
-        end
+            end
+      end
 
       ParamsSanitizer.sanitize_nameIdentifiers(params[:creators])
       ParamsSanitizer.sanitize_nameIdentifiers(params[:contributors])

--- a/spec/requests/datacite_dois/patch_spec.rb
+++ b/spec/requests/datacite_dois/patch_spec.rb
@@ -775,4 +775,121 @@ describe DataciteDoisController, type: :request, vcr: true do
       expect(json.dig("data", "attributes", "subjects")).to eq([])
     end
   end
+
+  context "when a doi has alternateIdentifier/identifier values" do
+    let(:valid_attributes) do
+      {
+        "data" => {
+          "type" => "dois",
+          "attributes" => {
+            "alternateIdentifiers" => nil,
+          },
+        },
+      }
+    end
+
+    it "the xml and doi record contain the values" do
+      xml = Maremma.from_xml(doi.xml).fetch("resource", {})
+      expect(xml.dig("alternateIdentifiers")).not_to eq(nil)
+      expect(doi.identifiers).not_to eq(nil)
+    end
+
+    it "the values are removed when nil values are sent in json" do
+      patch "/dois/#{doi.doi}", valid_attributes, headers
+
+      xml = Maremma.from_xml(Base64.decode64(json.dig("data", "attributes", "xml"))).fetch("resource", {})
+      expect(xml.dig("alternateIdentifiers")).to eq(nil)
+      expect(json.dig("data", "attributes", "identifiers")).to eq([])
+      expect(json.dig("data", "attributes", "alternateIdentifiers")).to eq([])
+    end
+  end
+
+  context "when a doi has alternateIdentifier/identifier values" do
+    let(:valid_attributes) do
+      {
+        "data" => {
+          "type" => "dois",
+          "attributes" => {
+            "alternateIdentifiers" => [],
+          },
+        },
+      }
+    end
+
+    it "the xml and doi record contain the values" do
+      xml = Maremma.from_xml(doi.xml).fetch("resource", {})
+      expect(xml.dig("alternateIdentifiers")).not_to eq(nil)
+      expect(doi.identifiers).not_to eq(nil)
+    end
+
+    it "the values are removed when blank values are sent in json" do
+      patch "/dois/#{doi.doi}", valid_attributes, headers
+
+      xml = Maremma.from_xml(Base64.decode64(json.dig("data", "attributes", "xml"))).fetch("resource", {})
+      expect(xml.dig("alternateIdentifiers")).to eq(nil)
+      expect(json.dig("data", "attributes", "identifiers")).to eq([])
+      expect(json.dig("data", "attributes", "alternateIdentifiers")).to eq([])
+    end
+  end
+
+  context "when a doi has alternateIdentifier/identifier values" do
+    let(:valid_attributes) do
+      {
+        "data" => {
+          "type" => "dois",
+          "attributes" => {
+            "alternateIdentifiers" => [
+              {
+                "alternateIdentifier" => "identifier",
+                "alternateIdentifierType" => "identifierType",
+              },
+              {
+                "alternateIdentifier" => "identifier_2",
+                "alternateIdentifierType" => "identifierType_2",
+              },
+            ],
+          },
+        },
+      }
+    end
+
+    it "the xml and doi record contain the values" do
+      xml = Maremma.from_xml(doi.xml).fetch("resource", {})
+      expect(xml.dig("alternateIdentifiers")).not_to eq(nil)
+      expect(doi.identifiers).not_to eq(nil)
+    end
+
+    it "the values are changed when new values are sent in json" do
+      patch "/dois/#{doi.doi}", valid_attributes, headers
+
+      xml = Maremma.from_xml(Base64.decode64(json.dig("data", "attributes", "xml"))).fetch("resource", {})
+      expect(xml.dig("alternateIdentifiers")).to eq(
+        "alternateIdentifier" => 
+          [
+            {"__content__"=>"identifier", "alternateIdentifierType"=>"identifierType"},
+            {"__content__"=>"identifier_2", "alternateIdentifierType"=>"identifierType_2"}
+          ]
+      )
+      expect(json.dig("data", "attributes", "alternateIdentifiers")).to eq([
+        {
+          "alternateIdentifier" => "identifier",
+          "alternateIdentifierType" => "identifierType"
+        },
+        {
+          "alternateIdentifier" => "identifier_2",
+          "alternateIdentifierType" => "identifierType_2"
+        }
+      ])
+      expect(json.dig("data", "attributes", "alternateIdentifiers")).to eq([
+        {
+          "alternateIdentifier" => "identifier",
+          "alternateIdentifierType" => "identifierType"
+        },
+        {
+          "alternateIdentifier" => "identifier_2",
+          "alternateIdentifierType" => "identifierType_2"
+        }
+      ])
+    end
+  end
 end

--- a/spec/requests/datacite_dois/patch_spec.rb
+++ b/spec/requests/datacite_dois/patch_spec.rb
@@ -870,14 +870,14 @@ describe DataciteDoisController, type: :request, vcr: true do
             { "__content__" => "identifier_2", "alternateIdentifierType" => "identifierType_2" }
           ]
       )
-      expect(json.dig("data", "attributes", "alternateIdentifiers")).to eq([
+      expect(json.dig("data", "attributes", "identifiers")).to eq([
         {
-          "alternateIdentifier" => "identifier",
-          "alternateIdentifierType" => "identifierType"
+          "identifier" => "identifier",
+          "identifierType" => "identifierType"
         },
         {
-          "alternateIdentifier" => "identifier_2",
-          "alternateIdentifierType" => "identifierType_2"
+          "identifier" => "identifier_2",
+          "identifierType" => "identifierType_2"
         }
       ])
       expect(json.dig("data", "attributes", "alternateIdentifiers")).to eq([
@@ -890,6 +890,48 @@ describe DataciteDoisController, type: :request, vcr: true do
           "alternateIdentifierType" => "identifierType_2"
         }
       ])
+    end
+
+    context "when a doi has alternateIdentifier/identifier values" do
+      let(:valid_attributes) do
+        {
+          "data" => {
+            "type" => "dois",
+            "attributes" => {
+              "subjects" => nil,
+            },
+          },
+        }
+      end
+  
+      it "the xml and doi record contain the values" do
+        xml = Maremma.from_xml(doi.xml).fetch("resource", {})
+        expect(xml.dig("alternateIdentifiers")).not_to eq(nil)
+        expect(doi.identifiers).not_to eq(nil)
+      end
+  
+      it "the values are the same when no values are sent in json" do
+        patch "/dois/#{doi.doi}", valid_attributes, headers
+
+        xml = Maremma.from_xml(Base64.decode64(json.dig("data", "attributes", "xml"))).fetch("resource", {})
+        expect(xml.dig("alternateIdentifiers")).to eq(
+          "alternateIdentifier" => {
+            "__content__" => "pk-1234", "alternateIdentifierType" => "publisher ID"
+          }
+        )
+        expect(json.dig("data", "attributes", "identifiers")).to eq([
+          {
+            "identifier" => "pk-1234",
+            "identifierType" => "publisher ID"
+          },
+        ])
+        expect(json.dig("data", "attributes", "alternateIdentifiers")).to eq([
+          {
+            "alternateIdentifier" => "pk-1234",
+            "alternateIdentifierType" => "publisher ID"
+          },
+        ])
+      end
     end
   end
 end

--- a/spec/requests/datacite_dois/patch_spec.rb
+++ b/spec/requests/datacite_dois/patch_spec.rb
@@ -903,13 +903,13 @@ describe DataciteDoisController, type: :request, vcr: true do
           },
         }
       end
-  
+
       it "the xml and doi record contain the values" do
         xml = Maremma.from_xml(doi.xml).fetch("resource", {})
         expect(xml.dig("alternateIdentifiers")).not_to eq(nil)
         expect(doi.identifiers).not_to eq(nil)
       end
-  
+
       it "the values are the same when no values are sent in json" do
         patch "/dois/#{doi.doi}", valid_attributes, headers
 

--- a/spec/requests/datacite_dois/patch_spec.rb
+++ b/spec/requests/datacite_dois/patch_spec.rb
@@ -864,10 +864,10 @@ describe DataciteDoisController, type: :request, vcr: true do
 
       xml = Maremma.from_xml(Base64.decode64(json.dig("data", "attributes", "xml"))).fetch("resource", {})
       expect(xml.dig("alternateIdentifiers")).to eq(
-        "alternateIdentifier" => 
+        "alternateIdentifier" =>
           [
-            {"__content__"=>"identifier", "alternateIdentifierType"=>"identifierType"},
-            {"__content__"=>"identifier_2", "alternateIdentifierType"=>"identifierType_2"}
+            { "__content__" => "identifier", "alternateIdentifierType" => "identifierType" },
+            { "__content__" => "identifier_2", "alternateIdentifierType" => "identifierType_2" }
           ]
       )
       expect(json.dig("data", "attributes", "alternateIdentifiers")).to eq([


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: https://github.com/datacite/datacite/issues/1899

## Approach
<!--- _How does this change address the problem?_ -->

Adds safety to conversion from `alternateIdentifiers` param to `identifiers` param. Checks for the existence of `alternateIdentifiers` and `identifiers` param rather than checking if either is blank.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
