### PR TITLE
Add datacite batch enqueue group to shoryuken config

### DIFF
--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -11,7 +11,12 @@ queues:
   - [lupo_support, 1]
 
 groups:
-  batch_enqueue_group:
+  batch_enqueue_other_group:
     concurrency: 1
     queues:
       - lupo_queue_batches_other_doi
+  batch_enqueue_datacite_group:
+    concurrency: 1
+    queues:
+      - lupo_queue_batches_datacite_doi
+


### PR DESCRIPTION
## Purpose

This PR introduces changes to the Shoryuken configuration file to accommodate new queue groups. Specifically, it adds a new group named `batch_enqueue_datacite_group` which will process messages from the `lupo_queue_batches_datacite_doi` queue.

## Approach

The `config/shoryuken.yml` file has been updated to include a new entry under the `groups` section for `batch_enqueue_datacite_group`. This new group is configured with a concurrency of 1 and specifies `lupo_queue_batches_datacite_doi` as its queue.

### Key Modifications

*   Added `batch_enqueue_datacite_group` to `config/shoryuken.yml`.
*   Configured `batch_enqueue_datacite_group` with a concurrency of 1.
*   Assigned `lupo_queue_batches_datacite_doi` to `batch_enqueue_datacite_group`.
*   Renamed `batch_enqueue_group` to `batch_enqueue_other_group` to better reflect its purpose.

### Important Technical Details

The change involves modifying a YAML configuration file, which is a standard practice for configuring Shoryuken worker groups and their associated queues and concurrency settings.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)


- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
