### PR TITLE
Fix flaky test: Clean DB before run

### DIFF
--- a/spec/requests/repositories_spec.rb
+++ b/spec/requests/repositories_spec.rb
@@ -90,19 +90,19 @@ describe RepositoriesController, type: :request, elasticsearch: true do
       import_index(Client)
     end
 
-    # it "returns repositories" do
-    #   get "/repositories", nil, headers
+    it "returns repositories", trunk_db_before: true do
+      get "/repositories", nil, headers
 
-    #   expect(last_response.status).to eq(200)
-    #   expect(json["data"].size).to eq(4)
-    #   expect(json.dig("meta", "total")).to eq(4)
-    #   expect(json.dig("meta", "providers").length).to eq(4)
-    #   expect(json.dig("meta", "providers").first).to eq(
-    #     "count" => 1,
-    #     "id" => provider.uid,
-    #     "title" => "My provider",
-    #   )
-    # end
+      expect(last_response.status).to eq(200)
+      expect(json["data"].size).to eq(4)
+      expect(json.dig("meta", "total")).to eq(4)
+      expect(json.dig("meta", "providers").length).to eq(4)
+      expect(json.dig("meta", "providers").first).to eq(
+        "count" => 1,
+        "id" => provider.uid,
+        "title" => "My provider",
+      )
+    end
   end
 
   describe "GET /repositories/:id" do

--- a/spec/support/database_cleaner_helper.rb
+++ b/spec/support/database_cleaner_helper.rb
@@ -9,6 +9,10 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :truncation, { pre_count: true }
   end
 
+  config.before(:each, trunk_db_before: true) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
   config.before(:each) { DatabaseCleaner.start }
 
   config.after(:each) { DatabaseCleaner.clean }


### PR DESCRIPTION
## Purpose
This PR addresses an issue where some tests were failing intermittently due to an unclean database state. Specifically, the previously commented-out test `it "returns repositories"` in `spec/requests/repositories_spec.rb` was unreliable due to leftover data from previous test runs.

## Approach
This change re-enables the `it "returns repositories"` test after ensuring a clean database state for that specific test run. This is achieved by introducing a new RSpec tag `trunk_db_before: true` which triggers a `DatabaseCleaner.clean_with(:truncation)` call before the test executes. This guarantees that the test starts with an empty database, preventing contamination from other tests.

### Key Modifications
- **Re-enabled `it "returns repositories"` test:** The previously commented-out test in `spec/requests/repositories_spec.rb` has been uncommented and now runs as part of the test suite.
- **Added `trunk_db_before: true` RSpec tag:** This tag has been added to the re-enabled test.
- **Introduced `config.before(:each, trunk_db_before: true)` hook:** A new `before` hook has been added to `spec/support/database_cleaner_helper.rb` to listen for the `trunk_db_before: true` tag. When this tag is present, `DatabaseCleaner.clean_with(:truncation)` is executed, ensuring a fresh database for the test.

### Important Technical Details
The `DatabaseCleaner.clean_with(:truncation)` strategy removes all data from the database tables. This is a more aggressive cleaning strategy compared to `DatabaseCleaner.start` and `DatabaseCleaner.clean`, which typically use transactions for rollback, and is necessary in cases where tests might leave behind data that interferes with subsequent test runs, especially when running `elasticsearch` tests.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
