### PR TITLE
Move metadata file storage for metadata history to S3

### DIFF
--- a/app/models/metadata.rb
+++ b/app/models/metadata.rb
@@ -1,23 +1,12 @@
 # frozen_string_literal: true
 
+require "aws-sdk-s3"
+
 class Metadata < ApplicationRecord
   include Bolognese::Utils
   include Bolognese::DoiUtils
 
   include Cacheable
-
-  # added a getter and setter for the xml attribute utf-8 encoding was not working as expected and we had failing specs.
-  # the failing spec spec/models/metadata_spec.rb:48
-  # example 1: Céline was persisted as C\xC3\xA9line.
-  # example 2: PatiÃ±o was persisted as Pati\xC3\x83\xC2\xB1o
-  def xml=(value)
-    value = value&.force_encoding("UTF-8")
-    super(value)
-  end
-
-  def xml
-    super&.force_encoding("UTF-8")
-  end
 
   alias_attribute :created_at, :created
   alias_attribute :datacite_doi_id, :doi_id
@@ -31,6 +20,37 @@ class Metadata < ApplicationRecord
 
   before_validation :set_metadata_version, :set_namespace
   before_create { self.created = Time.zone.now.utc.iso8601 }
+
+  before_create :upload_xml_to_s3
+
+  def xml=(value)
+    # The encoding is forced here to UTF8
+    # because the xml attribute utf-8 encoding was not working as expected and we had failing specs.
+    # the failing spec spec/models/metadata_spec.rb:48
+    # example 1: Céline was persisted as C\xC3\xA9line.
+    # example 2: PatiÃ±o was persisted as Pati\xC3\x83\xC2\xB1o
+    # See also the forced return on the getter
+    value = value&.force_encoding("UTF-8")
+    super(value)
+  end
+
+  def xml
+    # We check if the value is already set to object_key i.e. externally stored
+    # This helps avoid unnecessary calls to S3
+    if super == object_key
+
+      bucket_name = ENV["METADATA_STORAGE_BUCKET_NAME"]
+      object = Aws::S3::Object.new(bucket_name, object_key)
+
+      if object.exists?
+        return object.get.body.read
+      end
+    end
+
+    # Default return the original value
+    # See the setter for information on utf8 encoding
+    super&.force_encoding("UTF-8")
+  end
 
   def uid
     Base32::URL.encode(id, split: 4, length: 16)
@@ -88,5 +108,30 @@ class Metadata < ApplicationRecord
         v.start_with?("http://datacite.org/schema/kernel")
       end
     self.namespace = Array.wrap(ns).last
+  end
+
+  def upload_xml_to_s3
+    bucket_name = ENV["METADATA_STORAGE_BUCKET_NAME"]
+
+    object = Aws::S3::Object.new(bucket_name, object_key)
+    object.put(body: xml, content_type: "application/xml")
+
+    # Set the xml attribute to be the object_key
+    # this stops the large xml from being persisted but instead just stores
+    # a reference to the external storage
+    self.xml = object_key
+
+  rescue => e
+    Rails.logger.error(e)
+
+    # Raise to rollback transaction and error out attempt
+    # This is to prevent a partial storage in db without associated metadata
+    # It most likely means a new request needs to be made.
+    raise "Failed to upload XML to S3: #{e.message}"
+  end
+
+  # This is so we can store unique metadata files in external storage.
+  def object_key
+    Base64.urlsafe_encode64(doi_id + "_version_" + metadata_version.to_s, padding: false)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -66,6 +66,7 @@ ENV["HANDLES_MINTED"] ||= "10132"
 ENV["REALM"] ||= ENV["API_URL"]
 ENV["SQS_PREFIX"] ||= ""
 ENV["EXCLUDE_PREFIXES_FROM_DATA_IMPORT"] ||= ""
+ENV["METADATA_STORAGE_BUCKET_NAME"] ||= "metadata"
 
 module Lupo
   class Application < Rails::Application

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Aws.config.update({
+  region: ENV["AWS_REGION"],
+  access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+  secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+  s3: {
+    endpoint: ENV["AWS_ENDPOINT_URL_S3"] || ENV["AWS_ENDPOINT_URL"],
+    access_key_id: ENV["AWS_ACCESS_KEY_ID_S3"] || ENV["AWS_ACCESS_KEY_ID"],
+    secret_access_key: ENV["AWS_SECRET_ACCESS_KEY_S3"] || ENV["AWS_SECRET_ACCESS_KEY"],
+    force_path_style: true
+  },
+})

--- a/docker-compose.local.dev.yml
+++ b/docker-compose.local.dev.yml
@@ -6,7 +6,7 @@ services:
     networks:
       - public
     ports:
-      - "11211:11211"  # Expose the memcached port for external access
+      - "11211:11211" # Expose the memcached port for external access
   mysql:
     command: --max_allowed_packet=50000000
     environment:
@@ -40,6 +40,20 @@ services:
       test: curl -f http://admin:AnUnsecurePassword123@elasticsearch:9200
       interval: 10s
       timeout: 1s
+
+  minio:
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    image: minio/minio:latest
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    networks:
+      - public
+    volumes:
+      - data:/user/share/minio/data
 
 volumes:
   data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,10 +18,15 @@ services:
       - public
     depends_on:
       - elasticsearch
+      - mysql
+      - memcached
+      - minio
+
   memcached:
     image: memcached:1.4.31
     networks:
       - public
+
   mysql:
     command: --max_allowed_packet=50000000
     environment:
@@ -32,8 +37,9 @@ services:
       - "3309:3306"
     networks:
       - public
+
   elasticsearch:
-    image: opensearchproject/opensearch:2 
+    image: opensearchproject/opensearch:2
     ports:
       - "9201:9200"
       - "9301:9300"
@@ -55,6 +61,20 @@ services:
       test: curl -f http://admin:AnUnsecurePassword123@elasticsearch:9200
       interval: 10s
       timeout: 1s
+
+  minio:
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    image: minio/minio:latest
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    networks:
+      - public
+    volumes:
+      - data:/user/share/minio/data
 
 volumes:
   data:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,6 +22,9 @@ require "aasm/rspec"
 require "strip_attributes/matchers"
 require "rspec-benchmark"
 
+ENV["METADATA_STORAGE_BUCKET_NAME" ] = ENV["METADATA_STORAGE_BUCKET_NAME"] + "-test#{ENV["TEST_ENV_NUMBER"]}"
+
+
 # Checks for pending migration and applies them before tests are run.
 ActiveRecord::Migration.maintain_test_schema!
 

--- a/spec/support/objectstore_helper.rb
+++ b/spec/support/objectstore_helper.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "aws-sdk-s3"
+
+def clean_bucket
+  puts("Clearing metadata bucket")
+  bucket_name = ENV["METADATA_STORAGE_BUCKET_NAME"]
+  s3 = Aws::S3::Resource.new(region: ENV["AWS_REGION"])
+  bucket = s3.bucket(bucket_name)
+  bucket.objects.batch_delete!
+
+  # Delete the bucket
+  puts("Deleting metadata bucket")
+  bucket.delete
+end
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    puts("Creating metadata bucket")
+
+    bucket_name = ENV["METADATA_STORAGE_BUCKET_NAME"]
+    s3 = Aws::S3::Resource.new(region: ENV["AWS_REGION"])
+    s3.create_bucket(bucket: bucket_name)
+  end
+
+  # This is to clean up beteween tests metadata documents stored in the objectstore i.e. minio
+  config.after(:suite) do
+    clean_bucket
+  end
+end


### PR DESCRIPTION
## Purpose

This PR is to move the historical metadata storage from the metadata table in the database to an object store, namely S3.

The reasoning behind this is for performance and cost optimisations see: https://github.com/datacite/datacite/issues/2329 and sub issues

## Approach

Using the AWS SDK store the XML in S3 instead of storing directly in the xml blob in RDS. The database instead will just have the object_key for lookup.
We handle this by changing the model to fetch this data from S3 if it's got an object_key stored.
Most likely in the future once we migrate all historical data we can simplify this to always pull from S3.

See also: https://github.com/datacite/docs-engineering/blob/main/Planning/metadata_storage/Metadata%20storage%20-%20Stage%201%20Phase%201%20-%20Notes.md

#### Open Questions and Pre-Merge TODOs

- Is this still performant enough? This isn't necessarily pre merge but will need further testing most likely on staging.

## Learning

- Testing of how to handle S3 object keys, researching ideas on how best to store, what libraries to consider, considerations of long term maintainability.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
