### PR TITLE
Remove validation when hiding DOIs

### DIFF
--- a/app/jobs/hide_job.rb
+++ b/app/jobs/hide_job.rb
@@ -8,7 +8,7 @@ class HideJob < ApplicationJob
 
     if doi.present?
       doi.hide
-      doi.save(:validate => false)
+      doi.save(validate: false)
       Rails.logger.error "DOI hidden" + doi_id + "."
     else
       Rails.logger.error "Error hiding DOI " + doi_id + ": not found"


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

HideJob is used in rake task `prefix:delete` to hide DOIs associated with a deleted prefix. If records don't pass validation on save—for example, if they're on Schema 3 or use an incorrect URL for the repository rules—manual cleanup is necessary. This PR removes validation in HideJob so the `doi.hide` action is saved consistently and the DOI transitions to registered state despite validation issues. 

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
