### PR TITLE
Fix GraphQL 2.x scoped authorization NoMethodError 

### DIFF
--- a/app/graphql/connections/elasticsearch_model_response_connection.rb
+++ b/app/graphql/connections/elasticsearch_model_response_connection.rb
@@ -212,5 +212,10 @@ class ElasticsearchModelResponseConnection
       def cursor
         @connection.cursor_for(@item)
       end
+
+      # Delegate authorization check to the connection
+      def was_authorized_by_scope_items?
+        @connection.was_authorized_by_scope_items?
+      end
     end
 end

--- a/app/graphql/connections/hash_connection.rb
+++ b/app/graphql/connections/hash_connection.rb
@@ -202,5 +202,10 @@ class HashConnection
       def cursor
         @connection.cursor_for(@item)
       end
+
+      # Delegate authorization check to the connection
+      def was_authorized_by_scope_items?
+        @connection.was_authorized_by_scope_items?
+      end
     end
 end

--- a/spec/graphql/connections/elasticsearch_model_response_connection_spec.rb
+++ b/spec/graphql/connections/elasticsearch_model_response_connection_spec.rb
@@ -1,44 +1,44 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ElasticsearchModelResponseConnection::Edge do
-  let(:item) { { id: 1, name: 'test' } }
+  let(:item) { { id: 1, name: "test" } }
   let(:connection) { instance_double(ElasticsearchModelResponseConnection) }
   let(:edge) { described_class.new(item, connection) }
 
-  describe '#was_authorized_by_scope_items?' do
-    it 'delegates to the connection' do
+  describe "#was_authorized_by_scope_items?" do
+    it "delegates to the connection" do
       allow(connection).to receive(:was_authorized_by_scope_items?).and_return(true)
 
       expect(edge.was_authorized_by_scope_items?).to be true
       expect(connection).to have_received(:was_authorized_by_scope_items?)
     end
 
-    it 'returns false when connection returns false' do
+    it "returns false when connection returns false" do
       allow(connection).to receive(:was_authorized_by_scope_items?).and_return(false)
 
       expect(edge.was_authorized_by_scope_items?).to be false
     end
 
-    it 'returns nil when connection returns nil' do
+    it "returns nil when connection returns nil" do
       allow(connection).to receive(:was_authorized_by_scope_items?).and_return(nil)
 
       expect(edge.was_authorized_by_scope_items?).to be nil
     end
   end
 
-  describe '#node' do
-    it 'returns the item' do
+  describe "#node" do
+    it "returns the item" do
       expect(edge.node).to eq(item)
     end
   end
 
-  describe '#cursor' do
-    it 'delegates to the connection cursor_for method' do
-      allow(connection).to receive(:cursor_for).with(item).and_return('encoded_cursor')
+  describe "#cursor" do
+    it "delegates to the connection cursor_for method" do
+      allow(connection).to receive(:cursor_for).with(item).and_return("encoded_cursor")
 
-      expect(edge.cursor).to eq('encoded_cursor')
+      expect(edge.cursor).to eq("encoded_cursor")
       expect(connection).to have_received(:cursor_for).with(item)
     end
   end

--- a/spec/graphql/connections/elasticsearch_model_response_connection_spec.rb
+++ b/spec/graphql/connections/elasticsearch_model_response_connection_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ElasticsearchModelResponseConnection::Edge do
+  let(:item) { { id: 1, name: 'test' } }
+  let(:connection) { instance_double(ElasticsearchModelResponseConnection) }
+  let(:edge) { described_class.new(item, connection) }
+
+  describe '#was_authorized_by_scope_items?' do
+    it 'delegates to the connection' do
+      allow(connection).to receive(:was_authorized_by_scope_items?).and_return(true)
+
+      expect(edge.was_authorized_by_scope_items?).to be true
+      expect(connection).to have_received(:was_authorized_by_scope_items?)
+    end
+
+    it 'returns false when connection returns false' do
+      allow(connection).to receive(:was_authorized_by_scope_items?).and_return(false)
+
+      expect(edge.was_authorized_by_scope_items?).to be false
+    end
+
+    it 'returns nil when connection returns nil' do
+      allow(connection).to receive(:was_authorized_by_scope_items?).and_return(nil)
+
+      expect(edge.was_authorized_by_scope_items?).to be nil
+    end
+  end
+
+  describe '#node' do
+    it 'returns the item' do
+      expect(edge.node).to eq(item)
+    end
+  end
+
+  describe '#cursor' do
+    it 'delegates to the connection cursor_for method' do
+      allow(connection).to receive(:cursor_for).with(item).and_return('encoded_cursor')
+
+      expect(edge.cursor).to eq('encoded_cursor')
+      expect(connection).to have_received(:cursor_for).with(item)
+    end
+  end
+end

--- a/spec/graphql/connections/hash_connection_spec.rb
+++ b/spec/graphql/connections/hash_connection_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HashConnection::Edge do
+  let(:item) { { id: 1, name: 'test' } }
+  let(:connection) { instance_double(HashConnection) }
+  let(:edge) { described_class.new(item, connection) }
+
+  describe '#was_authorized_by_scope_items?' do
+    it 'delegates to the connection' do
+      allow(connection).to receive(:was_authorized_by_scope_items?).and_return(true)
+
+      expect(edge.was_authorized_by_scope_items?).to be true
+      expect(connection).to have_received(:was_authorized_by_scope_items?)
+    end
+
+    it 'returns false when connection returns false' do
+      allow(connection).to receive(:was_authorized_by_scope_items?).and_return(false)
+
+      expect(edge.was_authorized_by_scope_items?).to be false
+    end
+
+    it 'returns nil when connection returns nil' do
+      allow(connection).to receive(:was_authorized_by_scope_items?).and_return(nil)
+
+      expect(edge.was_authorized_by_scope_items?).to be nil
+    end
+  end
+
+  describe '#node' do
+    it 'returns the item' do
+      expect(edge.node).to eq(item)
+    end
+  end
+
+  describe '#cursor' do
+    it 'delegates to the connection cursor_for method' do
+      allow(connection).to receive(:cursor_for).with(item).and_return('encoded_cursor')
+
+      expect(edge.cursor).to eq('encoded_cursor')
+      expect(connection).to have_received(:cursor_for).with(item)
+    end
+  end
+end

--- a/spec/graphql/connections/hash_connection_spec.rb
+++ b/spec/graphql/connections/hash_connection_spec.rb
@@ -1,44 +1,44 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe HashConnection::Edge do
-  let(:item) { { id: 1, name: 'test' } }
+  let(:item) { { id: 1, name: "test" } }
   let(:connection) { instance_double(HashConnection) }
   let(:edge) { described_class.new(item, connection) }
 
-  describe '#was_authorized_by_scope_items?' do
-    it 'delegates to the connection' do
+  describe "#was_authorized_by_scope_items?" do
+    it "delegates to the connection" do
       allow(connection).to receive(:was_authorized_by_scope_items?).and_return(true)
 
       expect(edge.was_authorized_by_scope_items?).to be true
       expect(connection).to have_received(:was_authorized_by_scope_items?)
     end
 
-    it 'returns false when connection returns false' do
+    it "returns false when connection returns false" do
       allow(connection).to receive(:was_authorized_by_scope_items?).and_return(false)
 
       expect(edge.was_authorized_by_scope_items?).to be false
     end
 
-    it 'returns nil when connection returns nil' do
+    it "returns nil when connection returns nil" do
       allow(connection).to receive(:was_authorized_by_scope_items?).and_return(nil)
 
       expect(edge.was_authorized_by_scope_items?).to be nil
     end
   end
 
-  describe '#node' do
-    it 'returns the item' do
+  describe "#node" do
+    it "returns the item" do
       expect(edge.node).to eq(item)
     end
   end
 
-  describe '#cursor' do
-    it 'delegates to the connection cursor_for method' do
-      allow(connection).to receive(:cursor_for).with(item).and_return('encoded_cursor')
+  describe "#cursor" do
+    it "delegates to the connection cursor_for method" do
+      allow(connection).to receive(:cursor_for).with(item).and_return("encoded_cursor")
 
-      expect(edge.cursor).to eq('encoded_cursor')
+      expect(edge.cursor).to eq("encoded_cursor")
       expect(connection).to have_received(:cursor_for).with(item)
     end
   end


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
Fixes a GraphQL runtime NoMethodError when resolving Relay edges/nodes with custom connection wrappers in graphql-ruby 2.x.

When GraphQL executes connection edge/node fields, Relay internals propagate a scoped-authorization runtime flag by calling was_authorized_by_scope_items? on the wrapped edge object. Our custom edge wrappers for Elasticsearch and Hash connections did not expose that method, which caused:

`undefined method was_authorized_by_scope_items? for an instance of ...::Edge`

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->
Added the missing authorization-flag delegation expected by graphql-ruby’s Relay execution contract.

- Updated both custom edge wrappers to delegate was_authorized_by_scope_items? to their parent connection object.
- Kept connection-level was_authorized_by_scope_items? support in place for the underlying runtime state.
- Added focused specs for both edge classes to verify delegation and prevent regressions.
- Included basic edge behavior checks for node and cursor delegation in the same specs to ensure no behavior drift.

This aligns custom connection behavior with graphql-ruby 2.x built-in connection/edge expectations and prevents the runtime crash during edge/node resolution.

Implemented PR description content for Purpose and Approach, including root cause, fix summary, and testing coverage in a ready-to-paste format.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
