### PR TITLE
Exclude XML attribute from OS request; pluck XML from DB if detail=true

### DIFF
--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -186,7 +186,7 @@ class DataciteDoisController < ApplicationController
         xml_by_doi = Doi.where(doi: doi_ids).pluck(:doi, :xml).to_h
 
         results = results.map do |item|
-          source = item.respond_to?(:_source) ? item._source : item
+          source = item._source
 
           xml_content = xml_by_doi[source["doi"]]
           source.xml = xml_content

--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -180,6 +180,21 @@ class DataciteDoisController < ApplicationController
         total_pages = page[:size] > 0 ? (total_for_pages / page[:size]).ceil : 0
       end
 
+      # Pluck XML from DB if params[:detail] is true
+      if params[:detail] == "true"
+        doi_ids = results.map { |r| r._source["doi"] }.compact
+        xml_by_doi = Doi.where(doi: doi_ids).pluck(:doi, :xml).to_h
+
+        results = results.map do |item|
+          source = item.respond_to?(:_source) ? item._source : item
+          
+          xml_content = xml_by_doi[source["doi"]]
+          source.xml = xml_content 
+          
+          item
+        end
+      end
+
       if page[:scroll].present?
         options = {}
         options[:meta] = {

--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -187,10 +187,10 @@ class DataciteDoisController < ApplicationController
 
         results = results.map do |item|
           source = item.respond_to?(:_source) ? item._source : item
-          
+
           xml_content = xml_by_doi[source["doi"]]
-          source.xml = xml_content 
-          
+          source.xml = xml_content
+
           item
         end
       end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -136,6 +136,19 @@ class WorksController < ApplicationController
       # Results to return are either our sample group dois or the regular hit results
       @dois = sample_dois || response.results
 
+      # Pluck XML from DB for compatibility
+      doi_ids = @dois.map { |r| r._source["doi"] }.compact
+      xml_by_doi = Doi.where(doi: doi_ids).pluck(:doi, :xml).to_h
+
+      @dois = @dois.map do |item|
+        source = item._source
+
+        xml_content = xml_by_doi[source["doi"]]
+        source.xml = xml_content
+
+        item
+      end
+
       render(
         json: WorkSerializer.new(@dois, options).serializable_hash.to_json,
         status: :ok

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -5,6 +5,7 @@ require "maremma"
 class Doi < ApplicationRecord
   self.ignored_columns += [:publisher]
   PUBLISHER_JSON_SCHEMA = Rails.root.join("app", "models", "schemas", "doi", "publisher.json")
+  OS_SOURCE = { excludes: ["xml"] }.freeze
   audited only: %i[doi url creators contributors titles publisher_obj publication_year types descriptions container sizes formats version_info language dates identifiers related_identifiers related_items funding_references geo_locations rights_list subjects schema_version content_url landing_page aasm_state source reason]
 
   # disable STI
@@ -995,6 +996,7 @@ class Doi < ApplicationRecord
       from: (options.dig(:page, :number) - 1) * options.dig(:page, :size),
       size: options.dig(:page, :size),
       sort: [options[:sort]],
+      _source: OS_SOURCE,
       query: {
         bool: {
           must: must,
@@ -1007,6 +1009,7 @@ class Doi < ApplicationRecord
   # return results for one doi
   def self.find_by_id(id)
     __elasticsearch__.search(
+      _source: OS_SOURCE,
       query: {
         match: {
           uid: id,
@@ -1330,6 +1333,7 @@ class Doi < ApplicationRecord
         aggs: {
           "samples_hits": {
             top_hits: {
+              _source: OS_SOURCE,
               size: options[:sample_size].presence || 1,
             },
           },
@@ -1349,6 +1353,7 @@ class Doi < ApplicationRecord
         index: index_name,
         scroll: options.dig(:page, :scroll),
         body: {
+          _source: OS_SOURCE,
           size: options.dig(:page, :size),
           sort: sort,
           query: es_query,
@@ -1363,6 +1368,7 @@ class Doi < ApplicationRecord
       )
     elsif options.fetch(:page, {}).key?(:cursor)
       __elasticsearch__.search({
+        _source: OS_SOURCE,
         size: options.dig(:page, :size),
         search_after: search_after,
         sort: sort,
@@ -1372,6 +1378,7 @@ class Doi < ApplicationRecord
       }.compact)
     else
       __elasticsearch__.search({
+        _source: OS_SOURCE,
         size: options.dig(:page, :size),
         from: from,
         sort: sort,

--- a/app/serializers/datacite_doi_serializer.rb
+++ b/app/serializers/datacite_doi_serializer.rb
@@ -117,7 +117,7 @@ class DataciteDoiSerializer
               Proc.new { |_object, params|
                 params && params[:detail]
               } do |object|
-    Base64.strict_encode64(object.xml) if object.xml.present?
+    Base64.strict_encode64(object.xml) if object.respond_to?(:xml) && object.xml.present?
   rescue ArgumentError
     nil
   end


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Relates to explorations from:

- https://github.com/datacite/product-backlog/issues/778

Excludes xml attribute retrieval from most OS requests (GraphQL is not changed at present) and hydrates the xml attribute from the DB based on the OS results.

Benchmark for retrieving XML from DB in production, which demonstrates that this isn't a major performance burden even for large requests:

```
4.0.1 :001 > doi_ids = Doi.last(50000).pluck(:doi).sample(1000)
4.0.1 :002 > def database_query_timer(doi_ids)
4.0.1 :003 >   t1 = Time.now
4.0.1 :004 >   doi_and_xml = Doi.where(doi: doi_ids).pluck(:doi, :xml).to_h
4.0.1 :005 >   t2 = Time.now
4.0.1 :006 >   puts (t2 - t1)
4.0.1 :007 > end
 => :database_query_timer 
4.0.1 :008 > database_query_timer(doi_ids)
0.193738834
```

This is the initial step in a plan to remove XML from OpenSearch for performance, scalability, and storage minimization. Next steps would be: 

- Implement this retrieval approach for GraphQL
- Remove XML from new OS documents
- Re-index to remove XML from OS index 

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
