### PR TITLE
Update Percona Toolkit to 3.7.1-3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,12 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install Percona Toolkit 3.7.1
-RUN wget https://downloads.percona.com/downloads/percona-toolkit/3.7.1/binary/debian/noble/x86_64/percona-toolkit_3.7.1-2.noble_amd64.deb && \
+RUN wget https://downloads.percona.com/downloads/percona-toolkit/3.7.1/binary/debian/noble/x86_64/percona-toolkit_3.7.1-3.noble_amd64.deb && \
     apt-get update && \
     apt-get install -y -f && \
-    dpkg -i percona-toolkit_3.7.1-2.noble_amd64.deb && \
-    rm percona-toolkit_3.7.1-2.noble_amd64.deb
+    dpkg -i percona-toolkit_3.7.1-3.noble_amd64.deb && \
+    rm percona-toolkit_3.7.1-3.noble_amd64.deb && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install awscli
 RUN wget https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip && \


### PR DESCRIPTION
## Purpose

This PR updates the Percona Toolkit version in the Dockerfile.

## Approach

The Dockerfile has been modified to download and install a newer patch version of Percona Toolkit.

### Key Modifications

*   Updated the download URL for Percona Toolkit from `percona-toolkit_3.7.1-2.noble_amd64.deb` to `percona-toolkit_3.7.1-3.noble_amd64.deb`.
*   Updated the `dpkg -i` command to reflect the new filename.
*   Ensured cleanup commands are run after installation.

### Important Technical Details

The change is primarily a version update for a specific package, aiming to incorporate any bug fixes or minor improvements released in patch version 3.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.