### PR TITLE
Add destroy hook for metadata object store

### DIFF
--- a/app/models/metadata.rb
+++ b/app/models/metadata.rb
@@ -117,6 +117,10 @@ class Metadata < ApplicationRecord
   end
 
   def fetch_xml_from_s3
+    if not ENV["METADATA_STORAGE_BUCKET_NAME"].present?
+      return nil
+    end
+
     bucket_name = ENV["METADATA_STORAGE_BUCKET_NAME"]
     object = Aws::S3::Object.new(bucket_name, object_key)
 

--- a/spec/models/metadata_spec.rb
+++ b/spec/models/metadata_spec.rb
@@ -13,6 +13,18 @@ describe Metadata, type: :model, vcr: true do
     it { should validate_presence_of(:namespace) }
   end
 
+  describe "clean up" do
+    it "When destroy is run on metadata, remote object is deleted too" do
+      metadata = Metadata.create(xml: xml, doi: doi)
+
+      saved_xml = metadata.fetch_xml_from_s3
+      expect(saved_xml).not_to eq(nil)
+      metadata.destroy
+      saved_xml = metadata.fetch_xml_from_s3
+      expect(saved_xml).to eq(nil)
+    end
+  end
+
   describe "associations" do
     it { should belong_to(:doi).with_foreign_key(:dataset).inverse_of(:metadata) }
   end

--- a/spec/models/metadata_spec.rb
+++ b/spec/models/metadata_spec.rb
@@ -14,7 +14,7 @@ describe Metadata, type: :model, vcr: true do
   end
 
   describe "clean up" do
-    it "When destroy is run on metadata, remote object is deleted too" do
+    it("When destroy is run on metadata, remote object is deleted too", if: ENV["METADATA_STORAGE_BUCKET_NAME"].present?) do
       metadata = Metadata.create(xml: xml, doi: doi)
 
       saved_xml = metadata.fetch_xml_from_s3


### PR DESCRIPTION
If a destroy its called we don't want to leave the object dangling in S3(ObjectStore).

## Purpose
To avoid leaving data that has no relation in the database on S3.

In general this isn't a common action but we may need to handle deletes in certain scenarios (most likely test/stage)

## Approach
By adding a hook that then deletes if it exists.

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
