### PR TITLE
Add the running Lupo version to response headers

### DIFF
--- a/vendor/docker/webapp.conf.template
+++ b/vendor/docker/webapp.conf.template
@@ -16,6 +16,7 @@ server {
 
     error_log stderr;
 
+
     location / {
         # enable CORS
         set $cors 'true';
@@ -31,6 +32,9 @@ server {
             add_header 'Access-Control-Allow-Headers' 'Accept,Access-Control-Allow-Origin,Access-Control-Expose-Headers,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Mx-ReqToken,X-Requested-With' always;
             # required to be able to read Authorization header in frontend
             add_header 'Access-Control-Expose-Headers' 'Authorization' always;
+
+            # Return Lupo version
+            add_header 'X-LupoVersion' '${GIT_TAG}' always;
         }
 
         # 2 if are required, nginx treats each if block as a different context
@@ -42,6 +46,10 @@ server {
             add_header 'Access-Control-Max-Age' 1728000;
             add_header 'Content-Type' 'text/plain charset=UTF-8';
             add_header 'Content-Length' 0;
+
+            # Return Lupo version
+            add_header 'X-LupoVersion' '${GIT_TAG}' always;
+
             return 204;
         }
     }


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
This PR adds a new custom header to responses that contains the running Lupo version, as discussed in the Engineering call on 23/06/26.

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->
Achieved by using the existing `envsubst` script that sets Passenger variables in the nginx config from envvars, and adding another directive that sets a custom header using the value from the `GIT_TAG` envvar.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
