### PR TITLE
Release: API keys only (exclude enrichment changes)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-packaging
   - rubocop-performance
   - rubocop-rails

--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ end
 
 group :development, :test do
   gem "bullet", "~> 8.1"
-  gem "byebug", "~> 13.0", platforms: %i[mri mingw x64_mingw]
+  gem "byebug", "~> 13.0", platforms: %i[mri windows]
   gem "rspec-rails", "~> 8.0", ">= 8.0.4"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -763,7 +763,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -773,6 +773,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-23
+  arm64-darwin-25
   universal-darwin-21
   x86_64-darwin-20
   x86_64-linux

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+class ApiKeysController < ApplicationController
+  before_action :authenticate_user!
+  before_action :reject_api_key_credentials!
+
+  load_and_authorize_resource except: %i[index create]
+
+  def index
+    load_client_context
+
+    include_revoked = params[:include_revoked]
+
+    if @client.nil?
+      if current_user&.is_admin_or_staff?
+        authorize! :manage, ApiKey
+        api_keys = include_revoked ? ApiKey.all : ApiKey.active
+      else
+        raise CanCan::AccessDenied
+      end
+    else
+      authorize_api_key_index!(@client)
+      api_keys = include_revoked ? @client.api_keys : @client.api_keys.active
+    end
+
+    api_keys = order_api_keys(api_keys, include_revoked)
+
+    options = {
+      meta: { total: api_keys.count },
+      params: { current_ability: current_ability },
+    }
+
+    render json: ApiKeySerializer.new(api_keys, options).serializable_hash
+  end
+
+  def create
+    load_client_context
+    raise ActiveRecord::RecordNotFound unless @client
+
+    api_key = @client.api_keys.build(safe_params)
+    authorize! :create, api_key
+
+    if api_key.save
+      options = {
+        params: {
+          current_ability: current_ability,
+          include_plain_key: true,
+        },
+      }
+      render json: ApiKeySerializer.new(api_key, options).serializable_hash,
+             status: :created
+    else
+      render json: {
+        errors: api_key.errors.full_messages.map do |m|
+          { status: "422", title: m }
+        end,
+      }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @api_key.revoke!
+    head :no_content
+  end
+
+  private
+    def reject_api_key_credentials!
+      return unless current_user&.api_key_authenticated?
+
+      raise CanCan::AccessDenied,
+            "API keys cannot manage credentials; use the client password."
+    end
+
+    def authorize_api_key_index!(client)
+      probe = client.api_keys.build
+      unless can?(:manage, probe) || can?(:read, probe)
+        raise CanCan::AccessDenied
+      end
+    end
+
+    def load_client_context
+      @client = current_user&.client_id.present? ? Client.find_by(symbol: current_user.client_id.upcase) : nil
+    end
+
+    def order_api_keys(scope, include_revoked)
+      if include_revoked
+        scope.order(
+          Arel.sql("revoked_at IS NULL DESC, revoked_at DESC, created_at DESC"),
+        )
+      else
+        scope.order(created_at: :desc)
+      end
+    end
+
+    def safe_params
+      params.require(:data).require(:attributes).permit(:name)
+    end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -83,6 +83,7 @@ class ApplicationController < ActionController::API
 
     fail CanCan::AuthorizationNotPerformed if @current_user.errors.present?
 
+    set_api_key_sentry_tags
     @current_user
   end
 
@@ -175,7 +176,13 @@ class ApplicationController < ActionController::API
   private
     def append_info_to_payload(payload)
       super
-      payload[:uid] = current_user.uid.downcase if current_user.try(:uid)
+      return unless current_user.try(:uid)
+
+      payload[:uid] = current_user.uid.downcase
+      if current_user.try(:api_key_authenticated?)
+        payload[:auth_method] = current_user.auth_method
+        payload[:api_key_prefix] = current_user.api_key_prefix
+      end
     end
 
     def set_raven_context
@@ -185,6 +192,16 @@ class ApplicationController < ActionController::API
         else
           { ip_address: request.ip }
         end
+      )
+      set_api_key_sentry_tags
+    end
+
+    def set_api_key_sentry_tags
+      return unless current_user.try(:api_key_authenticated?)
+
+      Sentry.set_tags(
+        auth_method: current_user.auth_method,
+        api_key_prefix: current_user.api_key_prefix,
       )
     end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,6 +22,10 @@ class SessionsController < ApplicationController
       error_response("Wrong account ID or password.") && return
     end
 
+    if user.api_key_authenticated? || user.jwt.blank?
+      error_response("Wrong account ID or password.") && return
+    end
+
     render json: {
       "access_token" => user.jwt, "expires_in" => 3_600 * 24 * 30
     }.to_json,

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -13,6 +13,7 @@ class Ability
 
     if user.role_id == "staff_admin"
       can :manage, :all
+      can :manage, ApiKey
       cannot %i[new create], Doi do |doi|
         doi.client.blank? ||
           !(
@@ -77,6 +78,10 @@ class Ability
       end
       cannot %i[transfer], Client
       can %i[manage], ClientPrefix # , :client_id => user.provider_id
+      can :manage, ApiKey do |api_key|
+        client = api_key.client
+        client && client.provider_id == user.provider_id
+      end
 
       # if Flipper[:delete_doi].enabled?(user)
       #   can [:manage], Doi, :provider_id => user.provider_id
@@ -115,6 +120,9 @@ class Ability
       can %i[read], Provider
       can %i[read update read_contact_information read_analytics], Client, symbol: user.client_id.upcase
       can %i[read], ClientPrefix, client_id: user.client_id
+      can :manage, ApiKey do |api_key|
+        api_key.client&.symbol&.downcase == user.client_id && user.client&.is_active == "\x01"
+      end
 
       # if Flipper[:delete_doi].enabled?(user)
       #   can [:manage], Doi, :client_id => user.client_id
@@ -145,10 +153,50 @@ class Ability
         activity.doi.findable? || activity.doi.client_id == user.client_id
       end
       can %i[read], :access_datafile
+    elsif user.role_id == "client_api" && user.client.present? && user.client.is_active == "\x01"
+      can %i[read], Provider
+      can %i[read], Client, symbol: user.client_id.upcase
+      can %i[read], ClientPrefix, client_id: user.client_id
+      can %i[
+        read
+        destroy
+        update
+        register_url
+        validate
+        undo
+        get_url
+        read_landing_page_results
+      ],
+          Doi,
+          client_id: user.client_id
+      can %i[new create], Doi do |doi|
+        doi.client.prefixes.where(uid: doi.prefix).present? ||
+          doi.type == "OtherDoi"
+      end
+      can %i[read], Doi
+      can %i[read], User
+      can %i[read], Activity do |activity|
+        activity.doi.findable? || activity.doi.client_id == user.client_id
+      end
+      can %i[read], :access_datafile
+    elsif user.role_id == "client_api" && user.client.present?
+      can %i[read], Provider
+      can %i[read], Client, symbol: user.client_id.upcase
+      can %i[read], ClientPrefix, client_id: user.client_id
+      can %i[read], Doi, client_id: user.client_id
+      can %i[read], Doi
+      can %i[read], User
+      can %i[read], :access_datafile
+      can %i[read], Activity do |activity|
+        activity.doi.findable? || activity.doi.client_id == user.client_id
+      end
     elsif user.role_id == "client_admin" && user.client.present?
       can %i[read], Provider
       can %i[read read_contact_information read_analytics], Client, symbol: user.client_id.upcase
       can %i[read], ClientPrefix, client_id: user.client_id
+      can :read, ApiKey do |api_key|
+        api_key.client&.symbol&.downcase == user.client_id
+      end
       can %i[read], Doi, client_id: user.client_id
       can %i[read], Doi
       can %i[read], User
@@ -160,6 +208,9 @@ class Ability
       can %i[read], Provider
       can %i[read read_contact_information read_analytics], Client, symbol: user.client_id.upcase
       can %i[read], ClientPrefix, client_id: user.client_id
+      can :read, ApiKey do |api_key|
+        api_key.client&.symbol&.downcase == user.client_id
+      end
       can %i[read get_url read_landing_page_results],
           Doi,
           client_id: user.client_id

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,0 +1,56 @@
+class ApiKey < ApplicationRecord
+  include Passwordable
+
+  attr_accessor :key
+
+  belongs_to :client, touch: true
+
+  # Used by ApiKeySerializer belongs_to :client (id_method_name: :symbol)
+  # so relationship linkage IDs are client symbols (e.g. DATACITE.TESTKEY).
+  delegate :symbol, to: :client, allow_nil: true
+
+  validates_presence_of :client, :name
+
+  before_create :initialize_api_key
+
+  scope :active, -> { where(revoked_at: nil) }
+
+  def revoke!
+    update!(revoked_at: Time.zone.now)
+  end
+
+  def revoked?
+    revoked_at != nil
+  end
+
+  def self.authenticate(token)
+    return nil if token.blank?
+
+    prefix = token.to_s[0, 11]
+    candidates = active.where(key_prefix: prefix)
+
+    candidates.find do |api_key|
+      secure_compare(api_key.key_hash, api_key.encrypt_password_sha256(token))
+    end
+  end
+
+  private
+    def initialize_api_key
+      generate_id
+      generate_key
+    end
+
+    def generate_id
+      self.id ||= SecureRandom.uuid
+    end
+
+    def generate_key
+      prefix = "DC."
+      secret = SecureRandom.alphanumeric(32)
+      plain = prefix + secret
+
+      self.key = plain
+      self.key_prefix = prefix + secret[0, 8]
+      self.key_hash = encrypt_password_sha256(plain)
+    end
+end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -95,6 +95,7 @@ class Client < ApplicationRecord
   has_many :client_prefixes, dependent: :destroy
   has_many :prefixes, through: :client_prefixes
   has_many :provider_prefixes, through: :client_prefixes
+  has_many :api_keys, dependent: :destroy
   has_many :activities, as: :auditable, dependent: :destroy
 
   before_validation :set_defaults

--- a/app/models/concerns/authenticable.rb
+++ b/app/models/concerns/authenticable.rb
@@ -153,6 +153,18 @@ module Authenticable
 
     # basic auth
     def decode_auth_param(username: nil, password: nil)
+      if username.present? && username.length > 20 && username.match?(/\ADC\./i)
+        api_key = ApiKey.authenticate(username)
+        if api_key
+          client = api_key.client
+          if client
+            touch_api_key_last_used(api_key)
+            return payload_for_api_key(api_key, client)
+          end
+        end
+        return {}
+      end
+
       return {} unless username.present? && password.present?
 
       user =
@@ -162,14 +174,34 @@ module Authenticable
           Provider.unscoped.where(symbol: username.upcase).first
         end
 
-      unless user &&
+      if user &&
           secure_compare(user.password, encrypt_password_sha256(password))
-        return {}
+        uid = username.downcase
+        return get_payload(uid: uid, user: user, password: password.to_s)
       end
 
-      uid = username.downcase
+      if username.include?(".") && user
+        api_key = ApiKey.authenticate(password)
+        if api_key && api_key.client&.symbol&.downcase == user.symbol.downcase
+          touch_api_key_last_used(api_key)
+          # Do not pass the API key secret through as password (handle system).
+          return payload_for_api_key(api_key, user)
+        end
+      end
 
-      get_payload(uid: uid, user: user, password: password.to_s)
+      {}
+    end
+
+    # Authenticate using a raw API key (for direct Bearer usage)
+    def decode_api_key(token)
+      api_key = ApiKey.authenticate(token)
+      return { errors: "Invalid API key." } unless api_key
+
+      client = api_key.client
+      return { errors: "Invalid API key." } unless client
+
+      touch_api_key_last_used(api_key)
+      payload_for_api_key(api_key, client)
     end
 
     def get_payload(uid: nil, user: nil, password: nil)
@@ -202,6 +234,21 @@ module Authenticable
       payload
     end
 
+    def payload_for_api_key(api_key, client)
+      get_payload(uid: client.uid, user: client).merge(
+        "role_id" => "client_api",
+        "auth_method" => "api_key",
+        "api_key_id" => api_key.id,
+        "api_key_prefix" => api_key.key_prefix,
+      )
+    end
+
+    def touch_api_key_last_used(api_key)
+      return unless api_key.last_used_at.nil? || api_key.last_used_at < 15.minutes.ago
+
+      api_key.update_column(:last_used_at, Time.zone.now)
+    end
+
     # constant-time comparison algorithm to prevent timing attacks
     # from Devise
     def secure_compare(a, b)
@@ -231,7 +278,7 @@ module Authenticable
           user.provider_id == doi.provider_id
         return false
       end
-      if %w[client_admin client_user user temporary].include?(user.role_id) &&
+      if %w[client_admin client_api client_user user temporary].include?(user.role_id) &&
           user.client_id.present? &&
           user.client_id == doi.client_id
         return false

--- a/app/models/concerns/passwordable.rb
+++ b/app/models/concerns/passwordable.rb
@@ -5,6 +5,17 @@ module Passwordable
 
   require "digest"
 
+  class_methods do
+    # timing-safe compare to prevent timing attacks
+    def secure_compare(a, b)
+      return false if a.blank? || b.blank? || a.bytesize != b.bytesize
+      l = a.unpack "C#{a.bytesize}"
+      res = 0
+      b.each_byte { |byte| res |= byte ^ l.shift }
+      res == 0
+    end
+  end
+
   included do
     # "yes", "not set" (used in serializer) and a blank value are not allowed for new password
     def encrypt_password_sha256(password)
@@ -19,6 +30,11 @@ module Passwordable
 
     def authenticate_sha256(unencrypted_password)
       password == encrypt_password_sha256(unencrypted_password) && self
+    end
+
+    # delegate to class for convenience
+    def secure_compare(a, b)
+      self.class.secure_compare(a, b)
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,20 +23,28 @@ class User
                 :client_id,
                 :beta_tester,
                 :has_orcid_token,
+                :auth_method,
+                :api_key_id,
+                :api_key_prefix,
                 :errors
 
   def initialize(credentials, options = {})
     if credentials.present? && options.fetch(:type, "").casecmp("basic").zero?
       username, password = ::Base64.decode64(credentials).split(":", 2)
       payload = decode_auth_param(username: username, password: password)
-      @jwt =
-        encode_token(
-          payload.merge(
-            iat: Time.now.to_i,
-            exp: Time.now.to_i + 3_600 * 24 * 30,
-            aud: Rails.env,
-          ),
-        )
+      # Do not mint a session JWT from an API key. A JWT would lose auth_method
+      # and could manage credentials (list/create/revoke keys) via Bearer.
+      if payload.present? && payload["auth_method"] != "api_key" && !payload[:errors]
+        jwt_payload = payload.except("auth_method", "api_key_id", "api_key_prefix")
+        @jwt =
+          encode_token(
+            jwt_payload.merge(
+              iat: Time.now.to_i,
+              exp: Time.now.to_i + 3_600 * 24 * 30,
+              aud: Rails.env,
+            ),
+          )
+      end
     elsif credentials.present? && options.fetch(:type, "").casecmp("oidc").zero?
       payload = decode_alb_token(credentials)
 
@@ -63,7 +71,18 @@ class User
       end
     elsif credentials.present?
       payload = decode_token(credentials)
-      @jwt = credentials
+      if payload.blank? || payload[:errors]
+        # Try as API key (drop-in Bearer support, non-JWT)
+        ak_payload = decode_api_key(credentials)
+        if ak_payload.present? && !ak_payload[:errors]
+          payload = ak_payload
+          @jwt = nil # keys are not JWTs
+        else
+          @jwt = credentials
+        end
+      else
+        @jwt = credentials
+      end
     end
 
     if payload.blank? || payload[:errors]
@@ -79,7 +98,14 @@ class User
       @client_id = payload.fetch("client_id", nil)
       @beta_tester = payload.fetch("beta_tester", false)
       @has_orcid_token = payload.fetch("has_orcid_token", false)
+      @auth_method = payload["auth_method"]
+      @api_key_id = payload["api_key_id"]
+      @api_key_prefix = payload["api_key_prefix"]
     end
+  end
+
+  def api_key_authenticated?
+    auth_method == "api_key"
   end
 
   alias_attribute :orcid, :uid

--- a/app/serializers/api_key_client_serializer.rb
+++ b/app/serializers/api_key_client_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ApiKeyClientSerializer
+  include JSONAPI::Serializer
+
+  set_key_transform :camel_lower
+  set_type :clients
+  set_id :symbol
+end

--- a/app/serializers/api_key_serializer.rb
+++ b/app/serializers/api_key_serializer.rb
@@ -1,0 +1,27 @@
+class ApiKeySerializer
+  include JSONAPI::Serializer
+
+  set_key_transform :camel_lower
+  set_type :api_keys
+  set_id :id
+
+  attributes :name, :key_prefix, :created, :updated, :last_used_at, :revoked_at
+
+  # Only include the plaintext key on creation
+  attribute :key, if: Proc.new { |object, params| params && params[:include_plain_key] } do |object|
+    object.key
+  end
+
+  attribute :created do |object|
+    object.created_at&.iso8601
+  end
+
+  attribute :updated do |object|
+    object.updated_at&.iso8601
+  end
+
+  belongs_to :client,
+             record_type: :clients,
+             serializer: :ApiKeyClient,
+             id_method_name: :symbol
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -137,6 +137,9 @@ module Lupo
         ddsource: %w[ruby],
         params: event.payload[:params].except(*exceptions),
         uid: event.payload[:uid],
+        # Present only for API-key auth (prefix only — never the full secret).
+        auth_method: event.payload[:auth_method],
+        api_key_prefix: event.payload[:api_key_prefix],
       }
     end if defined?(Datadog::Tracing)
 

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -4,5 +4,5 @@
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
-  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc
+  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc, :api_key
 ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -179,6 +179,10 @@ Rails.application.routes.draw do
   # Monthly Data File access
   get "credentials/datafile", to: "datafile#create_credentials"
 
+  scope "credentials" do
+    resources :api_keys, path: "api-keys", only: %i[index create destroy]
+  end
+
   resources :heartbeat, only: %i[index]
 
   resources :activities, only: %i[index show], constraints: { id: /.+/ }

--- a/db/migrate/20260617100000_create_api_keys.rb
+++ b/db/migrate/20260617100000_create_api_keys.rb
@@ -1,0 +1,18 @@
+class CreateApiKeys < ActiveRecord::Migration[7.2]
+  def change
+    create_table :api_keys, id: false do |t|
+      t.string :id, limit: 36, primary_key: true
+      t.bigint :client_id, null: false
+      t.string :name, null: false, limit: 191
+      t.string :key_prefix, null: false, limit: 32
+      t.string :key_hash, null: false, limit: 191
+      t.datetime :last_used_at
+      t.datetime :revoked_at
+      t.timestamps
+
+      t.index :client_id
+      t.index :key_prefix, unique: true
+      t.index :revoked_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,25 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_10_131437) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_17_100000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "name", limit: 191, null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
+    t.string "name", limit: 191, null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "key", limit: 191, null: false
-    t.string "filename", limit: 191, null: false
-    t.string "content_type", limit: 191
-    t.text "metadata"
     t.bigint "byte_size", null: false
     t.string "checksum", limit: 191
+    t.string "content_type", limit: 191
     t.datetime "created_at", null: false
+    t.string "filename", limit: 191, null: false
+    t.string "key", limit: 191, null: false
+    t.text "metadata"
     t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
@@ -40,49 +40,49 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_10_131437) do
   end
 
   create_table "allocator", charset: "utf8mb3", force: :cascade do |t|
-    t.string "system_email", null: false
+    t.json "billing_contact"
+    t.json "billing_information"
+    t.text "comments", size: :long
+    t.string "consortium_id"
+    t.string "country_code"
     t.datetime "created"
+    t.datetime "deleted_at"
+    t.text "description"
+    t.string "display_name"
+    t.integer "doi_estimate", default: 0, null: false
     t.integer "doi_quota_allowed", null: false
     t.integer "doi_quota_used", null: false
-    t.binary "is_active", limit: 1
-    t.string "name", null: false
-    t.string "password"
-    t.string "role_name"
-    t.string "symbol", null: false
-    t.datetime "updated"
-    t.integer "version"
-    t.text "comments", size: :long
     t.string "experiments"
-    t.text "description"
-    t.string "region"
-    t.string "country_code"
-    t.string "website"
-    t.datetime "deleted_at"
+    t.string "focus_area", limit: 191
+    t.string "globus_uuid", limit: 191
+    t.string "group_email"
+    t.binary "is_active", limit: 1
     t.date "joined"
     t.string "logo"
-    t.string "focus_area", limit: 191
-    t.string "organization_type", limit: 191
-    t.json "billing_information"
-    t.string "twitter_handle", limit: 20
-    t.string "ror_id"
-    t.json "technical_contact"
-    t.json "service_contact"
-    t.json "voting_contact"
-    t.json "billing_contact"
-    t.json "secondary_billing_contact"
-    t.string "display_name"
-    t.string "group_email"
-    t.json "secondary_service_contact"
-    t.json "secondary_technical_contact"
-    t.string "consortium_id"
-    t.string "salesforce_id", limit: 191
-    t.string "non_profit_status", limit: 191
-    t.string "globus_uuid", limit: 191
-    t.string "logo_file_name"
     t.string "logo_content_type"
+    t.string "logo_file_name"
     t.bigint "logo_file_size"
     t.datetime "logo_updated_at"
-    t.integer "doi_estimate", default: 0, null: false
+    t.string "name", null: false
+    t.string "non_profit_status", limit: 191
+    t.string "organization_type", limit: 191
+    t.string "password"
+    t.string "region"
+    t.string "role_name"
+    t.string "ror_id"
+    t.string "salesforce_id", limit: 191
+    t.json "secondary_billing_contact"
+    t.json "secondary_service_contact"
+    t.json "secondary_technical_contact"
+    t.json "service_contact"
+    t.string "symbol", null: false
+    t.string "system_email", null: false
+    t.json "technical_contact"
+    t.string "twitter_handle", limit: 20
+    t.datetime "updated"
+    t.integer "version"
+    t.json "voting_contact"
+    t.string "website"
     t.index ["deleted_at"], name: "index_allocator_deleted_at"
     t.index ["organization_type"], name: "index_allocator_organization_type"
     t.index ["role_name"], name: "index_allocator_role_name"
@@ -90,21 +90,35 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_10_131437) do
     t.index ["symbol"], name: "symbol", unique: true
   end
 
+  create_table "api_keys", id: { type: :string, limit: 36 }, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "client_id", null: false
+    t.datetime "created_at", null: false
+    t.string "key_hash", limit: 191, null: false
+    t.string "key_prefix", limit: 32, null: false
+    t.datetime "last_used_at"
+    t.string "name", limit: 191, null: false
+    t.datetime "revoked_at"
+    t.datetime "updated_at", null: false
+    t.index ["client_id"], name: "index_api_keys_on_client_id"
+    t.index ["key_prefix"], name: "index_api_keys_on_key_prefix", unique: true
+    t.index ["revoked_at"], name: "index_api_keys_on_revoked_at"
+  end
+
   create_table "audits", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "auditable_id"
-    t.string "auditable_type"
+    t.string "action"
     t.integer "associated_id"
     t.string "associated_type"
+    t.integer "auditable_id"
+    t.string "auditable_type"
+    t.json "audited_changes"
+    t.string "comment"
+    t.datetime "created_at", precision: 3
+    t.string "remote_address"
+    t.string "request_uuid"
     t.integer "user_id"
     t.string "user_type"
     t.string "username"
-    t.string "action"
-    t.json "audited_changes"
     t.integer "version", default: 0
-    t.string "comment"
-    t.string "remote_address"
-    t.string "request_uuid"
-    t.datetime "created_at", precision: 3
     t.index ["associated_type", "associated_id"], name: "associated_index"
     t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
     t.index ["created_at"], name: "index_audits_on_created_at"
@@ -114,11 +128,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_10_131437) do
 
   create_table "client_prefixes", charset: "utf8mb3", force: :cascade do |t|
     t.bigint "client_id", null: false
-    t.bigint "prefix_id", null: false
     t.datetime "created_at"
-    t.datetime "updated_at"
+    t.bigint "prefix_id", null: false
     t.bigint "provider_prefix_id"
     t.string "uid", null: false
+    t.datetime "updated_at"
     t.index ["client_id"], name: "FK13A1B3BA47B5F5FF"
     t.index ["prefix_id"], name: "FK13A1B3BAAF86A1C7"
     t.index ["provider_prefix_id"], name: "index_client_prefixes_on_provider_prefix_id"
@@ -126,54 +140,54 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_10_131437) do
   end
 
   create_table "contacts", charset: "utf8mb3", force: :cascade do |t|
-    t.string "uid", limit: 36
-    t.bigint "provider_id", null: false
-    t.string "given_name"
-    t.string "family_name"
-    t.string "email"
-    t.json "role_name"
     t.datetime "created_at"
-    t.datetime "updated_at"
     t.datetime "deleted_at"
+    t.string "email"
+    t.string "family_name"
+    t.string "given_name"
+    t.bigint "provider_id", null: false
+    t.json "role_name"
+    t.string "uid", limit: 36
+    t.datetime "updated_at"
     t.index ["deleted_at"], name: "index_contacts_deleted_at"
     t.index ["email"], name: "index_contacts_email"
     t.index ["uid"], name: "index_contacts_uid"
   end
 
   create_table "datacentre", charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "allocator", null: false
+    t.string "alternate_name", limit: 191
+    t.text "analytics_dashboard_url"
+    t.string "analytics_tracking_id"
+    t.json "certificate"
+    t.string "client_type", limit: 191
     t.text "comments", size: :long
-    t.string "system_email", null: false
     t.datetime "created"
+    t.datetime "deleted_at"
+    t.text "description"
     t.integer "doi_quota_allowed", null: false
     t.integer "doi_quota_used", null: false
     t.text "domains"
-    t.binary "is_active", limit: 1
-    t.string "name", null: false
-    t.string "password"
-    t.string "role_name"
-    t.string "symbol", null: false
-    t.datetime "updated"
-    t.integer "version"
-    t.bigint "allocator", null: false
     t.string "experiments"
-    t.datetime "deleted_at"
-    t.string "re3data_id"
-    t.text "url"
-    t.string "software", limit: 191
-    t.text "description"
-    t.string "client_type", limit: 191
+    t.string "globus_uuid", limit: 191
+    t.binary "is_active", limit: 1
     t.json "issn"
-    t.json "certificate"
-    t.json "repository_type"
-    t.string "alternate_name", limit: 191
     t.json "language"
+    t.string "name", null: false
     t.integer "opendoar_id"
+    t.string "password"
+    t.string "re3data_id"
+    t.json "repository_type"
+    t.string "role_name"
     t.string "salesforce_id", limit: 191
     t.json "service_contact"
-    t.string "globus_uuid", limit: 191
-    t.text "analytics_dashboard_url"
-    t.string "analytics_tracking_id"
+    t.string "software", limit: 191
     t.json "subjects"
+    t.string "symbol", null: false
+    t.string "system_email", null: false
+    t.datetime "updated"
+    t.text "url"
+    t.integer "version"
     t.index ["allocator"], name: "FK6695D60546EBD781"
     t.index ["globus_uuid"], name: "index_datacentre_on_globus_uuid"
     t.index ["re3data_id"], name: "index_datacentre_on_re3data_id"
@@ -182,51 +196,51 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_10_131437) do
   end
 
   create_table "dataset", charset: "utf8mb3", force: :cascade do |t|
+    t.string "aasm_state"
+    t.string "agency", limit: 191, default: "datacite"
+    t.json "container"
+    t.json "content_url"
+    t.json "contributors"
     t.datetime "created"
+    t.json "creators"
+    t.bigint "datacentre", null: false
+    t.json "dates"
+    t.json "descriptions"
     t.string "doi", null: false
+    t.json "formats"
+    t.json "funding_references"
+    t.json "geo_locations"
+    t.json "identifiers"
+    t.datetime "indexed", precision: 3, default: "1970-01-01 00:00:00", null: false
     t.binary "is_active", limit: 1, null: false
     t.binary "is_ref_quality", limit: 1
+    t.json "landing_page"
+    t.string "language", limit: 191
+    t.text "last_landing_page"
+    t.string "last_landing_page_content_type"
     t.integer "last_landing_page_status"
     t.datetime "last_landing_page_status_check"
     t.json "last_landing_page_status_result"
     t.string "last_metadata_status"
-    t.datetime "updated"
-    t.integer "version"
-    t.bigint "datacentre", null: false
     t.datetime "minted"
-    t.text "url"
-    t.text "last_landing_page"
-    t.string "last_landing_page_content_type"
-    t.string "aasm_state"
-    t.string "reason"
-    t.string "source", limit: 191
-    t.datetime "indexed", precision: 3, default: "1970-01-01 00:00:00", null: false
-    t.json "creators"
-    t.json "contributors"
-    t.json "titles"
     t.integer "publication_year"
-    t.json "types"
-    t.json "descriptions"
-    t.json "container"
-    t.json "sizes"
-    t.json "formats"
-    t.string "version_info", limit: 191
-    t.string "language", limit: 191
-    t.json "dates"
-    t.json "identifiers"
-    t.json "related_identifiers"
-    t.json "funding_references"
-    t.json "geo_locations"
-    t.json "rights_list"
-    t.json "subjects"
-    t.string "schema_version", limit: 191
-    t.json "content_url"
-    t.binary "xml", size: :medium
-    t.json "landing_page"
-    t.string "agency", limit: 191, default: "datacite"
-    t.string "type", limit: 16, default: "DataCiteDoi"
-    t.json "related_items"
     t.json "publisher_obj"
+    t.string "reason"
+    t.json "related_identifiers"
+    t.json "related_items"
+    t.json "rights_list"
+    t.string "schema_version", limit: 191
+    t.json "sizes"
+    t.string "source", limit: 191
+    t.json "subjects"
+    t.json "titles"
+    t.string "type", limit: 16, default: "DataCiteDoi"
+    t.json "types"
+    t.datetime "updated"
+    t.text "url"
+    t.integer "version"
+    t.string "version_info", limit: 191
+    t.binary "xml", size: :medium
     t.index ["aasm_state"], name: "index_dataset_on_aasm_state"
     t.index ["created", "indexed", "updated"], name: "index_dataset_on_created_indexed_updated"
     t.index ["datacentre"], name: "FK5605B47847B5F5FF"
@@ -240,18 +254,18 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_10_131437) do
   end
 
   create_table "enrichments", charset: "utf8mb3", force: :cascade do |t|
-    t.string "doi", null: false
-    t.json "contributors", null: false
-    t.json "resources", null: false
-    t.string "field", null: false
     t.string "action", null: false
-    t.json "original_value"
-    t.json "enriched_value"
-    t.string "filename"
+    t.json "contributors", null: false
     t.datetime "created_at", null: false
+    t.string "doi", null: false
+    t.json "enriched_value"
+    t.string "field", null: false
+    t.string "filename"
+    t.json "original_value"
+    t.json "resources", null: false
+    t.string "source_id", null: false
     t.datetime "updated_at", null: false
     t.string "uuid", limit: 36, null: false
-    t.string "source_id", null: false
     t.index ["doi", "updated_at", "id"], name: "index_enrichments_on_doi_and_updated_at_and_id", order: { updated_at: :desc, id: :desc }
     t.index ["field"], name: "index_enrichments_on_field"
     t.index ["filename"], name: "index_enrichments_on_filename"
@@ -260,29 +274,29 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_10_131437) do
   end
 
   create_table "events", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.text "uuid", null: false
-    t.text "subj_id", null: false
-    t.text "obj_id"
-    t.string "source_id", limit: 191
     t.string "aasm_state"
-    t.string "state_event"
     t.text "callback"
-    t.text "error_messages"
-    t.text "source_token"
     t.datetime "created_at", precision: 3, null: false
-    t.datetime "updated_at", precision: 3, null: false
+    t.text "error_messages"
     t.datetime "indexed_at", default: "1970-01-01 00:00:00", null: false
-    t.datetime "occurred_at"
-    t.string "message_action", limit: 191, default: "create", null: false
-    t.string "relation_type_id", limit: 191
-    t.text "subj", size: :medium
-    t.text "obj", size: :medium
-    t.integer "total", default: 1
     t.string "license", limit: 191
+    t.string "message_action", limit: 191, default: "create", null: false
+    t.text "obj", size: :medium
+    t.text "obj_id"
+    t.datetime "occurred_at"
+    t.string "relation_type_id", limit: 191
     t.text "source_doi"
-    t.text "target_doi"
+    t.string "source_id", limit: 191
     t.string "source_relation_type_id", limit: 191
+    t.text "source_token"
+    t.string "state_event"
+    t.text "subj", size: :medium
+    t.text "subj_id", null: false
+    t.text "target_doi"
     t.string "target_relation_type_id", limit: 191
+    t.integer "total", default: 1
+    t.datetime "updated_at", precision: 3, null: false
+    t.text "uuid", null: false
     t.index ["created_at", "indexed_at", "updated_at"], name: "index_events_on_created_indexed_updated"
     t.index ["source_doi", "source_relation_type_id"], name: "index_events_on_source_doi", length: { source_doi: 100 }
     t.index ["source_id", "created_at"], name: "index_events_on_source_id_created_at"
@@ -294,11 +308,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_10_131437) do
 
   create_table "media", charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created"
+    t.bigint "dataset", null: false
     t.string "media_type", limit: 80
     t.datetime "updated"
     t.text "url", null: false
     t.integer "version"
-    t.bigint "dataset", null: false
     t.index ["dataset", "created"], name: "index_media_dataset_created"
     t.index ["dataset", "updated"], name: "dataset_updated"
     t.index ["dataset"], name: "FK62F6FE44D3D6B1B"
@@ -307,12 +321,12 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_10_131437) do
 
   create_table "metadata", charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created"
-    t.integer "metadata_version"
-    t.integer "version"
-    t.binary "xml", size: :medium
     t.bigint "dataset", null: false
     t.binary "is_converted_by_mds", limit: 1
+    t.integer "metadata_version"
     t.string "namespace"
+    t.integer "version"
+    t.binary "xml", size: :medium
     t.index ["dataset", "created"], name: "index_metadata_dataset_created"
     t.index ["dataset", "metadata_version"], name: "dataset_version"
     t.index ["dataset"], name: "FKE52D7B2F4D3D6B1B"
@@ -325,11 +339,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_10_131437) do
   end
 
   create_table "provider_prefixes", charset: "utf8mb3", force: :cascade do |t|
-    t.bigint "provider_id", null: false
-    t.bigint "prefix_id", null: false
     t.datetime "created_at"
-    t.datetime "updated_at"
+    t.bigint "prefix_id", null: false
+    t.bigint "provider_id", null: false
     t.string "uid", null: false
+    t.datetime "updated_at"
     t.index ["prefix_id"], name: "FKE7FBD674AF86A1C7"
     t.index ["provider_id"], name: "FKE7FBD67446EBD781"
     t.index ["uid"], name: "index_provider_prefixes_on_uid", length: 128
@@ -337,8 +351,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_10_131437) do
 
   create_table "reference_repositories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "client_id"
-    t.string "re3doi"
     t.datetime "created_at", null: false
+    t.string "re3doi"
     t.datetime "updated_at", null: false
   end
 

--- a/spec/concerns/authenticable_spec.rb
+++ b/spec/concerns/authenticable_spec.rb
@@ -118,6 +118,17 @@ describe User, type: :model, elasticsearch: true do
         ).to be false
       end
 
+      it "client_api" do
+        token =
+          User.generate_token(
+            role_id: "client_api", client_id: "datacite.rph",
+          )
+        subject = User.new(token)
+        expect(
+          subject.not_allowed_by_doi_and_user(doi: doi, user: subject),
+        ).to be false
+      end
+
       it "client_user" do
         token =
           User.generate_token(role_id: "client_user", client_id: "datacite.rph")
@@ -126,6 +137,7 @@ describe User, type: :model, elasticsearch: true do
           subject.not_allowed_by_doi_and_user(doi: doi, user: subject),
         ).to be false
       end
+
 
       it "user" do
         token = User.generate_token(role_id: "user")
@@ -239,6 +251,17 @@ describe User, type: :model, elasticsearch: true do
         ).to be false
       end
 
+      it "client_api" do
+        token =
+          User.generate_token(
+            role_id: "client_api", client_id: "datacite.rph",
+          )
+        subject = User.new(token)
+        expect(
+          subject.not_allowed_by_doi_and_user(doi: doi, user: subject),
+        ).to be false
+      end
+
       it "client_user" do
         token =
           User.generate_token(role_id: "client_user", client_id: "datacite.rph")
@@ -247,6 +270,7 @@ describe User, type: :model, elasticsearch: true do
           subject.not_allowed_by_doi_and_user(doi: doi, user: subject),
         ).to be false
       end
+
 
       it "user" do
         token = User.generate_token(role_id: "user")
@@ -408,6 +432,86 @@ describe Client, type: :model do
 
     it "does not contain password" do
       expect(payload).to include("role_id")
+    end
+  end
+end
+
+describe "API key authentication", type: :model do
+  let(:client) { create(:client, password_input: "12345") }
+  let(:api_key_record) { client.api_keys.create!(name: "spec key") }
+  let(:plain_key) { api_key_record.key }
+
+  describe "decode_auth_param using key as username (per ACs)" do
+    it "authenticates with api key as username (password ignored/discarded)" do
+      payload = client.decode_auth_param(
+        username: plain_key,
+        password: "",
+      )
+      expect(payload["uid"]).to eq(client.symbol.downcase)
+      expect(payload["role_id"]).to eq("client_api")
+      expect(payload["client_id"]).to eq(client.symbol.downcase)
+      expect(payload["auth_method"]).to eq("api_key")
+      expect(payload["api_key_prefix"]).to eq(api_key_record.key_prefix)
+      expect(payload["api_key_id"]).to eq(api_key_record.id)
+      expect(payload).not_to have_key("password")
+    end
+
+    it "authenticates with api key as username even with dummy password" do
+      payload = client.decode_auth_param(
+        username: plain_key,
+        password: "ignored",
+      )
+      expect(payload["uid"]).to eq(client.symbol.downcase)
+      expect(payload["auth_method"]).to eq("api_key")
+      expect(payload["role_id"]).to eq("client_api")
+    end
+  end
+
+  describe "decode_auth_param using key as password (backward compat)" do
+    it "authenticates with api key value instead of account password" do
+      payload = client.decode_auth_param(
+        username: client.symbol,
+        password: plain_key,
+      )
+      expect(payload["uid"]).to eq(client.symbol.downcase)
+      expect(payload["role_id"]).to eq("client_api")
+      expect(payload["client_id"]).to eq(client.symbol.downcase)
+      expect(payload["auth_method"]).to eq("api_key")
+      expect(payload["api_key_prefix"]).to eq(api_key_record.key_prefix)
+    end
+
+    it "still prefers the real password when both could match" do
+      payload = client.decode_auth_param(
+        username: client.symbol,
+        password: "12345",
+      )
+      expect(payload["uid"]).to eq(client.symbol.downcase)
+      expect(payload["role_id"]).to eq("client_admin")
+      expect(payload["auth_method"]).to be_nil
+      expect(payload["api_key_prefix"]).to be_nil
+    end
+
+    it "rejects wrong key" do
+      payload = client.decode_auth_param(
+        username: client.symbol,
+        password: "DC.wrongkeyvalue1234567890abcdef",
+      )
+      expect(payload).to eq({})
+    end
+  end
+
+  describe "decode_api_key (for Bearer)" do
+    it "returns payload for valid key" do
+      payload = client.decode_api_key(plain_key)
+      expect(payload["client_id"]).to eq(client.symbol.downcase)
+      expect(payload["role_id"]).to eq("client_api")
+      expect(payload["auth_method"]).to eq("api_key")
+      expect(payload["api_key_prefix"]).to eq(api_key_record.key_prefix)
+    end
+
+    it "returns error for invalid" do
+      payload = client.decode_api_key("bad")
+      expect(payload[:errors]).to be_present
     end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -157,6 +157,60 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         is_expected.to be_able_to(:destroy, doi)
         is_expected.not_to be_able_to(:transfer, doi)
       end
+
+      it "can manage api keys for the client" do
+        api_key = client.api_keys.build(name: "test")
+        is_expected.to be_able_to(:manage, api_key)
+      end
+    end
+
+    context "when is a client_api (API key automation)" do
+      let(:consortium) { create(:provider, role_name: "ROLE_CONSORTIUM") }
+      let(:provider) do
+        create(
+          :provider,
+          consortium: consortium, role_name: "ROLE_CONSORTIUM_ORGANIZATION",
+        )
+      end
+      let!(:prefix) { create(:prefix, uid: "10.14454") }
+      let!(:provider_prefix) { create(:provider_prefix, provider: provider, prefix: prefix) }
+      let(:client) { create(:client, provider: provider) }
+      let!(:client_prefix) { create(:client_prefix, client: client, prefix: prefix) }
+      let(:token) do
+        User.generate_token({
+          role_id: "client_api",
+          provider_id: provider.symbol.downcase,
+          client_id: client.symbol.downcase,
+        })
+      end
+
+      it "can read but not update the client or contacts/analytics" do
+        is_expected.to be_able_to(:read, client)
+        is_expected.not_to be_able_to(:update, client)
+        is_expected.not_to be_able_to(:read_contact_information, client)
+        is_expected.not_to be_able_to(:read_analytics, client)
+      end
+
+      it "cannot manage or read api keys" do
+        api_key = client.api_keys.build(name: "machine")
+        is_expected.not_to be_able_to(:manage, api_key)
+        is_expected.not_to be_able_to(:read, api_key)
+        is_expected.not_to be_able_to(:create, api_key)
+      end
+
+      it "can read/create/update/destroy dois but not get_urls or transfer" do
+        is_expected.to be_able_to(:read, doi)
+        is_expected.to be_able_to(:create, doi)
+        is_expected.to be_able_to(:update, doi)
+        is_expected.to be_able_to(:destroy, doi)
+        is_expected.to be_able_to(:get_url, doi)
+        is_expected.not_to be_able_to(:get_urls, Doi)
+        is_expected.not_to be_able_to(:transfer, doi)
+      end
+
+      it "can access datafile credentials" do
+        is_expected.to be_able_to(:read, :access_datafile)
+      end
     end
 
     context "when is a client admin inactive" do

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ApiKey, type: :model do
+  let(:client) { create(:client, password_input: "12345") }
+
+  describe "creation" do
+    it "generates a key with prefix and stores only the hash" do
+      api_key = client.api_keys.create!(name: "CI key")
+
+      expect(api_key.key).to start_with("DC.")
+      expect(api_key.key_prefix).to start_with("DC.")
+      expect(api_key.key_hash).to be_present
+      expect(api_key.key_hash).not_to eq(api_key.key)
+      expect(api_key.revoked_at).to be_nil
+      expect(api_key.id).to match(/\A[0-9a-f-]{36}\z/i)  # uuid
+      expect(api_key.created_at).to be_present
+    end
+  end
+
+  describe ".authenticate" do
+    it "returns the key for valid token" do
+      api_key = client.api_keys.create!(name: "test")
+      plain = api_key.key
+
+      found = ApiKey.authenticate(plain)
+      expect(found).to eq(api_key)
+    end
+
+    it "returns nil for invalid token" do
+      client.api_keys.create!(name: "test")
+      expect(ApiKey.authenticate("DC.wrong")).to be_nil
+    end
+
+    it "does not authenticate revoked keys" do
+      api_key = client.api_keys.create!(name: "test")
+      api_key.revoke!
+
+      expect(ApiKey.authenticate(api_key.key)).to be_nil
+    end
+  end
+
+  describe "revoke" do
+    it "soft revokes" do
+      api_key = client.api_keys.create!(name: "to-revoke")
+      api_key.revoke!
+      expect(api_key.revoked?).to be true
+      expect(ApiKey.active).not_to include(api_key)
+    end
+  end
+end

--- a/spec/requests/api_keys_spec.rb
+++ b/spec/requests/api_keys_spec.rb
@@ -1,0 +1,284 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ApiKeysController, type: :request do
+  include Passwordable
+
+  let(:admin) { create(:provider, symbol: "ADMIN") }
+  let(:admin_bearer) do
+    Client.generate_token(
+      role_id: "staff_admin",
+      uid: admin.symbol,
+      password: admin.password,
+    )
+  end
+  let(:admin_headers) do
+    {
+      "HTTP_ACCEPT" => "application/vnd.api+json",
+      "HTTP_AUTHORIZATION" => "Bearer " + admin_bearer,
+    }
+  end
+
+  let(:provider) { create(:provider, symbol: "DATACITE") }
+  let(:client) { create(:client, provider: provider, symbol: "DATACITE.TESTKEY", password_input: "12345") }
+  let(:bearer) do
+    Client.generate_token(
+      role_id: "client_admin",
+      uid: client.symbol.downcase,
+      provider_id: provider.symbol.downcase,
+      client_id: client.symbol.downcase,
+    )
+  end
+  let(:headers) { { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => "Bearer " + bearer } }
+
+  describe "POST /credentials/api-keys" do
+    it "creates an api key using Basic client credentials (infers client from auth)" do
+      basic = ActionController::HttpAuthentication::Basic.encode_credentials(client.symbol, "12345")
+      basic_headers = { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => basic }
+
+      post "/credentials/api-keys",
+           { data: { type: "api-keys", attributes: { name: "Dataverse key" } } },
+           basic_headers
+
+      expect(last_response.status).to eq(201)
+      expect(json.dig("data", "attributes", "name")).to eq("Dataverse key")
+      key = json.dig("data", "attributes", "key")
+      expect(key).to start_with("DC.")
+      expect(json.dig("data", "id")).to be_present  # uuid
+      expect(json.dig("data", "relationships", "client", "data", "id")).to eq(
+        client.symbol,
+      )
+      expect(json.dig("data", "relationships", "client", "data", "type")).to eq(
+        "clients",
+      )
+    end
+  end
+
+  describe "authentication with api key (drop-in)" do
+    let(:api_key) do
+      # create via direct model to avoid controller for this test
+      k = client.api_keys.create!(name: "auth-test")
+      k.key
+    end
+
+    it "allows basic auth using client symbol + api key value (as password)" do
+      basic = ActionController::HttpAuthentication::Basic.encode_credentials(client.symbol, api_key)
+      basic_headers = { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => basic }
+
+      # hit an authenticated endpoint that returns 200 for client
+      get "/clients/#{client.symbol}",
+          nil, basic_headers
+      expect(last_response.status).to eq(200)
+    end
+
+    it "allows basic auth using api key as username (password discarded)" do
+      basic = ActionController::HttpAuthentication::Basic.encode_credentials(api_key, "")
+      basic_headers = { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => basic }
+
+      get "/clients/#{client.symbol}",
+          nil, basic_headers
+      expect(last_response.status).to eq(200)
+    end
+
+    it "allows basic auth using api key as username (with dummy password, which is discarded)" do
+      basic = ActionController::HttpAuthentication::Basic.encode_credentials(api_key, "ignored")
+      basic_headers = { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => basic }
+
+      get "/clients/#{client.symbol}",
+          nil, basic_headers
+      expect(last_response.status).to eq(200)
+    end
+
+    it "allows Bearer with raw api key" do
+      bearer_headers = { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => "Bearer #{api_key}" }
+
+      get "/clients/#{client.symbol}",
+          nil, bearer_headers
+      expect(last_response.status).to eq(200)
+    end
+  end
+
+  describe "GET /credentials/api-keys" do
+    it "lists keys using Basic client credentials" do
+      client.api_keys.create!(name: "list-test")
+      basic = ActionController::HttpAuthentication::Basic.encode_credentials(client.symbol, "12345")
+      basic_headers = { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => basic }
+
+      get "/credentials/api-keys",
+          nil, basic_headers
+      expect(last_response.status).to eq(200)
+      items = json["data"]
+      expect(items.any? { |i| i.dig("attributes", "name") == "list-test" }).to be true
+      expect(items.first["id"]).to be_present
+      expect(items.first.dig("attributes", "created")).to be_present
+    end
+
+    it "includes revoked keys when requested by an admin" do
+      active_key = client.api_keys.create!(name: "active-key")
+      revoked_key = client.api_keys.create!(name: "revoked-key")
+      revoked_key.revoke!
+
+      get "/credentials/api-keys?include_revoked=true",
+          nil, admin_headers
+
+      expect(last_response.status).to eq(200)
+      items = json["data"]
+
+      expect(items.map { |item| item.dig("attributes", "name") }).to include("active-key", "revoked-key")
+      expect(items.find { |item| item.dig("attributes", "name") == "revoked-key" }.dig("attributes", "revokedAt")).to be_present
+      expect(items.find { |item| item.dig("attributes", "name") == "active-key" }.dig("attributes", "revokedAt")).to be_nil
+      expect(active_key.reload.revoked_at).to be_nil
+    end
+
+    it "includes own revoked keys for client password when include_revoked=true" do
+      client.api_keys.create!(name: "active-key")
+      revoked_key = client.api_keys.create!(name: "revoked-key")
+      revoked_key.revoke!
+
+      basic = ActionController::HttpAuthentication::Basic.encode_credentials(client.symbol, "12345")
+      basic_headers = { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => basic }
+
+      get "/credentials/api-keys?include_revoked=true", nil, basic_headers
+
+      expect(last_response.status).to eq(200)
+      names = json["data"].map { |item| item.dig("attributes", "name") }
+      expect(names).to include("active-key", "revoked-key")
+    end
+
+    it "returns 403 for provider credentials (no client_id)" do
+      ActionController::HttpAuthentication::Basic.encode_credentials(provider.symbol, "12345")
+      # provider factory may not set password — use token instead if needed
+      provider_token = Client.generate_token(
+        role_id: "provider_admin",
+        uid: provider.symbol.downcase,
+        provider_id: provider.symbol.downcase,
+      )
+      get "/credentials/api-keys",
+          nil,
+          {
+            "HTTP_ACCEPT" => "application/vnd.api+json",
+            "HTTP_AUTHORIZATION" => "Bearer #{provider_token}",
+          }
+      expect(last_response.status).to eq(403)
+    end
+
+    it "returns 401 without valid credentials" do
+      get "/credentials/api-keys",
+          nil
+      expect(last_response.status).to eq(401)
+    end
+  end
+
+  describe "DELETE /credentials/api-keys/:id" do
+    it "revokes the key using Basic client credentials" do
+      k = client.api_keys.create!(name: "to-delete")
+      basic = ActionController::HttpAuthentication::Basic.encode_credentials(client.symbol, "12345")
+      basic_headers = { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => basic }
+
+      delete "/credentials/api-keys/#{k.id}",
+             nil, basic_headers
+      expect(last_response.status).to eq(204)
+
+      expect(k.reload.revoked_at).to be_present
+    end
+  end
+
+  describe "API key cannot manage credentials" do
+    let(:api_key_record) { client.api_keys.create!(name: "machine") }
+    let(:plain_key) { api_key_record.key }
+    let(:other_key) { client.api_keys.create!(name: "other") }
+
+    it "rejects list with API key as Bearer" do
+      get "/credentials/api-keys",
+          nil,
+          {
+            "HTTP_ACCEPT" => "application/vnd.api+json",
+            "HTTP_AUTHORIZATION" => "Bearer #{plain_key}",
+          }
+      expect(last_response.status).to eq(403)
+    end
+
+    it "rejects create with API key as Basic username" do
+      basic = ActionController::HttpAuthentication::Basic.encode_credentials(plain_key, "")
+      post "/credentials/api-keys",
+           { data: { type: "api-keys", attributes: { name: "sibling" } } },
+           { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => basic }
+      expect(last_response.status).to eq(403)
+      expect(client.api_keys.where(name: "sibling")).to be_empty
+    end
+
+    it "rejects create with client symbol + API key as password" do
+      basic = ActionController::HttpAuthentication::Basic.encode_credentials(client.symbol, plain_key)
+      post "/credentials/api-keys",
+           { data: { type: "api-keys", attributes: { name: "sibling" } } },
+           { "HTTP_ACCEPT" => "application/vnd.api+json", "HTTP_AUTHORIZATION" => basic }
+      expect(last_response.status).to eq(403)
+    end
+
+    it "rejects revoke with API key Bearer" do
+      delete "/credentials/api-keys/#{other_key.id}",
+             nil,
+             {
+               "HTTP_ACCEPT" => "application/vnd.api+json",
+               "HTTP_AUTHORIZATION" => "Bearer #{plain_key}",
+             }
+      expect(last_response.status).to eq(403)
+      expect(other_key.reload.revoked_at).to be_nil
+    end
+
+    it "still allows DOI/client API with API key Bearer" do
+      get "/clients/#{client.symbol}",
+          nil,
+          {
+            "HTTP_ACCEPT" => "application/vnd.api+json",
+            "HTTP_AUTHORIZATION" => "Bearer #{plain_key}",
+          }
+      expect(last_response.status).to eq(200)
+    end
+
+    it "allows credential management with JWT (password session)" do
+      get "/credentials/api-keys", nil, headers
+      expect(last_response.status).to eq(200)
+    end
+
+    it "rejects list with JWT that has client_api role (no ApiKey ability)" do
+      api_jwt = Client.generate_token(
+        role_id: "client_api",
+        uid: client.symbol.downcase,
+        provider_id: provider.symbol.downcase,
+        client_id: client.symbol.downcase,
+      )
+      get "/credentials/api-keys",
+          nil,
+          {
+            "HTTP_ACCEPT" => "application/vnd.api+json",
+            "HTTP_AUTHORIZATION" => "Bearer #{api_jwt}",
+          }
+      expect(last_response.status).to eq(403)
+    end
+  end
+
+  describe "POST /token rejects API key credentials" do
+    it "does not mint a token when password is an API key" do
+      api_key = client.api_keys.create!(name: "no-token")
+      params =
+        "grant_type=password&username=#{client.symbol}&password=#{CGI.escape(api_key.key)}"
+      post "/token", params
+
+      expect(last_response.status).to eq(400)
+      expect(json.fetch("errors", {}).first["title"]).to eq(
+        "Wrong account ID or password.",
+      )
+      expect(json["access_token"]).to be_blank
+    end
+
+    it "mints a token with the real client password" do
+      params = "grant_type=password&username=#{client.symbol}&password=12345"
+      post "/token", params
+
+      expect(last_response.status).to eq(200)
+      expect(json["access_token"]).to be_present
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Hotfix/release branch based on **5.73.0** with only [PR #1543](https://github.com/datacite/lupo/pull/1543) (API keys for client/repository authentication).

This intentionally **excludes** all enrichment-related work that landed in 5.74.0:

- #1527 Add enriched DOI OS index
- #1562 Enriched DOI indexing
- #1561 Fix enrichments index next link
- #1564 Add enrichments to enriched_doi mapping
- #1565 Index original DOI into enriched-dois when invalid
- #1566 Rescue indexing errors when enriched-dois indices unavailable

### How this branch was built

1. Branched from tag `5.73.0` (`29f329f7`)
2. Cherry-picked `68e05638` (API keys squash merge from #1543) → `03cd35b5`

### Deploy intent

Ship a release that contains **only** API key authentication changes relative to 5.73.0—not the enriched-DOI stack from 5.74.0.

**Note:** Merging this PR into `master` will not remove enrichment commits already on `master`. Use this branch as a release/hotfix line (tag and deploy from here), or follow up separately to revert enrichment PRs on `master` if that history should be cleaned up.

## Test plan

- [ ] Confirm branch tip is `5.73.0` + API keys only (`git log --oneline 5.73.0..HEAD` shows a single #1543 commit)
- [ ] Run API key request specs (`spec/requests/api_keys_spec.rb`, related authenticable/ability specs)
- [ ] Smoke-test create / list / revoke API keys with client Basic auth
- [ ] Smoke-test MDS/REST auth with API key as Basic username
- [ ] Confirm no enriched-DOI index code paths are present in this tree
- [ ] Tag and deploy from this branch; verify production does not pick up enrichment indexing behavior from 5.74.0