### PR TITLE
Skip client domains and Schema version validation when importing metadata from XML

### DIFF
--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -79,6 +79,9 @@ class Doi < ApplicationRecord
   attribute :should_validate, :boolean, default: false
   attribute :publisher, :string, default: nil
 
+  attr_accessor :skip_client_domains_validation
+  attr_accessor :skip_schema_version_validation
+
   belongs_to :client, foreign_key: :datacentre, optional: true
   has_many :media, -> { order "created DESC" }, foreign_key: :dataset, dependent: :destroy, inverse_of: :doi
   has_many :metadata, -> { order "created DESC" }, foreign_key: :dataset, dependent: :destroy, inverse_of: :doi
@@ -124,7 +127,7 @@ class Doi < ApplicationRecord
   validates_inclusion_of :agency, in: %w(datacite crossref kisti medra istic jalc airiti cnki op), allow_blank: true
   validates :last_landing_page_status, numericality: { only_integer: true }, if: :last_landing_page_status?
   validates :xml, presence: true, xml_schema: true, if: Proc.new { |doi| doi.validatable? }
-  validate :check_url, if: Proc.new { |doi| doi.is_registered_or_findable? }
+  validate :check_url, if: Proc.new { |doi| doi.is_registered_or_findable? && !skip_client_domains_validation }
   validate :check_dates, if: :dates?
   validate :check_rights_list, if: :rights_list?
   validate :check_titles, if: :titles?
@@ -1347,6 +1350,7 @@ class Doi < ApplicationRecord
     end.to_h.merge(schema_version: meta["schema_version"] || "http://datacite.org/schema/kernel-4", xml: string, version: doi.version.to_i + 1)
 
     # update_attributes will trigger validations and Elasticsearch indexing
+    attrs = attrs.merge(skip_client_domains_validation: true, skip_schema_version_validation: true)
     doi.update(attrs)
     message = "[MySQL] Imported metadata for DOI " + doi.doi + "."
     Rails.logger.info message

--- a/app/validators/xml_schema_validator.rb
+++ b/app/validators/xml_schema_validator.rb
@@ -48,7 +48,7 @@ class XmlSchemaValidator < ActiveModel::EachValidator
       http://datacite.org/schema/kernel-3
     ]
 
-    if invalid_schemas.include?(record.schema_version)
+    if invalid_schemas.include?(record.schema_version) && !record.skip_schema_version_validation
       record.errors.add(:xml, "DOI #{record.uid}: Schema #{record.schema_version} is no longer supported")
       return false
     end

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -2150,4 +2150,58 @@ describe Doi, type: :model, vcr: true, elasticsearch: false, prefix_pool_size: 1
       expect(coverage_date["date"]).to eq("2020-03-15")
     end
   end
+
+  describe "Importing XML metadata" do
+    let(:schema_3_xml) { file_fixture("datacite_schema_3.xml").read }
+    let(:client) { create(:client) }
+    let(:doi) { create(:doi, aasm_state: "findable", client: client) }
+
+    it "updates values when DOI url is invalid against client domains settings" do
+      correct_types = doi.types
+      incorrect_types = {
+        "resourceTypeGeneral": "Project",
+        "resourceType": "New Project",
+        "schemaOrg": "Dataset",
+        "citeproc": "dataset",
+        "bibtex": "misc",
+        "ris": "DATA",
+      }
+      # Update DOI types column to contain metadata mismatched with XML
+      doi.update_column(:types, incorrect_types)
+      expect(doi.types.symbolize_keys).to eq(incorrect_types.symbolize_keys)
+
+      # Invalidate the URL against client domains setting
+      client.domains = "datacite.org"
+      client.save!
+
+      # Re-import XML to assign correct types metadata values
+      Doi.import_one(doi_id: doi.doi)
+      doi.reload
+      expect(doi.types.symbolize_keys).to eq(correct_types.symbolize_keys)
+    end
+
+    it "updates values when DOI is using an invalid Schema version" do
+      correct_types = doi.types
+      incorrect_types = {
+        "resourceTypeGeneral": "Project",
+        "resourceType": "New Project",
+        "schemaOrg": "Dataset",
+        "citeproc": "dataset",
+        "bibtex": "misc",
+        "ris": "DATA",
+      }
+      # Update DOI types column to contain metadata mismatched with XML
+      doi.update_column(:types, incorrect_types)
+      expect(doi.types.symbolize_keys).to eq(incorrect_types.symbolize_keys)
+
+      # Invalidate the Schema version
+      doi.xml = schema_3_xml
+      doi.save!(validate: false)
+
+      # Re-import XML to assign correct types metadata values
+      Doi.import_one(doi_id: doi.doi)
+      doi.reload
+      expect(doi.types.symbolize_keys).to eq(correct_types.symbolize_keys)
+    end
+  end
 end


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

When using `Doi.import_one` to refresh JSON metadata from XML, the operation would silently fail if the record was invalid. While this might be an appropriate behavior for some fields, it is an obstacle to importing DOIs on Schema 3 and below and DOIs that may not have URLs that are valid against their `client.domains`. This PR skips these two validations when importing.

Needed to remediate issues like the following:

- https://github.com/datacite/datacite/issues/2441
- https://github.com/datacite/datacite/issues/2443

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
