### PR TITLE
Speed up model specs by disabling Elasticsearch and prefix pool size

### DIFF
--- a/spec/models/client_prefix_spec.rb
+++ b/spec/models/client_prefix_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe ClientPrefix, type: :model, elasticsearch: true do
+describe ClientPrefix, type: :model, elasticsearch: false, prefix_pool_size: 3 do
   context "Prefix assigned from the pool on repository creation" do
     let(:provider) { create(:provider) }
     let(:client) { create(:client, provider: provider) }

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe Client, type: :model do
+describe Client, type: :model, prefix_pool_size: 3 do
   let!(:provider) { create(:provider) }
   let!(:client) { create(:client, provider: provider) }
 

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe Doi, type: :model, vcr: true, elasticsearch: true do
+describe Doi, type: :model, vcr: true, elasticsearch: false, prefix_pool_size: 1 do
   it_behaves_like "an STI class"
 
   describe "validations" do
@@ -1554,7 +1554,7 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
     end
   end
 
-  describe "transfer", elasticsearch: true do
+  describe "transfer", elasticsearch: true, prefix_pool_size: 3 do
     let(:provider) { create(:provider) }
     let(:client) { create(:client, provider: provider) }
     let(:target) { create(:client, provider: provider, symbol: provider.symbol + ".TARGET", name: "Target Client") }
@@ -1852,7 +1852,7 @@ describe Doi, type: :model, vcr: true, elasticsearch: true do
     end
   end
 
-  describe "stats_query", elasticsearch: true do
+  describe "stats_query", elasticsearch: true, prefix_pool_size: 3 do
     subject { Doi }
 
     before do


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
This PR aims to speed up the model specs by disabling Elasticsearch in some tests and limiting the prefix pool size used during testing.

## Approach
<!--- _How does this change address the problem?_ -->
The changes disable unnecessary Elasticsearch indexing in certain model specs and reduce the number of prefixes created and used during testing. This should lead to faster test execution.

### Key Modifications

- Disabled Elasticsearch for `ClientPrefix`, `Client`, and most `Doi` specs.
- Added `prefix_pool_size` option to specify the number of prefixes used in certain specs.

### Important Technical Details

- The `elasticsearch: false` flag is added to the `describe` block to disable Elasticsearch indexing for the entire spec file or block.
- The `prefix_pool_size` option is a custom spec helper that limits the number of prefixes created during tests, reducing test setup time.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
