### PR TITLE
Sync "country_code" and "tax_status" fields to Salesforce

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -857,6 +857,7 @@ class Provider < ApplicationRecord
       "group_email" => group_email,
       "description" => description,
       "region" => region,
+      "country_code" => country_code,
       "logo_url" => logo_url,
       "non_profit_status" => non_profit_status,
       "focus_area" => focus_area,


### PR DESCRIPTION
This requires 2 additional fields to be exported from lupo for the provider export - country_code and tax_status (aka non_profit_status) as described in [PB768](https://github.com/datacite/product-backlog/issues/768) 

This is part one of this fix.  Part 2 will be a fix to the salesforce lambda.

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: https://github.com/datacite/product-backlog/issues/768

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
