### PR TITLE
Change datadog gem loading

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem "countries", "~> 2.1", ">= 2.1.2"
 gem "country_select", "~> 3.1"
 gem "crawler_detect"
 gem "dalli", "~> 3.2", ">= 3.2.8"
-gem "datadog", require: "datadog/auto_instrument"
 gem "departure", "~> 6.2"
 gem "diffy", "~> 3.2", ">= 3.2.1"
 gem "dotenv"
@@ -77,6 +76,10 @@ gem "string_pattern"
 gem "strip_attributes", "~> 1.8"
 gem "turnout", "~> 2.5"
 gem "uuid", "~> 2.3", ">= 2.3.9"
+
+group :production, :stage do
+  gem "datadog", require: "datadog/auto_instrument"
+end
 
 group :development, :test do
   gem "better_errors"

--- a/config/application.rb
+++ b/config/application.rb
@@ -133,7 +133,7 @@ module Lupo
         params: event.payload[:params].except(*exceptions),
         uid: event.payload[:uid],
       }
-    end
+    end if defined?(Datadog::Tracing)
 
     # configure caching
     config.cache_store = :mem_cache_store, ENV["MEMCACHE_SERVERS"], { namespace: ENV["APPLICATION"] }

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "datadog"
-
 Datadog.configure do |c|
   # Global
   c.agent.host = "datadog.local"
@@ -21,7 +19,8 @@ Datadog.configure do |c|
   c.tracing.instrument :rails
   c.tracing.instrument :elasticsearch
   c.tracing.instrument :shoryuken
+  c.tracing.instrument :graphql, enabled: false, with_deprecated_tracers: true
 
   # Profiling setup
   c.profiling.enabled = Rails.env.stage?
-end
+end if defined?(Datadog)


### PR DESCRIPTION
Only load on production stage group envs
Also change how the initlaiser is loaded so doesn't do anything when not loaded.

## Purpose

This is to prevent it running in environments it shouldn't

## Approach
N/A

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
