### PR TITLE
Feat: Control fail-fast behavior in parallel CI

### DIFF
--- a/.github/workflows/parallel_ci.yml
+++ b/.github/workflows/parallel_ci.yml
@@ -1,12 +1,18 @@
 name: Parallel CI
 on:
   workflow_call:
+    inputs:
+      fail-fast:
+        description: 'Stop all jobs if any job fails'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   parallel-test:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: ${{ inputs.fail-fast }}
       matrix:
         # set N-1 indexes for parallel jobs
         # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
@@ -106,5 +112,9 @@ jobs:
           CI_NODE_INDEX: ${{ matrix.ci_node_index }}
           RAILS_ENV: test
         run: |
-          bundle exec parallel_test spec/ -n $CI_NODE_TOTAL --only-group $CI_NODE_INDEX --type rspec -o "--fail-fast"
+          if [ "${{ inputs.fail-fast }}" = "true" ]; then
+            bundle exec parallel_test spec/ -n $CI_NODE_TOTAL --only-group $CI_NODE_INDEX --type rspec -o "--fail-fast"
+          else
+            bundle exec parallel_test spec/ -n $CI_NODE_TOTAL --only-group $CI_NODE_INDEX --type rspec
+          fi
           echo $?

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,12 @@ on:
     branches:
       - master
   workflow_dispatch:
+    inputs:
+      fail-fast:
+        description: 'Stop all jobs if any job fails'
+        type: boolean
+        default: true
+        required: false
 jobs:
   lint:
     uses: ./.github/workflows/rubocop.yml
@@ -11,3 +17,5 @@ jobs:
     needs: lint
     uses: ./.github/workflows/parallel_ci.yml
     secrets: inherit
+    with:
+      fail-fast: ${{ github.event_name == 'workflow_dispatch' && inputs.fail-fast || !contains(github.event.pull_request.labels.*.name, 'run-all-tests') }}


### PR DESCRIPTION
## Purpose
This PR introduces the ability to control the `fail-fast` behavior of the parallel CI workflow. Previously, `fail-fast` was hardcoded
to `true`, meaning all jobs would stop as soon as one failed. This change allows for this behavior to be optionally disabled, providing more flexibility in how CI jobs are executed.

## Approach
The `parallel_ci.yml` workflow has been updated to accept a `fail-fast` input. This input is then used to configure the `fail-fast` strategy within the `parallel_test` job.

Additionally, the `pull_request.yml` workflow has been modified to pass the `fail-fast` input to the `parallel_ci.yml` workflow. The logic for this is as follows:
- If the workflow is triggered by `workflow_dispatch` and the `fail-fast` input is provided, that value will be used.
- Otherwise, `fail-fast` will be enabled (`true`) unless the pull request has a label named `run-all-tests`. This allows users to opt-in to running all tests even if one fails by adding the `run-all-tests` label to their PR.

### Key Modifications
*   Added `fail-fast` input to `.github/workflows/parallel_ci.yml`.
*   Configured `parallel_test` job in `parallel_ci.yml` to use the `fail-fast` input.
*   Modified `pull_request.yml` to conditionally pass the `fail-fast` input to `parallel_ci.yml`.

### Important Technical Details
*   The `fail-fast` behavior for the `parallel_test` job is now controlled by the `inputs.fail-fast` variable in `parallel_ci.yml`.
*   In `pull_request.yml`, the `with` clause for the `parallel_ci.yml` job dynamically sets the `fail-fast` value based on the event trigger and PR labels.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [X] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
