### PR TITLE
FIX: Add Sentry logging to doi deletion rake task 

### DIFF
--- a/lib/tasks/client.rake
+++ b/lib/tasks/client.rake
@@ -251,10 +251,8 @@ namespace :client do
     deleted = 0
     dois.find_in_batches(batch_size: 1000) do |batch|
       batch.each do |doi|
-        begin
-          ActiveRecord::Base.logger.silence do
-            doi.destroy
-          end
+        ActiveRecord::Base.logger.silence do
+          doi.destroy
           deleted += 1
         rescue => error
           Sentry.capture_exception(error, extra: { doi: doi.doi })


### PR DESCRIPTION
## Purpose
We keep having issues with the rake task when it fails it halts the task and we have to start it again.

closes: _Add github issue that originated this PR_

## Approach
Catch all errors and send to Sentry.
Silence all loggers from the deletion, they where making the console noisy.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
