### PR TITLE
Explicitly install imagemagick in CI

### DIFF
--- a/.github/workflows/parallel_ci.yml
+++ b/.github/workflows/parallel_ci.yml
@@ -84,6 +84,10 @@ jobs:
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-gems-
+      - name: Install ImageMagick
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y imagemagick
       - name: Install
         env:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}


### PR DESCRIPTION
## Purpose
Paperclip-related problems in CI pointed to imagemagick not being installed.

Turns out that the new image for ubuntu-latest used in CI is now based on ubuntu-24.04, where it previously was based on ubuntu-22.04.  They have different default packages installed. as outlined in 
https://github.com/actions/runner-images/blob/ubuntu22/20250105.1/images/ubuntu/Ubuntu2204-Readme.md#installed-apt-packages
and https://github.com/actions/runner-images/blob/ubuntu24/20250105.1/images/ubuntu/Ubuntu2404-Readme.md#installed-apt-packages

In 22.04 imagemagick was already installed, whereas in 24.04 it is not installed by default.

## Approach
Explicitly installs imgagemagick in CI


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
