### PR TITLE
Move web service to profiles for explicit startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ Using Docker.
 docker run -p 8065:80 datacite/lupo
 ```
 
-or
+or using with docker compose `app` profile
 
 ```bash
-docker-compose up
+docker compose --profile app up
 ```
+
+Without specifying the `app` profile just the core infrastructure parts will start i.e. mysql, opensearch etc
 
 If you want to build the docker image locally (instead of pulling it from docker hub)
  and use docker compose for development you can use

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   web:
+    profiles: [ app ]
     env_file: .env
     environment:
       - ELASTIC_PASSWORD=AnUnsecurePassword123
@@ -18,10 +19,12 @@ services:
       - public
     depends_on:
       - elasticsearch
+
   memcached:
     image: memcached:1.4.31
     networks:
       - public
+
   mysql:
     command: --max_allowed_packet=50000000
     environment:
@@ -32,8 +35,9 @@ services:
       - "3309:3306"
     networks:
       - public
+
   elasticsearch:
-    image: opensearchproject/opensearch:2 
+    image: opensearchproject/opensearch:2
     ports:
       - "9201:9200"
       - "9301:9300"


### PR DESCRIPTION
This is a different way of specifying what comes up with docker compose

This is a breaking workflow change as by default with "docker compose up" it will not start the rails app "web"

## Purpose

This is to allow for example local running of the rails app but still starting anxillery services needed by the app i.e. mysql, opensearch etc.
This is the same as using the docker compose file .local

If this PR is accepted seperately we might wish to remove the .local one.

## Approach
Uses docker profiles https://docs.docker.com/compose/how-tos/profiles/

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
See approach

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
