### PR TITLE
Match more permissive detail= conditional to serializer

### DIFF
--- a/app/controllers/datacite_dois_controller.rb
+++ b/app/controllers/datacite_dois_controller.rb
@@ -181,7 +181,7 @@ class DataciteDoisController < ApplicationController
       end
 
       # Pluck XML from DB if params[:detail] is true
-      if params[:detail] == "true"
+      if params[:detail]
         doi_ids = results.map { |r| r._source["doi"] }.compact
         xml_by_doi = Doi.where(doi: doi_ids).pluck(:doi, :xml).to_h
 


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

The DataciteDoiSerializer uses `if: Proc.new { |_object, params| params && params[:detail] }`, so the same conditional is now used in the controller so they're equally permissive. (OAI-PMH, i.e. viringo, uses `detail=True`, which calls for this change.) 

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
