### PR TITLE
Cleanup unused gem and move rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem "bolognese", "~> 2.3.2"
 gem "bootsnap", "~> 1.4", ">= 1.4.4", require: false
 gem "cancancan", "~> 3.0"
 gem "countries", "~> 2.1", ">= 2.1.2"
-gem "country_select", "~> 3.1"
 gem "crawler_detect"
 gem "dalli", "~> 3.2", ">= 3.2.8"
 gem "datadog", require: "datadog/auto_instrument"
@@ -86,11 +85,6 @@ group :development, :test do
   gem "rspec-benchmark", "~> 0.4.0"
   gem "rspec-graphql_matchers", "~> 1.4"
   gem "rspec-rails", "~> 6.1", ">= 6.1.1"
-  gem "rubocop", "~> 1.3", ">= 1.3.1"
-  gem "rubocop-performance", "~> 1.5", ">= 1.5.1"
-  gem "rubocop-rails", "~> 2.8", ">= 2.8.1"
-  gem "rubocop-packaging", "~> 0.5.1"
-  gem "rubocop-rspec", "~> 2.0", require: false
 end
 
 group :development do
@@ -103,6 +97,11 @@ group :development do
   gem "spring", "~> 4.1", ">= 4.1.3"
   gem "spring-commands-rspec"
   gem "spring-watcher-listen", "~> 2.1"
+  gem "rubocop", "~> 1.3", ">= 1.3.1", require: false
+  gem "rubocop-performance", "~> 1.5", ">= 1.5.1", require: false
+  gem "rubocop-rails", "~> 2.8", ">= 2.8.1", require: false
+  gem "rubocop-packaging", "~> 0.5.1", require: false
+  gem "rubocop-rspec", "~> 2.0", require: false
 end
 
 group :test do


### PR DESCRIPTION
Rubocop isn't needed anywhere but on the test runner and dev mode, so don't load it other than there

Country-select isn't being used

## Purpose
Just trying to improve startup speed of rspec.

## Approach
N/A

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
M/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
