### PR TITLE
Skip Doi model validations when transferring to different client

### DIFF
--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -562,7 +562,7 @@ class DataciteDoisController < ApplicationController
   def update
     @doi = DataciteDoi.where(doi: params[:id]).first
     exists = @doi.present?
-    validate = true
+    should_validate = true
 
     # capture username and password for reuse in the handle system
 
@@ -574,7 +574,7 @@ class DataciteDoisController < ApplicationController
 
         authorize! :transfer, @doi
         @doi.assign_attributes(sanitized_params.slice(:client_id))
-        validate = false
+        should_validate = false
       else
         authorize! :update, @doi
         if sanitized_params[:schema_version].blank?
@@ -598,7 +598,7 @@ class DataciteDoisController < ApplicationController
       authorize! :new, @doi
     end
 
-    if @doi.save(validate: validate)
+    if @doi.save(validate: should_validate)
       options = {}
       options[:include] = @include
       options[:is_collection] = false

--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -562,6 +562,7 @@ class DataciteDoisController < ApplicationController
   def update
     @doi = DataciteDoi.where(doi: params[:id]).first
     exists = @doi.present?
+    validate = true
 
     # capture username and password for reuse in the handle system
 
@@ -573,6 +574,7 @@ class DataciteDoisController < ApplicationController
 
         authorize! :transfer, @doi
         @doi.assign_attributes(sanitized_params.slice(:client_id))
+        validate = false
       else
         authorize! :update, @doi
         if sanitized_params[:schema_version].blank?
@@ -596,7 +598,7 @@ class DataciteDoisController < ApplicationController
       authorize! :new, @doi
     end
 
-    if @doi.save
+    if @doi.save(validate: validate)
       options = {}
       options[:include] = @include
       options[:is_collection] = false

--- a/spec/fixtures/vcr_cassettes/DataciteDoisController/PATCH_/dois/_id/when_we_transfer_a_DOI_as_staff_and_the_DOI_has_a_schema_version_that_is_not_supported/updates_the_client_id.yml
+++ b/spec/fixtures/vcr_cassettes/DataciteDoisController/PATCH_/dois/_id/when_we_transfer_a_DOI_as_staff_and_the_DOI_has_a_schema_version_that_is_not_supported/updates_the_client_id.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://handle.test.datacite.org/api/handles/10.14454/119495
+    body:
+      encoding: UTF-8
+      string: '[{"index":100,"type":"HS_ADMIN","data":{"format":"admin","value":{"handle":"","index":300,"permissions":"111111111111"}}},{"index":1,"type":"URL","data":{"format":"string","value":"http://www.bl.uk/pdf/pat.pdf"}}]'
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/5.0.0; mailto:info@datacite.org)
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Content-Type:
+      - application/json;charset=UTF-8
+      Authorization:
+      - Basic <HANDLE_TOKEN>
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Tue, 08 Jul 2025 10:02:10 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Www-Authenticate:
+      - Basic realm="handle", Handle sessionId="node01nmh70vo7juax1j3s41kxcsdqu1",
+        nonce="s9lRiiv+1+XIb11PTzu2CA==", error="Identity not verified"
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+  recorded_at: Tue, 08 Jul 2025 10:02:10 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/DataciteDoisController/PATCH_/dois/_id/when_we_transfer_a_DOI_as_staff_and_the_client_has_non-matching_domains/updates_the_client_id.yml
+++ b/spec/fixtures/vcr_cassettes/DataciteDoisController/PATCH_/dois/_id/when_we_transfer_a_DOI_as_staff_and_the_client_has_non-matching_domains/updates_the_client_id.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://handle.test.datacite.org/api/handles/10.14454/119495
+    body:
+      encoding: UTF-8
+      string: '[{"index":100,"type":"HS_ADMIN","data":{"format":"admin","value":{"handle":"","index":300,"permissions":"111111111111"}}},{"index":1,"type":"URL","data":{"format":"string","value":"http://www.bl.uk/pdf/pat.pdf"}}]'
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/5.0.0; mailto:info@datacite.org)
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Content-Type:
+      - application/json;charset=UTF-8
+      Authorization:
+      - Basic <HANDLE_TOKEN>
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Tue, 08 Jul 2025 09:52:59 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Www-Authenticate:
+      - Basic realm="handle", Handle sessionId="node01p1gb764nvyf5sm1oujl2z8r40",
+        nonce="t1aWYJvk4XTBCyf2Vz83sw==", error="Identity not verified"
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+  recorded_at: Tue, 08 Jul 2025 09:52:59 GMT
+recorded_with: VCR 6.2.0

--- a/spec/requests/datacite_dois/patch_spec.rb
+++ b/spec/requests/datacite_dois/patch_spec.rb
@@ -658,7 +658,6 @@ describe DataciteDoisController, type: :request, vcr: true do
     context "when we transfer a DOI as staff" do
       let(:doi) { create(:doi, doi: "10.14454/119495", url: "http://www.bl.uk/pdf/pat.pdf", client: client, aasm_state: "registered") }
       let(:new_client) { create(:client, symbol: "#{provider.symbol}.M", provider: provider, password: ENV["MDS_PASSWORD"]) }
-      let(:xml) { Base64.strict_encode64(file_fixture("datacite.xml").read) }
       let(:valid_attributes) do
         {
           "data" => {
@@ -690,7 +689,6 @@ describe DataciteDoisController, type: :request, vcr: true do
     context "when we transfer a DOI as staff and the client has non-matching domains" do
       let(:doi) { create(:doi, doi: "10.14454/119495", url: "http://www.bl.uk/pdf/pat.pdf", client: client, aasm_state: "registered") }
       let(:new_client) { create(:client, symbol: "#{provider.symbol}.M", provider: provider, password: ENV["MDS_PASSWORD"], domains: "datacite.org") }
-      let(:xml) { Base64.strict_encode64(file_fixture("datacite.xml").read) }
       let(:valid_attributes) do
         {
           "data" => {
@@ -726,7 +724,6 @@ describe DataciteDoisController, type: :request, vcr: true do
         d
       end
       let(:new_client) { create(:client, symbol: "#{provider.symbol}.M", provider: provider, password: ENV["MDS_PASSWORD"]) }
-      let(:xml) { Base64.strict_encode64(file_fixture("datacite.xml").read) }
       let(:valid_attributes) do
         {
           "data" => {


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

When transferring DOIs from one repo to another, Doi model validations can sometimes fail for unexpected reasons unrelated to the transfer request. This causes some DOIs not to transfer, affecting staff-initiated transfers and transfers in the Fabrica interface. Primary reasons for transfer failures include:

- The DOI is on a deprecated Schema version (for example, version 3) 
- The new client has `domains` settings that exclude the new DOI. 

To avoid these issues, this PR skips validations when updating only when the transfer mode is set and the update has already passed authorization. 

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
