### PR TITLE
Remove invalid `:events` association

### DIFF
--- a/app/models/other_doi.rb
+++ b/app/models/other_doi.rb
@@ -128,7 +128,6 @@ class OtherDoi < Doi
       :part_of_events,
       :version_events,
       :version_of_events,
-      :events,
       :metadata
     ).where(id: ids)
 


### PR DESCRIPTION
## Purpose
This PR addresses an issue where the `OtherDoi` model was attempting to preload an `:events` association that doesn't exist, leading to potential errors or unnecessary overhead. The goal is to remove this erroneous association, ensuring the model functions correctly and efficiently.

closes: #1348

## Approach
This change directly fixes the problem by removing the invalid `:events` association from the `includes` statement within the `OtherDoi` model. This prevents the application from trying to preload non-existent data, streamlining query execution.

### Key Modifications
- Removed `:events` from the `includes` array within the `find_by_ids` method in `app/models/other_doi.rb`.

### Important Technical Details
The `OtherDoi` model, which inherits from `Doi`, was incorrectly attempting to preload an association named `:events`. This association does not exist directly on the `Doi` or `OtherDoi` models in the current schema. Removing this invalid inclusion ensures that the `includes` method only attempts to preload valid associations, preventing potential ActiveRecord errors or inefficient queries.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
