### PR TITLE
add facets from graphQL missing in REST

### DIFF
--- a/app/controllers/concerns/facetable.rb
+++ b/app/controllers/concerns/facetable.rb
@@ -561,5 +561,14 @@ module Facetable
 
       arr
     end
+
+
+    def metric_value(aggregate)
+      aggregate.value.to_i
+    end
+
+    def metric_doc_count(aggregate)
+      aggregate.doc_count.to_i
+    end
   end
 end

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -677,6 +677,27 @@ class Doi < ApplicationRecord
   DOI_AGGREGATION_DEFINITIONS = {
       # number of resourceTypeGeneral increased from 30 to 32 in schema 4.6
       resource_types: { terms: { field: "resource_type_id_and_name", size: 32, min_doc_count: 1 } },
+      open_licenses: {
+        filter: { terms: {
+          "rights_list.rightsIdentifier": [
+            "cc-by-1.0",
+            "cc-by-2.0",
+            "cc-by-2.5",
+            "cc-by-3.0",
+            "cc-by-3.0-at",
+            "cc-by-3.0-us",
+            "cc-by-4.0",
+            "cc-pddc",
+            "cc0-1.0",
+            "cc-pdm-1.0"
+          ]
+        } },
+        aggs: {
+          resource_types: {
+            terms: { field: "resource_type_id_and_name", size: 32, min_doc_count: 1 }
+          }
+        }
+      },
       states: { terms: { field: "aasm_state", size: 3, min_doc_count: 1 } },
       published: {
         date_histogram: {
@@ -725,7 +746,11 @@ class Doi < ApplicationRecord
       licenses: { terms: { field: "rights_list.rightsIdentifier", size: 10, min_doc_count: 1 } },
       licenses_with_missing: { terms: { field: "rights_list.rightsIdentifier", size: 10, min_doc_count: 1, missing: "__missing__" } },
       languages: { terms: { field: "language", size: 10, min_doc_count: 1 } },
+      citation_count: { sum: { field: "citation_count" } },
+      view_count: { sum: { field: "view_count" } },
+      download_count: { sum: { field: "download_count" } },
       certificates: { terms: { field: "client.certificate", size: 10, min_doc_count: 1 } },
+      content_url_count: { value_count: { field: "content_url" } },
       authors: {
         terms: {
           field: "creators.nameIdentifiers.nameIdentifier",


### PR DESCRIPTION
## Purpose
A few facets from GraphQL are now needed in the REST API:
- downloads
- citation_count
- view_count
- download_count
- content_url_count
- open_licenses
- open_licenses_count

closes: _Add github issue that originated this PR_

## Approach
- Add aggregations present in the GraphQL to the REST API
- For the open_license_count, which isn't an aggregation itself but is derived from the open_licenses aggregation, specify the path within the aggregations that should be sent as an argument to its facet method

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
