### PR TITLE
Batch enqueue Datacite DOI import tasks

### DIFF
--- a/app/jobs/datacite_doi_batch_enqueue_job.rb
+++ b/app/jobs/datacite_doi_batch_enqueue_job.rb
@@ -1,0 +1,13 @@
+
+# frozen_string_literal: true
+
+class DataciteDoiBatchEnqueueJob < ApplicationJob
+  queue_as :lupo_import
+
+  def perform(start_id, end_id, batch_size: 50, index: nil)
+    ids = DataciteDoi.where(type: "DataciteDoi", id: start_id..end_id).pluck(:id)
+    ids.each_slice(batch_size) do |batch_ids|
+      DataciteDoiImportInBulkJob.perform_later(batch_ids, index: index)
+    end
+  end
+end

--- a/app/jobs/datacite_doi_batch_enqueue_job.rb
+++ b/app/jobs/datacite_doi_batch_enqueue_job.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 class DataciteDoiBatchEnqueueJob < ApplicationJob
-  queue_as :lupo_import
+  queue_as :lupo_queue_batches_datacite_doi
 
   def perform(start_id, end_id, batch_size: 50, index: nil)
     ids = DataciteDoi.where(type: "DataciteDoi", id: start_id..end_id).pluck(:id)


### PR DESCRIPTION
## Purpose
This PR introduces a job for enqueuing Datacite DOI import tasks in batches. This is to address potential issues with job size limits and improve the efficiency of importing large volumes of DataCite DOIs.

## Approach
A new background job, `DataciteDoiBatchEnqueueJob`, has been created. This job is responsible for dividing a range of Datacite DOI IDs into smaller, manageable batches and enqueuing individual `DataciteDoiImportInBulkJob` instances for each batch. The `DataciteDoi.import_by_ids` method has been refactored to utilize this new job.

### Key Modifications
*   **New Job:** `DataciteDoiBatchEnqueueJob` is created to handle the batching and enqueuing of DOI import jobs.
*   **Refactored `DataciteDoi.import_by_ids`:** This method now uses `DataciteDoiBatchEnqueueJob` to process DOIs in chunks, improving scalability.
*   **Conditional Indexing Logic:** The logic for determining the Elasticsearch index during import has been slightly simplified.

### Important Technical Details
*   The `DataciteDoiBatchEnqueueJob` uses the `lupo_queue_batches_datacite_doi` queue.
*   The `shard_size` option in `DataciteDoi.import_by_ids` controls the range of IDs processed by each `DataciteDoiBatchEnqueueJob`. This helps in managing the number of jobs enqueued at once.
*   The `batch_size` option within `DataciteDoiBatchEnqueueJob` controls how many DOIs are processed by each individual `DataciteDoiImportInBulkJob`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
