### PR TITLE
Stop normalizing rights sub-properties in database and store as a separate field in OpenSearch; use new field for OpenSearch aggregation

### DIFF
--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -150,7 +150,6 @@ class Doi < ApplicationRecord
   before_validation :update_agency
   before_validation :update_field_of_science
   before_validation :update_language, if: :language?
-  # before_validation :update_rights_list, if: :rights_list?
   before_validation :update_identifiers
   before_validation :update_types
   before_save :set_defaults, :save_metadata


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

As described in the [PR335](https://github.com/datacite/product-backlog/issues/335), Stop normalizing rights sub-properties in database and store as a separate field in OpenSearch; use new field for OpenSearch aggregation

closes: datacite/product-backlog#335

## Approach
<!--- _How does this change address the problem?_ -->

Use the suggested implementation in datacite/product-backlog#335. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

This has a checklist as below:

- [ ] Divide this pr into 2 prs.  Move the licenses and licenses_with_missing aggregation into the second pr.  
- [ ] Merge the first pr.
- [ ] Re-index datacite_dois and other_dois.
- [ ] Merge the second pr

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
