### PR TITLE
Optimize OtherDoi bulk import

### DIFF
--- a/app/jobs/other_doi_bulk_shard_job.rb
+++ b/app/jobs/other_doi_bulk_shard_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class OtherDoiBulkShardJob < ApplicationJob
+  queue_as :lupo_import_other_doi
+
+  def perform(start_id, end_id, batch_size: 50, index: nil)
+    ids = DataciteDoi.where(type: "OtherDoi", id: start_id..end_id).pluck(:id)
+    ids.each_slice(batch_size) do |batch_ids|
+      OtherDoiImportInBulkJob.perform_later(batch_ids, index: index)
+    end
+  end
+end 

--- a/app/models/datacite_doi.rb
+++ b/app/models/datacite_doi.rb
@@ -156,7 +156,7 @@ class DataciteDoi < Doi
       end
 
     # get database records from array of database ids
-    selected_dois = DataciteDoi.where(id: ids).includes(
+    selected_dois = DataciteDoi.where(id: ids, type: "DataciteDoi").includes(
       :client,
       :media,
       :view_events,

--- a/app/models/other_doi.rb
+++ b/app/models/other_doi.rb
@@ -105,46 +105,13 @@ class OtherDoi < Doi
     count
   end
 
-  def self.import_in_bulk(ids, options = {})
-    index =
-      if Rails.env.test?
-        index_name
-      elsif options[:index].present?
-        options[:index]
-      else
-        inactive_index
-      end
+  def self.upload_to_elasticsearch(index, bulk_body)
+    number_of_dois = bulk_body.length
     errors = 0
-
-    # get database records from array of database ids
-    dois = OtherDoi.includes(
-      :client,
-      :media,
-      :view_events,
-      :download_events,
-      :citation_events,
-      :reference_events,
-      :part_events,
-      :part_of_events,
-      :version_events,
-      :version_of_events,
-      :metadata
-    ).where(id: ids, type: "OtherDoi")
-
     response =
       OtherDoi.__elasticsearch__.client.bulk index: index,
-                                                type:
-                                                  OtherDoi.document_type,
-                                                body:
-                                                  dois.map { |doi|
-                                                    {
-                                                      index: {
-                                                        _id: doi.id,
-                                                        data:
-                                                          doi.as_indexed_json,
-                                                      },
-                                                    }
-                                                  }
+                                             type: OtherDoi.document_type,
+                                             body: bulk_body
 
     # report errors
     if response["errors"]
@@ -158,22 +125,61 @@ class OtherDoi < Doi
 
     if errors > 1
       Rails.logger.error "[Elasticsearch] #{errors} errors importing #{
-                           dois.length
+                          number_of_dois
                          } Other DOIs."
-    elsif dois.length > 0
-      Rails.logger.debug "[Elasticsearch] Imported #{
-                          dois.length
-                        } Other DOIs."
+    elsif number_of_dois > 0
+      Rails.logger.debug "[Elasticsearch] Imported #{number_of_dois} Other DOIs."
     end
 
-    count
+    number_of_dois
   rescue Elasticsearch::Transport::Transport::Errors::RequestEntityTooLarge,
     Aws::SQS::Errors::RequestEntityTooLarge,
     Faraday::ConnectionFailed,
     ActiveRecord::LockWaitTimeout => e
 
-    Rails.logger.error "[Elasticsearch] Error #{e.class} with message #{
-                   e.message
-                 } importing Other DOIs."
+    Rails.logger.error "[Elasticsearch] Error #{e.class} with message #{e.message} importing Other DOIs."
+  end
+
+  def self.import_in_bulk(ids, options = {})
+    # Get optional parameters
+    batch_size = options[:batch_size] || 50
+    # default batch_size is 50 here in order to avoid creating a bulk request
+    # to elasticsearch that is too large
+    # With this the number of ids can be very large.
+
+    index =
+      if Rails.env.test?
+        index_name
+      elsif options[:index].present?
+        options[:index]
+      else
+        inactive_index
+      end
+
+    # get database records from array of database ids
+    selected_dois = OtherDoi.where(id: ids, type: "OtherDoi").includes(
+      :client,
+      :media,
+      :view_events,
+      :download_events,
+      :citation_events,
+      :reference_events,
+      :part_events,
+      :part_of_events,
+      :version_events,
+      :version_of_events,
+      :metadata
+    )
+    selected_dois.find_in_batches(batch_size: batch_size) do |dois|
+      bulk_body = dois.map do |doi|
+        {
+          index: {
+            _id: doi.id,
+            data: doi.as_indexed_json,
+          },
+        }
+      end
+      upload_to_elasticsearch(index, bulk_body)
+    end
   end
 end

--- a/app/models/other_doi.rb
+++ b/app/models/other_doi.rb
@@ -129,7 +129,7 @@ class OtherDoi < Doi
       :version_events,
       :version_of_events,
       :metadata
-    ).where(id: ids)
+    ).where(id: ids, type: "OtherDoi")
 
     response =
       OtherDoi.__elasticsearch__.client.bulk index: index,

--- a/lib/tasks/other_doi.rake
+++ b/lib/tasks/other_doi.rake
@@ -60,7 +60,16 @@ namespace :other_doi do
   task import: :environment do
     from_id = (ENV["FROM_ID"] || OtherDoi.minimum(:id)).to_i
     until_id = (ENV["UNTIL_ID"] || OtherDoi.maximum(:id)).to_i
-    puts OtherDoi.import_by_ids(from_id: from_id, until_id: until_id, index: ENV["INDEX"] || OtherDoi.inactive_index)
+    shard_size = ENV["SHARD_SIZE"]&.to_i || 10_000
+    batch_size = ENV["BATCH_SIZE"]&.to_i || 50
+    selected_index = ENV["INDEX"] || OtherDois.inactive_index
+    puts OtherDoi.import_by_ids(
+      from_id: from_id,
+      until_id: until_id,
+      index: selected_index,
+      shard_size: shard_size,
+      batch_size: batch_size
+    )
   end
 
   desc "Import one other DOI"


### PR DESCRIPTION
## Purpose
This PR introduces a more robust and scalable approach to importing "Other DOIs" into Elasticsearch. Previously, the `import_by_ids` method in `OtherDoi` could lead to large memory consumption and potential failures due to processing all records at once. This change addresses that by implementing a sharding and bulk import strategy.

**Related Issue:** [Link to any relevant issues or tickets]

## Approach
The core idea is to break down the large import task into smaller, manageable chunks. This is achieved by:

1. **Introducing `OtherDoiBulkShardJob`:** A new job that takes a range of `OtherDoi` IDs, shards them, and then enqueues `OtherDoiImportInBulkJob` for each shard.
2. **Refactoring `OtherDoi.import_by_ids`:** This method now leverages the new sharding job, making it more efficient for large datasets.
3. **Refactoring `OtherDoi.import_in_bulk`:** This method now handles a batch of IDs and utilizes a new `upload_to_elasticsearch` helper to perform the actual bulk indexing, improving error handling and logging.
4. **Clarifying `DataciteDoi` queries:** Explicitly adding `type: "DataciteDoi"` to queries to ensure only `DataciteDoi` records are selected when expected.

### Key Modifications

*   **New File:** `app/jobs/other_doi_bulk_shard_job.rb`
    *   Defines `OtherDoiBulkShardJob` to shard DOI IDs and queue `OtherDoiImportInBulkJob`.
*   `app/models/datacite_doi.rb`
    *   Modified `selected_dois` query to explicitly include `type: "DataciteDoi"` for clarity and correctness.
*   `app/models/other_doi.rb`
    *   **`self.import_by_ids`:** This method now queues `OtherDoiBulkShardJob` for defined ranges, rather than processing all IDs directly. Added `shard_size` and `batch_size` parameters.
    *   **New Method:** `self.upload_to_elasticsearch(index, bulk_body)`: A new helper method extracted from `import_in_bulk` to handle the actual Elasticsearch bulk upload and error reporting.
    *   **`self.import_in_bulk`:** Refactored to utilize the `upload_to_elasticsearch` helper and process `OtherDoi` records in batches when retrieving from the database.
*   `lib/tasks/other_doi.rake`
    *   Updated the `import` task to allow specifying `SHARD_SIZE` and `BATCH_SIZE` environment variables, giving users more control over the import process.

### Important Technical Details

*   **Sharding Logic:** `OtherDoiBulkShardJob` divides the total range of `OtherDoi` IDs into smaller "shards" defined by `shard_size`. Within each shard, it further divides the `ids` into `batch_size` chunks for `OtherDoiImportInBulkJob`.
*   **Error Handling:** The `upload_to_elasticsearch` method consolidates error reporting for Elasticsearch bulk operations, providing clearer logging for failures during indexing.
*   **Explicit Type Filtering:** Adding `type: "DataciteDoi"` or `type: "OtherDoi"` to queries when fetching records is crucial for correct behavior given the STI (Single Table Inheritance) setup. This prevents unintended record selection.
*   **Performance Improvement:** By processing DOIs in smaller, more manageable batches and leveraging background jobs, this change significantly reduces the memory footprint and execution time for large imports, making the system more stable and performant.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
