### PR TITLE
Change passenger metrics resolution

### DIFF
--- a/vendor/docker/passenger-metrics.sh
+++ b/vendor/docker/passenger-metrics.sh
@@ -11,7 +11,7 @@ SERVER_NAME="${SERVERNAME:-unknown}"
 # Set up global variables
 NAMESPACE="Custom/LupoPassenger"
 SERVICE_NAME="${SERVER_NAME%.datacite.org}" # client-api.datacite.org -> client-api
-INTERVAL=15
+INTERVAL=30
 
 log() {
   echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] passenger-metrics: $*" >&2
@@ -32,7 +32,6 @@ publish_metrics() {
   aws cloudwatch put-metric-data \
     --region "$AWS_REGION" \
     --namespace "$NAMESPACE" \
-    --storage-resolution 1 \
     --metric-data \
       "MetricName=PassengerMaxWorkers,Value=${max_workers},Unit=Count,Timestamp=${timestamp},Dimensions=[{Name=Service,Value=${SERVICE_NAME}}]" \
       "MetricName=PassengerCurrentWorkers,Value=${current_workers},Unit=Count,Timestamp=${timestamp},Dimensions=[{Name=Service,Value=${SERVICE_NAME}}]" \


### PR DESCRIPTION
For high resolution metrics, CloudWatch only retains them for a couple of hours (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Metric) this is insufficient for our needs, so this PR switches the passenger scripts to publish the metrics as the "standard" resolution 1-minute metric type.

Since each container needs to report _at least once_ per minute, the script interval is also changed to 30 seconds, removing 2 (or 3, depending on exact timing of the script run) calls to CloudWatch per minute.

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
