### PR TITLE
Add new support task queue

### DIFF
--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -8,6 +8,7 @@ queues:
   - [lupo_import_other_doi, 8]
   - [lupo_transfer, 4]
   - [lupo_background, 2]
+  - [lupo_support, 1]
 
 groups:
   batch_enqueue_group:


### PR DESCRIPTION
This is for jobs that are related to support work, e.g. data migration / fixes They only get called infrequently compared to other queues.

## Purpose

Adds new queue option for tasks that needed by support.
Specifically for my needs I want to put xml storage migration tasks on here.,

## Approach
Add to shorokyun

#### Open Questions and Pre-Merge TODOs
Will also create related queues on S3.

## Learning
N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
