### PR TITLE
Reduce logging verbosity in RorReferenceStore lookup method

### DIFF
--- a/app/services/ror_reference_store.rb
+++ b/app/services/ror_reference_store.rb
@@ -54,17 +54,16 @@ class RorReferenceStore
       def lookup(mapping, key)
         value = Rails.cache.read(value_cache_key(mapping, key))
         unless value.nil?
-          Rails.logger.info "[RorReferenceStore] hit: #{mapping}/#{key}"
           return value
         end
 
         # Value nil: might be cold cache or key not in mapping — check populated
         unless cache_populated?(mapping)
-          Rails.logger.info "[RorReferenceStore] cache cold for #{mapping} – no populated key"
+          # Rails.logger.info "[RorReferenceStore] cache cold for #{mapping} – no populated key"
           # refresh!(mapping)
           # value = Rails.cache.read(value_cache_key(mapping, key))
         end
-        Rails.logger.info "[RorReferenceStore] #{value ? 'hit' : 'miss'}: #{mapping}/#{key}"
+        # Rails.logger.error "[RorReferenceStore] #{value ? 'hit' : 'miss'}: #{mapping}/#{key}"
         value
       end
 


### PR DESCRIPTION
## Purpose

The purpose of this PR is to reduce log verbosity within the `RorReferenceStore` service. The current implementation generates a high volume of logs for every cache hit or miss during ROR (Research Organization Registry) lookups, which can clutter log files and affect system performance under high load.

## Approach

The logging statements within the `lookup` method have been commented out or removed. This silences the per-key lookup information while maintaining the core logic of the cache retrieval process.

### Key Modifications

- **RorReferenceStore#lookup**: 
    - Removed `Rails.logger.info` for successful cache hits.
    - Commented out the `Rails.logger.info` for cold cache warnings.
    - Commented out the final `Rails.logger.error` summary for hits/misses.

### Important Technical Details

- No functional changes were made to the caching logic; this is strictly a maintenance change to reduce I/O overhead from logging.
- The commented-out lines remain in the source for future debugging if needed, though they no longer execute in production or development environments.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.