### PR TITLE
Add rake/job for metadata migration

### DIFF
--- a/app/jobs/migrate_metadata_xml_job.rb
+++ b/app/jobs/migrate_metadata_xml_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class MigrateMetadataXmlJob < ApplicationJob
+  queue_as :lupo_support
+
+  def perform(id)
+    Metadata.migrate_xml_by_id(id)
+  end
+end

--- a/lib/tasks/metadata.rake
+++ b/lib/tasks/metadata.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+namespace :metadata do
+  desc "Migrate from stored xml in database to object store (mysql to s3)"
+  task migrate_xml: :environment do
+    from_id = (ENV["FROM_ID"] || Metadata.minimum(:id)).to_i
+    until_id = (ENV["UNTIL_ID"] || Metadata.maximum(:id)).to_i
+
+    # Call a function that will move previous versions to S3
+    puts Metadata.migrate_xml(from_id, until_id)
+  end
+
+  desc "Migrate one record from stored xml in database to object store (mysql to s3)"
+  task migrate_xml_one: :environment do
+    id = ENV["ID"]
+
+    # Call a function that will move previous versions to S3
+    puts Metadata.migrate_xml_by_id(id)
+  end
+end


### PR DESCRIPTION
## Purpose
Rake task to trigger queuing of migration tasks
Rake task for one off migration

## Approach
Use queue for scheduling
Checks for existing object key and if not migrated triggers S3 upload and save.
Skips validation to prevent new versions.

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
