### PR TITLE
Add missing resource-type-id options to openapi.yaml

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -424,6 +424,7 @@ paths:
               type: string
               enum:
                 - audiovisual
+                - award
                 - book
                 - book-chapter
                 - collection
@@ -444,6 +445,7 @@ paths:
                 - peer-review
                 - physical-object
                 - preprint
+                - project
                 - report
                 - service
                 - software


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->


## Approach
<!--- _How does this change address the problem?_ -->
- Add "award" and "project" (from schema 4.6) to the resource-type-id list for get /dois in openapi.yaml

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
