### PR TITLE
Fix: Sync indices during reindex with `index_sync_enabled?`

### DIFF
--- a/app/jobs/index_job_doi_registration.rb
+++ b/app/jobs/index_job_doi_registration.rb
@@ -10,8 +10,19 @@ class IndexJobDoiRegistration < ApplicationJob
     Rails.logger.error error.message
   end
 
+  def index_sync_enabled?(obj)
+    if Rails.env.test?
+      return false
+    end
+    obj.respond_to?(:index_sync_enabled?) && obj.index_sync_enabled?
+  end
+
   def perform(obj)
     response = obj.__elasticsearch__.index_document
     Rails.logger.error "[Elasticsearch] Error #{response.inspect}" unless %w(created updated).include?(response["result"])
+    if index_sync_enabled?(obj)
+      response2 = obj.__elasticsearch__.index_document(index: obj.inactive_index)
+      Rails.logger.error "[Elasticsearch] Error #{response2.inspect}" unless %w(created updated).include?(response2["result"])
+    end
   end
 end

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -2491,6 +2491,14 @@ class Doi < ApplicationRecord
     read_attribute("publisher_obj")
   end
 
+  def index_sync_enabled?
+    self.__class__.index_sync_enabled?
+  end
+
+  def self.index_sync_enabled?
+    Rails.cache.read("INDEX_SYNC_ENABLED") == true
+  end
+
   def self.repair_landing_page(id: nil)
     if id.blank?
       Rails.logger.error "[Error] No id provided."

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -2496,7 +2496,7 @@ class Doi < ApplicationRecord
   end
 
   def self.index_sync_enabled?
-    Rails.cache.read("INDEX_SYNC_ENABLED") == true
+    AppSettings.index_sync_enabled?
   end
 
   def self.repair_landing_page(id: nil)

--- a/app/services/app_settings.rb
+++ b/app/services/app_settings.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AppSettings
+  # Use a constant to avoid magic strings scattered in your code
+  INDEX_SYNC_KEY = "INDEX_SYNC_ENABLED".freeze
+
+  # Define all methods on the class itself for easy access
+  class << self
+    def index_sync_enabled?
+      Rails.cache.read(INDEX_SYNC_KEY) == true
+    end
+
+    def enable_index_sync!
+      Rails.cache.write(INDEX_SYNC_KEY, true)
+    end
+
+    def disable_index_sync!
+      Rails.cache.write(INDEX_SYNC_KEY, false)
+    end
+  end
+end

--- a/lib/tasks/index_sync.rake
+++ b/lib/tasks/index_sync.rake
@@ -1,20 +1,19 @@
 namespace :index_sync do
   desc "Enables index syncing by setting the cache flag to true"
   task enable: :environment do
-    Rails.cache.write("INDEX_SYNC_ENABLED", true)
+    AppSettings.enable_index_sync!
     puts "✅ Index syncing has been ENABLED."
   end
 
   desc "Disables index syncing by setting the cache flag to false"
   task disable: :environment do
-    Rails.cache.write("INDEX_SYNC_ENABLED", false)
+    AppSettings.disable_index_sync!
     puts "❌ Index syncing has been DISABLED."
   end
 
   desc "Checks the current status of the index sync flag"
   task status: :environment do
-    is_enabled = Rails.cache.read("INDEX_SYNC_ENABLED") == true
-    if is_enabled
+    if AppSettings.index_sync_enabled?
       puts "🟢 Index syncing is currently ENABLED."
     else
       puts "🔴 Index syncing is currently DISABLED."

--- a/lib/tasks/index_sync.rake
+++ b/lib/tasks/index_sync.rake
@@ -1,0 +1,23 @@
+namespace :index_sync do
+  desc "Enables index syncing by setting the cache flag to true"
+  task enable: :environment do
+    Rails.cache.write("INDEX_SYNC_ENABLED", true)
+    puts "✅ Index syncing has been ENABLED."
+  end
+
+  desc "Disables index syncing by setting the cache flag to false"
+  task disable: :environment do
+    Rails.cache.write("INDEX_SYNC_ENABLED", false)
+    puts "❌ Index syncing has been DISABLED."
+  end
+
+  desc "Checks the current status of the index sync flag"
+  task status: :environment do
+    is_enabled = Rails.cache.read("INDEX_SYNC_ENABLED") == true
+    if is_enabled
+      puts "🟢 Index syncing is currently ENABLED."
+    else
+      puts "🔴 Index syncing is currently DISABLED."
+    end
+  end
+end

--- a/spec/services/app_settings_spec.rb
+++ b/spec/services/app_settings_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe AppSettings, type: :service do
+  # Define a constant for the cache key to avoid repeating the "magic string"
+  let(:cache_key) { AppSettings::INDEX_SYNC_KEY }
+
+  # IMPORTANT: Before each individual test (`it` block), clear the cache.
+  # This ensures that tests are isolated and don't affect each other.
+  before do
+    Rails.cache.clear
+  end
+
+  describe '.index_sync_enabled?' do
+    context 'when the cache is set to true' do
+      it 'returns true' do
+        Rails.cache.write(cache_key, true)
+        expect(described_class.index_sync_enabled?).to be(true)
+      end
+    end
+
+    context 'when the cache is set to false' do
+      it 'returns false' do
+        Rails.cache.write(cache_key, false)
+        expect(described_class.index_sync_enabled?).to be(false)
+      end
+    end
+
+    context 'when the cache key is not set (nil)' do
+      it 'returns false' do
+        # We don't write anything to the cache, so it's nil
+        expect(described_class.index_sync_enabled?).to be(false)
+      end
+    end
+
+    context 'when the cache contains a non-boolean "truthy" value' do
+      it 'returns false because it performs a strict boolean check' do
+        # This test ensures that we aren't accidentally treating strings
+        # or numbers as true.
+        Rails.cache.write(cache_key, 'true')
+        expect(described_class.index_sync_enabled?).to be(false)
+      end
+    end
+  end
+
+  describe '.enable_index_sync!' do
+    it 'writes `true` to the cache' do
+      # We don't care about the return value, we care about the side effect.
+      described_class.enable_index_sync!
+      expect(Rails.cache.read(cache_key)).to be(true)
+    end
+
+    it 'changes the value from false to true' do
+      Rails.cache.write(cache_key, false)
+
+      # The `change` matcher is a great way to test side effects.
+      # It checks the value of the block before and after the code runs.
+      expect {
+        described_class.enable_index_sync!
+      }.to change { Rails.cache.read(cache_key) }.from(false).to(true)
+    end
+  end
+
+  describe '.disable_index_sync!' do
+    it 'writes `false` to the cache' do
+      described_class.disable_index_sync!
+      expect(Rails.cache.read(cache_key)).to be(false)
+    end
+
+    it 'changes the value from true to false' do
+      Rails.cache.write(cache_key, true)
+
+      expect {
+        described_class.disable_index_sync!
+      }.to change { Rails.cache.read(cache_key) }.from(true).to(false)
+    end
+  end
+end


### PR DESCRIPTION
## Purpose
This PR addresses an issue where indices can become out of sync during large-scale reindexing operations by introducing a mechanism to control index synchronization. The core of this change revolves around the `index_sync_enabled?` flag.

## Approach
The change introduces a new service, `AppSettings`, to manage the `index_sync_enabled?` flag, which is stored in the Rails cache. The `IndexJobDoiRegistration` job now checks this flag before performing a secondary indexing operation. If the flag is enabled, the DOI is indexed into its inactive index as well, ensuring that both the active and inactive indices are synchronized. A new rake task is also added to easily enable, disable, and check the status of index syncing.

### Key Modifications

*   **`IndexJobDoiRegistration`:** Modified to include a check for `index_sync_enabled?` on the object being indexed. If enabled, it performs an additional `index_document` call targeting the object's inactive index.
*   **`Doi` Model:** Added `index_sync_enabled?` instance and class methods for easier access to the synchronization status.
*   **`AppSettings` Service:** New service created to manage the `INDEX_SYNC_ENABLED` flag in the Rails cache, providing methods to enable, disable, and check its status.
*   **`lib/tasks/index_sync.rake`:** New rake task file added to provide commands for managing the index sync status (`enable`, `disable`, `status`).
*   **`spec/services/app_settings_spec.rb`:** Added comprehensive tests for the `AppSettings` service to ensure correct behavior of the index sync flag management.

### Important Technical Details

*   The `index_sync_enabled?` check in `IndexJobDoiRegistration` is bypassed in the test environment to prevent unintended behavior during tests.
*   The `AppSettings` service uses `Rails.cache` to persist the `INDEX_SYNC_ENABLED` flag.
*   The `AppSettings.index_sync_enabled?` method performs a strict boolean comparison (`== true`) to ensure that only explicitly `true` values enable synchronization. Any other value (including `nil` or string "true") will result in `false`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)


- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
