### PR TITLE
Allows providers with ROLE_MEMBER "Member Only" role to retrieve non-findable DOIs at /dois endpoint

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -72,6 +72,9 @@ class Ability
       can %i[manage], Contact, provider_id: user.provider_id
       can %i[manage], ProviderPrefix, provider_id: user.provider_id
       can %i[manage read_contact_information], Client, provider_id: user.provider_id
+      cannot %i[manage read_contact_information], Client do |client|
+        client.provider.role_name.in?(["ROLE_MEMBER"])
+      end
       cannot %i[transfer], Client
       can %i[manage], ClientPrefix # , :client_id => user.provider_id
 

--- a/app/models/concerns/authenticable.rb
+++ b/app/models/concerns/authenticable.rb
@@ -178,6 +178,7 @@ module Authenticable
         "ROLE_DEV" => "staff_admin",
         "ROLE_DATACENTRE" => "client_admin",
         "ROLE_ALLOCATOR" => "provider_admin",
+        "ROLE_MEMBER" => "provider_admin",
         "ROLE_CONSORTIUM" => "consortium_admin",
         "ROLE_CONSORTIUM_ORGANIZATION" => "provider_admin",
         "ROLE_CONTRACTUAL_PROVIDER" => "provider_admin",

--- a/spec/requests/clients_spec.rb
+++ b/spec/requests/clients_spec.rb
@@ -127,7 +127,7 @@ describe ClientsController, type: :request, elasticsearch: true do
           },
         }
       end
-      
+
       let(:raid_registry_client_id) { provider.symbol + ".RAID" }
       let(:params_raid_registry) do
         {

--- a/spec/requests/clients_spec.rb
+++ b/spec/requests/clients_spec.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+include Passwordable
 
 describe ClientsController, type: :request, elasticsearch: true do
   let(:ids) { clients.map(&:uid).join(",") }
   let(:bearer) { User.generate_token }
   let(:provider) { create(:provider, password_input: "12345") }
+  let(:provider_member_only) { create(:provider, role_name: "ROLE_MEMBER", symbol: "YYYY", password: encrypt_password_sha256(ENV["MDS_PASSWORD"])) }
   let!(:client) { create(:client, provider: provider) }
   let(:params) do
     {
@@ -125,7 +127,7 @@ describe ClientsController, type: :request, elasticsearch: true do
           },
         }
       end
-
+      
       let(:raid_registry_client_id) { provider.symbol + ".RAID" }
       let(:params_raid_registry) do
         {
@@ -228,6 +230,26 @@ describe ClientsController, type: :request, elasticsearch: true do
         }
       end
 
+      let(:provider_member_only_basic_auth_headers) { { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(provider_member_only.symbol, ENV["MDS_PASSWORD"]) } }
+      let(:params_member_only) do
+        {
+          "data" => {
+            "type" => "clients",
+            "attributes" => {
+              "symbol" => provider_member_only.symbol + ".IMPERIAL",
+              "name" => "Imperial College",
+              "contactEmail" => "bob@example.com",
+              "clientType" => "repository",
+            },
+            "relationships": {
+              "provider": {
+                "data": { "type": "providers", "id": provider_member_only.uid },
+              },
+            },
+          },
+        }
+      end
+
       it "returns status code 422" do
         post "/clients", params, headers
 
@@ -246,6 +268,12 @@ describe ClientsController, type: :request, elasticsearch: true do
             },
           ],
         )
+      end
+
+      it "returns status code 422" do
+        post "/clients", params_member_only, provider_member_only_basic_auth_headers
+
+        expect(last_response.status).to eq(403)
       end
     end
   end

--- a/spec/requests/datacite_dois/auth_headers_spec.rb
+++ b/spec/requests/datacite_dois/auth_headers_spec.rb
@@ -9,6 +9,7 @@ describe DataciteDoisController, type: :request, vcr: true do
   let(:admin_headers) { { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => "Bearer " + admin_bearer } }
 
   let(:provider) { create(:provider, symbol: "DATACITE", password: encrypt_password_sha256(ENV["MDS_PASSWORD"])) }
+  let(:provider_member_only) { create(:provider, role_name: "ROLE_MEMBER", symbol: "YYYY", password: encrypt_password_sha256(ENV["MDS_PASSWORD"])) }
   let(:client) { create(:client, provider: provider, symbol: ENV["MDS_USERNAME"], password: encrypt_password_sha256(ENV["MDS_PASSWORD"]), re3data_id: "10.17616/r3xs37") }
   let!(:prefix) { create(:prefix, uid: "10.14454") }
   let!(:client_prefix) { create(:client_prefix, client: client, prefix: prefix) }
@@ -24,6 +25,7 @@ describe DataciteDoisController, type: :request, vcr: true do
     let(:anonymous_basic_auth_headers) { { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(client.symbol, "") } }
     let(:client_basic_auth_headers) { { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(client.symbol, ENV["MDS_PASSWORD"]) } }
     let(:provider_basic_auth_headers) { { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(provider.symbol, ENV["MDS_PASSWORD"]) } }
+    let(:provider_member_only_basic_auth_headers) { { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(provider_member_only.symbol, ENV["MDS_PASSWORD"]) } }
 
     before do
       DataciteDoi.import
@@ -59,6 +61,15 @@ describe DataciteDoisController, type: :request, vcr: true do
 
     it "return dois in all states with authenticated provider user" do
       get "/dois", nil, provider_basic_auth_headers
+
+      expect(json.dig("meta", "total")).to eq(12)
+      expect(json.dig("meta", "states", 0, "count")).to eq(10)
+      expect(json.dig("meta", "states", 1, "count")).to eq(1)
+      expect(json.dig("meta", "states", 2, "count")).to eq(1)
+    end
+
+    it "return dois in all states with authenticated ROLE_MEMBER provider user" do
+      get "/dois", nil, provider_member_only_basic_auth_headers
 
       expect(json.dig("meta", "total")).to eq(12)
       expect(json.dig("meta", "states", 0, "count")).to eq(10)


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Providers with the ROLE_MEMBER role should have access to non-findable DOIs at the /dois endpoint alongside other authenticated members. This PR addresses this inconsistency. 

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
