### PR TITLE
Move default ENV settings for tests to test env

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -55,4 +55,56 @@ Rails.application.configure do
   #   Bullet.counter_cache_enable = false
   # end
   config.log_level = :ERROR
+
+  # Set reasonable default environment variables for testing if not already set
+  ENV["TEST_ENV_NUMBER"] ||= "" # For parallel tests, often set by CI, default to empty
+  ENV["ES_PREFIX"] ||= "" # ElasticSearch index prefix
+  ENV["API_KEY"] ||= "test_api_key" # Placeholder for general API key
+  ENV["SESSION_ENCRYPTED_COOKIE_SALT"] ||= "a_strong_secret_key_for_testing_purposes"
+  ENV["VOLPINO_URL"] ||= "http://localhost:3000/api" # Placeholder for Volpino service
+  ENV["HANDLE_USERNAME"] ||= "test_handle_user"
+  ENV["HANDLE_URL"] ||= "https://handle.test.datacite.org"
+  ENV["HANDLE_PASSWORD"] ||= "test_handle_password"
+  ENV["BRACCO_URL"] ||= "http://doi.datacite.org"
+  ENV["BRACCO_TITLE"] ||= "DataCite Fabrica Test"
+  ENV["MAILGUN_API_KEY"] ||= "test_mailgun_api_key"
+  ENV["MG_FROM"] ||= "support@example.com"
+  ENV["MG_DOMAIN"] ||= "mg.example.com"
+  ENV["SLACK_WEBHOOK_URL"] ||= "" # Keep empty if not sending Slack notifications in tests
+  ENV["MDS_USERNAME"] ||= "DATACITE.TESTUSER"
+  ENV["MDS_PASSWORD"] ||= "test_mds_password"
+  ENV["ADMIN_USERNAME"] ||= "DATACITE.TESTADMIN"
+  ENV["ADMIN_PASSWORD"] ||= "test_admin_password"
+  ENV["PRIVATE_IP"] ||= "127.0.0.1" # Placeholder for local testing
+  ENV["ES_HOST"] ||= "elasticsearch:9200" # Assuming a local or test Elasticsearch instance
+  ENV["VCR_MODE"] ||= "once"
+  ENV["VCR"] ||= "once"
+  ENV["AWS_REGION"] ||= "us-east-1" # Placeholder if SQS is used, even if mocked
+  ENV["SQS_PREFIX"] ||= ""
+  ENV["APPLICATION"] ||= "client-api"
+  ENV["HOSTNAME"] ||= "lupo"
+  ENV["MEMCACHE_SERVERS"] ||= "memcached:11211"
+  ENV["SITE_TITLE"] ||= "DataCite REST API"
+  ENV["LOG_LEVEL"] ||= "info"
+  ENV["CONCURRENCY"] ||= "25"
+  ENV["API_URL"] ||= "http://localhost:4000"
+  ENV["CDN_URL"] ||= "http://localhost:9000"
+  ENV["GITHUB_URL"] ||= "https://github.com/datacite/lupo"
+  ENV["SEARCH_URL"] ||= "http://localhost:5000"
+  ENV["RE3DATA_URL"] ||= "https://www.re3data.org/api/beta"
+  ENV["CITEPROC_URL"] ||= "https://citation.crosscite.org/format"
+  ENV["MYSQL_DATABASE"] ||= "lupo_test"
+  ENV["MYSQL_USER"] ||= "root"
+  ENV["MYSQL_PASSWORD"] ||= ""
+  ENV["MYSQL_HOST"] ||= "mysql"
+  ENV["MYSQL_PORT"] ||= "3306"
+  ENV["ES_REQUEST_TIMEOUT"] ||= "120"
+  ENV["ES_NAME"] ||= "elasticsearch"
+  ENV["ES_SCHEME"] ||= "http"
+  ENV["ES_PORT"] ||= "80"
+  ENV["TRUSTED_IP"] ||= "10.0.40.1"
+  ENV["HANDLES_MINTED"] ||= "10132"
+  ENV["REALM"] ||= "http://localhost:4000"
+  ENV["EXCLUDE_PREFIXES_FROM_DATA_IMPORT"] ||= ""
+
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -106,5 +106,4 @@ Rails.application.configure do
   ENV["HANDLES_MINTED"] ||= "10132"
   ENV["REALM"] ||= "http://localhost:4000"
   ENV["EXCLUDE_PREFIXES_FROM_DATA_IMPORT"] ||= ""
-
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,57 +4,6 @@ ENV["RAILS_ENV"] = "test"
 ENV["TEST_CLUSTER_NODES"] = "1"
 ENV["PREFIX_POOL_SIZE"] = "20"
 
-# Set reasonable default environment variables for testing if not already set
-ENV["TEST_ENV_NUMBER"] ||= "" # For parallel tests, often set by CI, default to empty
-ENV["ES_PREFIX"] ||= "" # ElasticSearch index prefix
-ENV["API_KEY"] ||= "test_api_key" # Placeholder for general API key
-ENV["SESSION_ENCRYPTED_COOKIE_SALT"] ||= "a_strong_secret_key_for_testing_purposes"
-ENV["VOLPINO_URL"] ||= "http://localhost:3000/api" # Placeholder for Volpino service
-ENV["HANDLE_USERNAME"] ||= "test_handle_user"
-ENV["HANDLE_URL"] ||= "https://handle.test.datacite.org"
-ENV["HANDLE_PASSWORD"] ||= "test_handle_password"
-ENV["BRACCO_URL"] ||= "http://doi.datacite.org"
-ENV["BRACCO_TITLE"] ||= "DataCite Fabrica Test"
-ENV["MAILGUN_API_KEY"] ||= "test_mailgun_api_key"
-ENV["MG_FROM"] ||= "support@example.com"
-ENV["MG_DOMAIN"] ||= "mg.example.com"
-ENV["SLACK_WEBHOOK_URL"] ||= "" # Keep empty if not sending Slack notifications in tests
-ENV["MDS_USERNAME"] ||= "DATACITE.TESTUSER"
-ENV["MDS_PASSWORD"] ||= "test_mds_password"
-ENV["ADMIN_USERNAME"] ||= "DATACITE.TESTADMIN"
-ENV["ADMIN_PASSWORD"] ||= "test_admin_password"
-ENV["PRIVATE_IP"] ||= "127.0.0.1" # Placeholder for local testing
-ENV["ES_HOST"] ||= "elasticsearch:9200" # Assuming a local or test Elasticsearch instance
-ENV["VCR_MODE"] ||= "once"
-ENV["VCR"] ||= "once"
-ENV["AWS_REGION"] ||= "us-east-1" # Placeholder if SQS is used, even if mocked
-ENV["SQS_PREFIX"] ||= ""
-ENV["APPLICATION"] ||= "client-api"
-ENV["HOSTNAME"] ||= "lupo"
-ENV["MEMCACHE_SERVERS"] ||= "memcached:11211"
-ENV["SITE_TITLE"] ||= "DataCite REST API"
-ENV["LOG_LEVEL"] ||= "info"
-ENV["CONCURRENCY"] ||= "25"
-ENV["API_URL"] ||= "http://localhost:4000"
-ENV["CDN_URL"] ||= "http://localhost:9000"
-ENV["GITHUB_URL"] ||= "https://github.com/datacite/lupo"
-ENV["SEARCH_URL"] ||= "http://localhost:5000"
-ENV["RE3DATA_URL"] ||= "https://www.re3data.org/api/beta"
-ENV["CITEPROC_URL"] ||= "https://citation.crosscite.org/format"
-ENV["MYSQL_DATABASE"] ||= "lupo_test"
-ENV["MYSQL_USER"] ||= "root"
-ENV["MYSQL_PASSWORD"] ||= ""
-ENV["MYSQL_HOST"] ||= "mysql"
-ENV["MYSQL_PORT"] ||= "3306"
-ENV["ES_REQUEST_TIMEOUT"] ||= "120"
-ENV["ES_NAME"] ||= "elasticsearch"
-ENV["ES_SCHEME"] ||= "http"
-ENV["ES_PORT"] ||= "80"
-ENV["TRUSTED_IP"] ||= "10.0.40.1"
-ENV["HANDLES_MINTED"] ||= "10132"
-ENV["REALM"] ||= "http://localhost:4000"
-ENV["EXCLUDE_PREFIXES_FROM_DATA_IMPORT"] ||= ""
-
 # set up Code Climate
 require "simplecov"
 SimpleCov.start


### PR DESCRIPTION
This is because the rails_helper is included before the environments are actually set up, so the default ENV settings are never set, i.e. dotenv not loaded either.

## Purpose
ENV Vars are never set to defaults from the app, i.e. you can't override with .env files

## Approach
Move to test env that is loaded at app setup but only for test env (i.e. specs)

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
