### PR TITLE
Move Event and Activity indexing jobs to lupo_background

### DIFF
--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -11,6 +11,8 @@ module Indexable
       if ["Doi", "DataciteDoi", "OtherDoi"].include?(self.class.name) && agency != "datacite"
         other_doi = OtherDoi.find_by(id: self.id)
         IndexBackgroundJob.perform_later(other_doi) if other_doi
+      elsif ["Event", "Activity"].include?(self.class.name)
+        IndexBackgroundJob.perform_later(self)
       elsif not %w[Prefix ProviderPrefix ClientPrefix DataciteDoi].include?(self.class.name)
         IndexJob.perform_later(self)
       elsif instance_of?(DataciteDoi)

--- a/spec/fixtures/vcr_cassettes/Indexable_class_methods/after_commit_callback/when_event_is_committed/performs_IndexBackgroundJob_with_Event_when_event_created.yml
+++ b/spec/fixtures/vcr_cassettes/Indexable_class_methods/after_commit_callback/when_event_is_committed/performs_IndexBackgroundJob_with_Event_when_event_created.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://doi.org/ra/10.1371
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/5.0.0; mailto:info@datacite.org)
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 06 Mar 2025 19:30:48 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin, accept-encoding
+      Permissions-Policy:
+      - interest-cohort=(),browsing-topics=()
+      Content-Encoding:
+      - gzip
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=1xWyk%2FNVGE7ZcNAbbXm3krW2%2BV6y%2B2prM2BWobhI6W5ZG2aMlaVCUA3Ef5k4OeXnqjYyXQljG%2FXgEop8KSCHUcIteKCJc%2BCMd%2F8Z9bF%2FVPq6CzSm%2BjiYXBQ%3D"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 91c4450cfd5c432b-EWR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+      Server-Timing:
+      - cfL4;desc="?proto=TCP&rtt=16008&min_rtt=12767&rtt_var=7103&sent=4&recv=6&lost=0&retrans=0&sent_bytes=2781&recv_bytes=862&delivery_rate=226834&cwnd=251&unsent_bytes=0&cid=24372fda810034f0&ts=73&x=0"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4vmUlCoBmIFBSUXf08lKwUlQwM9Q2NzQyUdiGiQI0jQuSi/uLgoNU0JKFjLFQsAfpIZsjYAAAA=
+  recorded_at: Thu, 06 Mar 2025 19:30:48 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Event and Activity indexing is currently sent to the `lupo` queue via `IndexJob`. Because Event and Activity are lower-priority jobs, this PR changes their indexing queue to `lupo_background` via `IndexBackgroundJob`. 

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
