### PR TITLE
Json schema tweaks

### DIFF
--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -154,8 +154,6 @@ class Doi < ApplicationRecord
   validate :check_language, if: :language?
 
   # JSON-SCHEMA VALIDATION
-  # temporarily commenting out this validation.
-  validates :identifier, if: proc { |doi| doi.validate_json_attribute?(:identifier) }, json: { message: ->(errors) { errors }, schema: lambda { schema_file_path("identifier") } }, unless: :only_validate
   validates :creators, if: proc { |doi| doi.validate_json_attribute?(:creators) }, json: { message: ->(errors) { errors }, schema: lambda { schema_file_path("creators") } }, unless: :only_validate
   validates :titles, if: proc { |doi| doi.validate_json_attribute?(:titles) }, json: { message: ->(errors) { errors }, schema: lambda { schema_file_path("titles") } }, unless: :only_validate
   validates :publisher_obj, if: proc { |doi| doi.validate_json_attribute?(:publisher_obj) }, json: { message: ->(errors) { errors }, schema: lambda { schema_file_path("publisher") } }, unless: :only_validate
@@ -163,7 +161,7 @@ class Doi < ApplicationRecord
   validates :subjects, if: proc { |doi| doi.validate_json_attribute?(:subjects) }, json: { message: ->(errors) { errors }, schema: lambda { schema_file_path("subjects") } }, unless: :only_validate
   validates :contributors, if: proc { |doi| doi.validate_json_attribute?(:contributors) }, json: { message: ->(errors) { errors }, schema: lambda { schema_file_path("contributors") } }, unless: :only_validate
   validates :dates, if: proc { |doi| doi.validate_json_attribute?(:dates) }, json: { message: ->(errors) { errors }, schema: lambda { schema_file_path("dates") } }, unless: :only_validate
-  validates :alternate_identifiers, if: proc { |doi| doi.validate_json_attribute?(:alternate_identifiers) }, json: { message: ->(errors) { errors }, schema: lambda { schema_file_path("alternate_identifiers") } }, unless: :only_validate
+  validates :identifiers, if: proc { |doi| doi.validate_json_attribute?(:identifiers) }, json: { message: ->(errors) { errors }, schema: lambda { schema_file_path("alternate_identifiers") } }, unless: :only_validate
   validates :related_identifiers, if: proc { |doi| doi.validate_json_attribute?(:related_identifiers) }, json: { message: ->(errors) { errors }, schema: lambda { schema_file_path("related_identifiers") } }, unless: :only_validate
   validates :sizes, if: proc { |doi| doi.validate_json_attribute?(:sizes) }, json: { message: ->(errors) { errors }, schema: lambda { schema_file_path("sizes") } }, unless: :only_validate
   validates :formats, if: proc { |doi| doi.validate_json_attribute?(:formats) }, json: { message: ->(errors) { errors }, schema: lambda { schema_file_path("formats") } }, unless: :only_validate
@@ -173,24 +171,16 @@ class Doi < ApplicationRecord
   validates :geolocations, if: proc { |doi| doi.validate_json_attribute?(:geolocations) }, json: { message: ->(errors) { errors }, schema: lambda { schema_file_path("geolocations") } }, unless: :only_validate
   validates :funding_references, if: proc { |doi| doi.validate_json_attribute?(:funding_references) }, json: { message: ->(errors) { errors }, schema: lambda { schema_file_path("funding_references") } }, unless: :only_validate
   validates :related_items, if: proc { |doi| doi.validate_json_attribute?(:related_items) }, json: { message: ->(errors) { errors }, schema: lambda { schema_file_path("related_items") } }, unless: :only_validate
+  validates :types, if: proc { |doi| doi.validate_json_attribute?(:types) }, json: { message: ->(errors) { errors }, schema: lambda { schema_file_path("resource_type") } }, unless: :only_validate
 
   validates :raw_language, presence: true, if: proc { |doi| doi.validate_json_attribute?(:raw_language) }, json: {
     message: ->(errors) { errors },
     schema: lambda { schema_file_path("language") }
   }, unless: :only_validate
 
-  validates :raw_types, if: proc { |doi| doi.validate_json_attribute?(:raw_types) }, json: {
-    message: ->(errors) { errors },
-    schema: lambda { schema_file_path("resource_type") },
-  }, unless: :only_validate
-
   # See https://github.com/mirego/activerecord_json_validator for an explanation of why this must be done.
   def raw_language
     self[:language]
-  end
-
-  def raw_types
-    self[:types]
   end
 
   after_commit :update_url, on: %i[create update]
@@ -199,7 +189,6 @@ class Doi < ApplicationRecord
   before_validation :update_publisher, if: [ :will_save_change_to_publisher? ]
   before_validation :update_xml, if: :regenerate
   before_validation :update_agency
-  before_validation :update_field_of_science
   before_validation :update_language, if: :language?
   before_validation :update_rights_list, if: :rights_list?
   before_validation :update_identifiers
@@ -2622,18 +2611,6 @@ class Doi < ApplicationRecord
       elsif language.match?(/^[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*$/)
         language
       end
-  end
-
-  def update_field_of_science
-    self.subjects = Array.wrap(subjects).reduce([]) do |sum, subject|
-      if subject.is_a?(String)
-        sum += name_to_fos(subject)
-      elsif subject.is_a?(Hash)
-        sum += hsh_to_fos(subject)
-      end
-
-      sum
-    end.uniq
   end
 
   def update_rights_list

--- a/app/models/schemas/doi/affiliation.json
+++ b/app/models/schemas/doi/affiliation.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "name": {
-      "$ref": "definitions.json#/$defs/nonemptycontentStringType"
+      "type": "string"
     },
     "affiliationIdentifier": {
       "type": "string"

--- a/app/models/schemas/doi/alternate_identifier.json
+++ b/app/models/schemas/doi/alternate_identifier.json
@@ -4,13 +4,12 @@
   "description": "An identifier or identifiers other than the primary Identifier applied to the resource being registered. This may be any alphanumeric string which is unique within its domain of issue. May be used for local identifiers. AlternateIdentifier should be used for another identifier of the same instance (same location, same file).",
   "type": "object",
   "properties": {
-    "alternateIdentifier": {
-      "type": "string"
+    "identifier": {
+      "type": ["string", "null"]
     },
-    "alternateIdentifierType": {
-      "type": "string"
+    "identifierType": {
+      "type": ["string", "null"]
     }
   },
-  "required": ["alternateIdentifierType"],
   "additionalProperties": false
 }

--- a/app/models/schemas/doi/resource_type.json
+++ b/app/models/schemas/doi/resource_type.json
@@ -10,9 +10,8 @@
       "$ref": "controlled_vocabularies/resource_type_general.json" 
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
-    "resourceType",
     "resourceTypeGeneral"
   ]
 }

--- a/app/models/schemas/doi/subject.json
+++ b/app/models/schemas/doi/subject.json
@@ -23,8 +23,5 @@
         "$ref": "definitions.json#/$defs/language"
       }
     },
-    "required": [
-      "subject"
-    ],
     "additionalProperties": false
 }

--- a/app/models/schemas/doi/title.json
+++ b/app/models/schemas/doi/title.json
@@ -14,8 +14,5 @@
       "$ref": "definitions.json#/$defs/language"
     }
   },
-  "additionalProperties": false,
-  "required": [
-    "title"
-  ]
+  "additionalProperties": false
 }


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

- Removes validation for `identifier`, which isn't present in the database schema. 
- Validates `identifiers` instead of `alternate_identifiers` to align with database column naming and internal `identifiers` attribute naming.
- Validates `types` instead of `raw_types` and allows additional properties (like `bibtex` and `schemaOrg`) in the JSON Schema.
- Removes requirement for `types.resourceType`, which is an optional field.
- Removes `update_field_of_science`, which seemed to cull some subject properties; for example, when `subjects.subject` is submitted as an integer. 
  - We intended to remove this method as part of current work here anyway: https://github.com/datacite/product-backlog/issues/465 
- Allows empty string `affiliation.name` since this is permitted by the XSD.
- Allows nil for `identifiers.identifier` and `identifiers.identifierType` since nils can be appear for these properties when reading XML. 
- Does not require `titles.title` or `subjects.subject` since these can be blank if the elements are submitted empty via XML. 


closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
