### PR TITLE
Add rake task to delete dois for a client

### DIFF
--- a/lib/tasks/client.rake
+++ b/lib/tasks/client.rake
@@ -209,4 +209,45 @@ namespace :client do
       puts "Client prefix for client #{target.symbol} and prefix #{prefix} created."
     end
   end
+
+  desc "Delete client DOIs within a given date range"
+  task delete_client_dois: :environment do
+    # eg. CLIENT_ID='DATACITE.TEST' START_DATE=2025-09-01 END_DATE=2025-09-30 bin/rake client:delete_client_dois
+
+    client_id  = ENV["CLIENT_ID"]
+    start_date = ENV["START_DATE"]
+    end_date   = ENV["END_DATE"]
+
+    abort "ENV['CLIENT_ID'] is required." if client_id.blank?
+    abort "ENV['START_DATE'] and ENV['END_DATE'] are required." if start_date.blank? || end_date.blank?
+
+    begin
+      client = Client.find_by!(symbol: client_id)
+    rescue ActiveRecord::RecordNotFound
+      abort "Client not found for client ID #{client_id}."
+    end
+
+    begin
+      start_date = Date.parse(start_date).beginning_of_day
+      end_date   = Date.parse(end_date).end_of_day
+    rescue ArgumentError => e
+      abort "Invalid date provided: #{e.message}"
+    end
+
+    dois = client.dois.where(created_at: start_date..end_date)
+    total = dois.count
+
+    puts "Found #{total} DOIs for client #{client.symbol} between #{start_date} and #{end_date}."
+
+    deleted = 0
+    dois.find_in_batches(batch_size: 1000) do |batch|
+      batch.each do |doi|
+        doi.destroy
+        deleted += 1
+      end
+      puts "Deleted #{deleted}/#{total} DOIs"
+    end
+
+    puts "Deleted #{deleted} DOIs for client #{client.symbol}."
+  end
 end


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
Remove DiSSCo Doi records from the test system and reduce storage ceiling

closes: https://github.com/datacite/product-backlog/issues/423

## Approach
<!--- _How does this change address the problem?_ -->
Create a rake task that takes client_id(symbol), start and end date, and delete dois for that client within the date range 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->
- [ ] Notify DiSSCo that the records will be removed and suggest a timeframe. 
- [ ] In the agreed timeframe, remove the records from the database and OpenSearch. 
- [ ] Reduce the storage ceiling for OpenSearch in test.

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
