### PR TITLE
Percona toolkit could not be found in the build_and_deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install Percona Toolkit 3.7.1
-RUN wget https://downloads.percona.com/downloads/percona-toolkit/3.7.1/binary/debian/noble/x86_64/percona-toolkit_3.7.1-3.noble_amd64.deb && \
+RUN wget https://downloads.percona.com/downloads/percona-toolkit/3.7.1-3/binary/debian/noble/x86_64/percona-toolkit_3.7.1-3.noble_amd64.deb && \
     apt-get update && \
     apt-get install -y -f && \
     dpkg -i percona-toolkit_3.7.1-3.noble_amd64.deb && \


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Dockerfile percona toolkit could not be found in build_and_deploy - download site changed the path.  (https://github.com/datacite/lupo/actions/runs/28889015378/job/85730359302)

closes: none

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
