### PR TITLE
Fix is_active truthiness so inactive accounts stay inactive

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -26,7 +26,10 @@ class Ability
       can :export, :repositories
     elsif user.role_id == "staff_user"
       can %i[read read_billing_information read_contact_information read_analytics], :all
-    elsif user.role_id == "consortium_admin" && user.provider_id.present?
+    elsif user.role_id == "consortium_admin" && user.provider_id.present? &&
+        provider_account_active?(user)
+      # Active consortium: full management of self, child orgs, and their clients.
+      # Same pattern as active client_admin (is_active == "\x01").
       can %i[manage read_billing_information read_contact_information], Provider do |provider|
         user.provider_id.casecmp(provider.consortium_id)
       end
@@ -66,7 +69,38 @@ class Ability
             user.provider_id.casecmp(activity.doi.provider.consortium_id)
       end
       can %i[read], :access_datafile
-    elsif user.role_id == "provider_admin" && user.provider_id.present?
+    elsif user.role_id == "consortium_admin" && user.provider_id.present?
+      # Inactive consortium: read-only (cannot self-reactivate or manage orgs/clients).
+      can %i[read read_billing_information read_contact_information], Provider do |provider|
+        user.provider_id.casecmp(provider.consortium_id)
+      end
+      can %i[read read_billing_information read_contact_information],
+          Provider,
+          symbol: user.provider_id.upcase
+      can %i[read], ProviderPrefix do |provider_prefix|
+        provider_prefix.provider &&
+          user.provider_id.casecmp(provider_prefix.provider.consortium_id)
+      end
+      can %i[read], Contact
+      can %i[read read_contact_information], Client do |client|
+        client.provider &&
+          user.provider_id.casecmp(client.provider.consortium_id)
+      end
+      can %i[read], ClientPrefix
+      can %i[read get_url read_landing_page_results], Doi do |doi|
+        user.provider_id.casecmp(doi.provider.consortium_id)
+      end
+      can %i[read], Doi
+      can %i[read], User
+      can %i[read], Activity do |activity|
+        activity.doi.findable? ||
+          activity.doi.provider &&
+            user.provider_id.casecmp(activity.doi.provider.consortium_id)
+      end
+      can %i[read], :access_datafile
+    elsif user.role_id == "provider_admin" && user.provider_id.present? &&
+        provider_account_active?(user)
+      # Active provider/member: full self-service rights.
       can %i[update read read_billing_information read_contact_information read_analytics],
           Provider,
           symbol: user.provider_id.upcase
@@ -90,6 +124,25 @@ class Ability
       # end
 
       can %i[read get_url transfer read_landing_page_results],
+          Doi,
+          provider_id: user.provider_id
+      can %i[read], Doi
+      can %i[read], User
+      can %i[read], Activity do |activity|
+        activity.doi.findable? || activity.doi.provider_id == user.provider_id
+      end
+      can %i[read], :access_datafile
+    elsif user.role_id == "provider_admin" && user.provider_id.present?
+      # Inactive provider: read-only (cannot self-reactivate or manage repositories).
+      # Mirrors inactive client_admin (update/manage stripped when is_active != "\x01").
+      can %i[read read_billing_information read_contact_information read_analytics],
+          Provider,
+          symbol: user.provider_id.upcase
+      can %i[read], Contact, provider_id: user.provider_id
+      can %i[read], ProviderPrefix, provider_id: user.provider_id
+      can %i[read read_contact_information], Client, provider_id: user.provider_id
+      can %i[read], ClientPrefix
+      can %i[read get_url read_landing_page_results],
           Doi,
           provider_id: user.provider_id
       can %i[read], Doi
@@ -259,4 +312,11 @@ class Ability
       end
     end
   end
+
+  private
+    # Providers store is_active as binary(1): "\x01" active, "\x00" inactive.
+    # Same check used for client_admin / client_api active gates.
+    def provider_account_active?(user)
+      user.provider.present? && user.provider.is_active == "\x01"
+    end
 end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -26,6 +26,9 @@ class Client < ApplicationRecord
   # include helper module for setting password
   include Passwordable
 
+  # normalize binary is_active flags without Ruby truthiness bugs
+  include BinaryActiveFlag
+
   # include helper module for authentication
   include Authenticable
 
@@ -990,7 +993,7 @@ class Client < ApplicationRecord
       if repository_type.blank? || client_type == "periodical"
         self.repository_type = []
       end
-      self.is_active = is_active ? "\x01" : "\x00"
+      normalize_binary_is_active
       self.version = version.present? ? version + 1 : 0
       self.role_name = "ROLE_DATACENTRE" if role_name.blank?
       self.doi_quota_used = 0 unless doi_quota_used.to_i > 0

--- a/app/models/concerns/binary_active_flag.rb
+++ b/app/models/concerns/binary_active_flag.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# is_active is stored as binary(1): "\x01" active, "\x00" inactive.
+# Ruby truthiness treats "\x00" as truthy, so plain `is_active ? ...` wrongly
+# reactivates inactive accounts on every validation.
+module BinaryActiveFlag
+  extend ActiveSupport::Concern
+
+  private
+    def normalize_binary_is_active
+      self.is_active = binary_is_active? ? "\x01" : "\x00"
+    end
+
+    # Accepts API booleans/integers and the binary column values used in the DB.
+    def binary_is_active?(value = is_active)
+      case value
+      when true, 1, "1"
+        true
+      when false, 0, "0", nil
+        false
+      else
+        str = value.to_s
+        return false if str.empty?
+
+        str.getbyte(0) == 1
+      end
+    end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -37,6 +37,9 @@ class Provider < ApplicationRecord
   # include helper module for setting password
   include Passwordable
 
+  # normalize binary is_active flags without Ruby truthiness bugs
+  include BinaryActiveFlag
+
   # include helper module for authentication
   include Authenticable
 
@@ -978,7 +981,7 @@ class Provider < ApplicationRecord
 
     def set_defaults
       self.symbol = symbol.upcase if symbol.present?
-      self.is_active = is_active ? "\x01" : "\x00"
+      normalize_binary_is_active
       self.version = version.present? ? version + 1 : 0
       self.role_name = "ROLE_ALLOCATOR" if role_name.blank?
       self.doi_quota_used = 0 unless doi_quota_used.to_i > 0

--- a/spec/concerns/binary_active_flag_spec.rb
+++ b/spec/concerns/binary_active_flag_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe BinaryActiveFlag do
+  # Provider includes BinaryActiveFlag; exercise the private helpers via send.
+  let(:provider) { build(:provider) }
+
+  describe "#binary_is_active?" do
+    it "treats true-like values as active" do
+      expect(provider.send(:binary_is_active?, true)).to be true
+      expect(provider.send(:binary_is_active?, 1)).to be true
+      expect(provider.send(:binary_is_active?, "1")).to be true
+      expect(provider.send(:binary_is_active?, "\x01")).to be true
+    end
+
+    it "treats false-like values as inactive" do
+      expect(provider.send(:binary_is_active?, false)).to be false
+      expect(provider.send(:binary_is_active?, 0)).to be false
+      expect(provider.send(:binary_is_active?, "0")).to be false
+      expect(provider.send(:binary_is_active?, nil)).to be false
+      expect(provider.send(:binary_is_active?, "")).to be false
+      expect(provider.send(:binary_is_active?, "\x00")).to be false
+    end
+
+    # Regression for product-backlog#912: "\x00" is truthy in Ruby but means inactive.
+    it "does not treat the inactive binary flag as active" do
+      expect(!!"\x00").to be true
+      expect(provider.send(:binary_is_active?, "\x00")).to be false
+    end
+  end
+
+  describe "#normalize_binary_is_active" do
+    it "writes binary flags for active and inactive states" do
+      provider.is_active = false
+      provider.send(:normalize_binary_is_active)
+      expect(provider.is_active).to eq("\x00")
+
+      provider.is_active = "\x00"
+      provider.send(:normalize_binary_is_active)
+      expect(provider.is_active).to eq("\x00")
+
+      provider.is_active = true
+      provider.send(:normalize_binary_is_active)
+      expect(provider.is_active).to eq("\x01")
+    end
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -365,6 +365,21 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
     end
 
     context "when is a provider admin" do
+      # Persisted provider required: Ability checks user.provider.is_active.
+      let(:consortium) { create(:provider, role_name: "ROLE_CONSORTIUM") }
+      let(:provider) do
+        create(
+          :provider,
+          consortium: consortium,
+          role_name: "ROLE_CONSORTIUM_ORGANIZATION",
+          is_active: true,
+        )
+      end
+      let(:contact) { create(:contact, provider: provider) }
+      let!(:prefix) { create(:prefix, uid: "10.14454") }
+      let!(:provider_prefix) { create(:provider_prefix, provider: provider, prefix: prefix) }
+      let(:client) { create(:client, provider: provider) }
+      let!(:client_prefix) { create(:client_prefix, client: client, prefix: prefix) }
       let(:token) do
         User.generate_token(
           role_id: "provider_admin", provider_id: provider.symbol.downcase,
@@ -424,7 +439,87 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
       end
     end
 
+    context "when is a provider admin inactive" do
+      let(:consortium) { create(:provider, role_name: "ROLE_CONSORTIUM") }
+      let(:provider) do
+        create(
+          :provider,
+          consortium: consortium,
+          role_name: "ROLE_CONSORTIUM_ORGANIZATION",
+          is_active: false,
+        )
+      end
+      let(:contact) { create(:contact, provider: provider) }
+      let!(:prefix) { create(:prefix, uid: "10.14454") }
+      let!(:provider_prefix) { create(:provider_prefix, provider: provider, prefix: prefix) }
+      let(:client) { create(:client, provider: provider) }
+      let!(:client_prefix) { create(:client_prefix, client: client, prefix: prefix) }
+      let(:token) do
+        User.generate_token(
+          role_id: "provider_admin", provider_id: provider.symbol.downcase,
+        )
+      end
+
+      it "can read the user" do
+        is_expected.to be_able_to(:read, user)
+      end
+
+      it "can read but not update/create/destroy the provider (cannot self-reactivate)" do
+        is_expected.to be_able_to(:read, provider)
+        is_expected.to be_able_to(:read_billing_information, provider)
+        is_expected.to be_able_to(:read_contact_information, provider)
+        is_expected.not_to be_able_to(:update, provider)
+        is_expected.not_to be_able_to(:create, provider)
+        is_expected.not_to be_able_to(:destroy, provider)
+      end
+
+      it "can read but not create/update/destroy the contact" do
+        is_expected.to be_able_to(:read, contact)
+        is_expected.not_to be_able_to(:create, contact)
+        is_expected.not_to be_able_to(:update, contact)
+        is_expected.not_to be_able_to(:destroy, contact)
+      end
+
+      it "can read but not create/update/destroy/transfer the client" do
+        is_expected.to be_able_to(:read, client)
+        is_expected.to be_able_to(:read_contact_information, client)
+        is_expected.not_to be_able_to(:create, client)
+        is_expected.not_to be_able_to(:update, client)
+        is_expected.not_to be_able_to(:destroy, client)
+        is_expected.not_to be_able_to(:transfer, client)
+      end
+
+      it "can read but not create/update/destroy the provider prefix" do
+        is_expected.to be_able_to(:read, provider_prefix)
+        is_expected.not_to be_able_to(:create, provider_prefix)
+        is_expected.not_to be_able_to(:update, provider_prefix)
+        is_expected.not_to be_able_to(:destroy, provider_prefix)
+      end
+
+      it "can read but not transfer/create/update/destroy the doi" do
+        is_expected.to be_able_to(:read, doi)
+        is_expected.not_to be_able_to(:transfer, doi)
+        is_expected.not_to be_able_to(:create, doi)
+        is_expected.not_to be_able_to(:update, doi)
+        is_expected.not_to be_able_to(:destroy, doi)
+      end
+    end
+
     context "when is a consortium admin" do
+      let(:consortium) { create(:provider, role_name: "ROLE_CONSORTIUM", is_active: true) }
+      let(:provider) do
+        create(
+          :provider,
+          consortium: consortium,
+          role_name: "ROLE_CONSORTIUM_ORGANIZATION",
+        )
+      end
+      let(:contact) { create(:contact, provider: provider) }
+      let(:consortium_contact) { create(:contact, provider: consortium) }
+      let!(:prefix) { create(:prefix, uid: "10.14454") }
+      let!(:provider_prefix) { create(:provider_prefix, provider: provider, prefix: prefix) }
+      let(:client) { create(:client, provider: provider) }
+      let!(:client_prefix) { create(:client_prefix, client: client, prefix: prefix) }
       let(:token) do
         User.generate_token(
           role_id: "consortium_admin", provider_id: consortium.symbol.downcase,
@@ -498,6 +593,62 @@ describe User, type: :model, elasticsearch: false, skip_prefix_pool: true do
         is_expected.not_to be_able_to(:create, doi)
         is_expected.not_to be_able_to(:update, doi)
         is_expected.not_to be_able_to(:destroy, doi)
+      end
+    end
+
+    context "when is a consortium admin inactive" do
+      let(:consortium) { create(:provider, role_name: "ROLE_CONSORTIUM", is_active: false) }
+      let(:provider) do
+        create(
+          :provider,
+          consortium: consortium,
+          role_name: "ROLE_CONSORTIUM_ORGANIZATION",
+        )
+      end
+      let(:contact) { create(:contact, provider: provider) }
+      let(:consortium_contact) { create(:contact, provider: consortium) }
+      let!(:prefix) { create(:prefix, uid: "10.14454") }
+      let!(:provider_prefix) { create(:provider_prefix, provider: provider, prefix: prefix) }
+      let(:client) { create(:client, provider: provider) }
+      let!(:client_prefix) { create(:client_prefix, client: client, prefix: prefix) }
+      let(:token) do
+        User.generate_token(
+          role_id: "consortium_admin", provider_id: consortium.symbol.downcase,
+        )
+      end
+
+      it "can read the user" do
+        is_expected.to be_able_to(:read, user)
+      end
+
+      it "can read but not update/create/destroy the consortium (cannot self-reactivate)" do
+        is_expected.to be_able_to(:read, consortium)
+        is_expected.not_to be_able_to(:update, consortium)
+        is_expected.not_to be_able_to(:create, consortium)
+        is_expected.not_to be_able_to(:destroy, consortium)
+      end
+
+      it "can read but not create/update/destroy child consortium organizations" do
+        is_expected.to be_able_to(:read, provider)
+        is_expected.not_to be_able_to(:create, provider)
+        is_expected.not_to be_able_to(:update, provider)
+        is_expected.not_to be_able_to(:destroy, provider)
+      end
+
+      it "can read but not create/update/destroy/transfer the client" do
+        is_expected.to be_able_to(:read, client)
+        is_expected.not_to be_able_to(:create, client)
+        is_expected.not_to be_able_to(:update, client)
+        is_expected.not_to be_able_to(:destroy, client)
+        is_expected.not_to be_able_to(:transfer, client)
+      end
+
+      it "can read but not create/update/destroy contacts" do
+        is_expected.to be_able_to(:read, contact)
+        is_expected.to be_able_to(:read, consortium_contact)
+        is_expected.not_to be_able_to(:create, contact)
+        is_expected.not_to be_able_to(:update, contact)
+        is_expected.not_to be_able_to(:destroy, contact)
       end
     end
 

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -198,6 +198,43 @@ describe Client, type: :model, prefix_pool_size: 3 do
     end
   end
 
+  describe "is_active" do
+    it "defaults to active binary flag" do
+      expect(client.is_active).to eq("\x01")
+    end
+
+    it "deactivates when set to false" do
+      expect(client.update(is_active: false)).to be true
+      expect(client.reload.is_active).to eq("\x00")
+    end
+
+    it "stays inactive across subsequent updates that omit is_active" do
+      client.update!(is_active: false)
+      expect(client.is_active).to eq("\x00")
+
+      expect(client.update(name: "Updated Repository")).to be true
+      expect(client.reload.is_active).to eq("\x00")
+    end
+
+    it "does not treat the inactive binary flag as truthy during validation" do
+      client.update!(is_active: false)
+      client.is_active = "\x00"
+      client.valid?
+      expect(client.is_active).to eq("\x00")
+    end
+
+    it "reactivates when set to true" do
+      client.update!(is_active: false)
+      expect(client.update(is_active: true)).to be true
+      expect(client.reload.is_active).to eq("\x01")
+    end
+
+    it "maps nil to inactive binary flag" do
+      expect(client.update(is_active: nil)).to be true
+      expect(client.reload.is_active).to eq("\x00")
+    end
+  end
+
   describe "issn" do
     let(:client) do
       build(:client, provider: provider, client_type: "periodical")

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -340,4 +340,46 @@ describe Provider, type: :model do
       expect(activity.audited_changes["non_profit_status"]).to eq("non-profit")
     end
   end
+
+  describe "is_active" do
+    it "defaults to active binary flag" do
+      provider = create(:provider)
+      expect(provider.is_active).to eq("\x01")
+    end
+
+    it "deactivates when set to false" do
+      provider = create(:provider)
+      expect(provider.update(is_active: false)).to be true
+      expect(provider.reload.is_active).to eq("\x00")
+    end
+
+    it "stays inactive across subsequent updates that omit is_active" do
+      provider = create(:provider, is_active: false)
+      expect(provider.is_active).to eq("\x00")
+
+      expect(
+        provider.update(name: "Updated Name", display_name: "Updated Name"),
+      ).to be true
+      expect(provider.reload.is_active).to eq("\x00")
+    end
+
+    it "does not treat the inactive binary flag as truthy during validation" do
+      provider = create(:provider, is_active: false)
+      provider.is_active = "\x00"
+      provider.valid?
+      expect(provider.is_active).to eq("\x00")
+    end
+
+    it "reactivates when set to true" do
+      provider = create(:provider, is_active: false)
+      expect(provider.update(is_active: true)).to be true
+      expect(provider.reload.is_active).to eq("\x01")
+    end
+
+    it "maps nil to inactive binary flag" do
+      provider = create(:provider)
+      expect(provider.update(is_active: nil)).to be true
+      expect(provider.reload.is_active).to eq("\x00")
+    end
+  end
 end

--- a/spec/requests/clients_spec.rb
+++ b/spec/requests/clients_spec.rb
@@ -405,6 +405,38 @@ describe ClientsController, type: :request, elasticsearch: true do
       end
     end
 
+    context "deactivates isActive" do
+      let(:params) do
+        {
+          "data" => {
+            "type" => "clients",
+            "attributes" => { "isActive" => false },
+          },
+        }
+      end
+
+      it "sets isActive to false and keeps it false on later updates" do
+        put "/clients/#{client.symbol}", params, headers
+
+        expect(last_response.status).to eq(200)
+        expect(json.dig("data", "attributes", "isActive")).to be false
+        expect(client.reload.is_active).to eq("\x00")
+
+        put "/clients/#{client.symbol}",
+            {
+              "data" => {
+                "type" => "clients",
+                "attributes" => { "name" => "Still Inactive Repository" },
+              },
+            },
+            headers
+
+        expect(last_response.status).to eq(200)
+        expect(json.dig("data", "attributes", "isActive")).to be false
+        expect(client.reload.is_active).to eq("\x00")
+      end
+    end
+
     context "invalid globus_uuid" do
       let(:params) do
         {

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1004,6 +1004,38 @@ describe ProvidersController, type: :request, elasticsearch: true do
       end
     end
 
+    context "deactivates isActive" do
+      let(:params) do
+        {
+          "data" => {
+            "type" => "providers",
+            "attributes" => { "isActive" => false },
+          },
+        }
+      end
+
+      it "sets isActive to false and keeps it false on later updates" do
+        put "/providers/#{provider.symbol}", params, admin_headers
+
+        expect(last_response.status).to eq(200)
+        expect(json.dig("data", "attributes", "isActive")).to be false
+        expect(provider.reload.is_active).to eq("\x00")
+
+        put "/providers/#{provider.symbol}",
+            {
+              "data" => {
+                "type" => "providers",
+                "attributes" => { "name" => "Still Inactive Provider" },
+              },
+            },
+            admin_headers
+
+        expect(last_response.status).to eq(200)
+        expect(json.dig("data", "attributes", "isActive")).to be false
+        expect(provider.reload.is_active).to eq("\x00")
+      end
+    end
+
     context "invalid globus_uuid" do
       let(:params) do
         {

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1036,6 +1036,118 @@ describe ProvidersController, type: :request, elasticsearch: true do
       end
     end
 
+    context "inactive provider_admin cannot self-reactivate or update" do
+      let(:provider) do
+        create(
+          :provider,
+          consortium: consortium,
+          role_name: "ROLE_CONSORTIUM_ORGANIZATION",
+          is_active: false,
+          password_input: "12345",
+        )
+      end
+      let(:provider_admin_token) do
+        User.generate_token(
+          role_id: "provider_admin",
+          provider_id: provider.symbol.downcase,
+        )
+      end
+      let(:provider_admin_headers) do
+        {
+          "HTTP_ACCEPT" => "application/vnd.api+json",
+          "HTTP_AUTHORIZATION" => "Bearer " + provider_admin_token,
+        }
+      end
+
+      it "rejects isActive true and leaves the provider inactive" do
+        put "/providers/#{provider.symbol}",
+            {
+              "data" => {
+                "type" => "providers",
+                "attributes" => { "isActive" => true },
+              },
+            },
+            provider_admin_headers
+
+        expect(last_response.status).to eq(403)
+        expect(provider.reload.is_active).to eq("\x00")
+      end
+
+      it "rejects other attribute updates while inactive" do
+        put "/providers/#{provider.symbol}",
+            {
+              "data" => {
+                "type" => "providers",
+                "attributes" => { "name" => "Should Not Change" },
+              },
+            },
+            provider_admin_headers
+
+        expect(last_response.status).to eq(403)
+        expect(provider.reload.name).not_to eq("Should Not Change")
+      end
+    end
+
+    context "active consortium_admin can set child organization isActive" do
+      let(:params) do
+        {
+          "data" => {
+            "type" => "providers",
+            "attributes" => { "isActive" => false },
+          },
+        }
+      end
+
+      it "deactivates a consortium organization" do
+        expect(provider.is_active).to eq("\x01")
+
+        put "/providers/#{provider.symbol}", params, headers
+
+        expect(last_response.status).to eq(200)
+        expect(json.dig("data", "attributes", "isActive")).to be false
+        expect(provider.reload.is_active).to eq("\x00")
+      end
+    end
+
+    context "inactive consortium_admin cannot update self or child orgs" do
+      let(:consortium) do
+        create(:provider, role_name: "ROLE_CONSORTIUM", is_active: false)
+      end
+      let(:token) do
+        User.generate_token(
+          role_id: "consortium_admin",
+          provider_id: consortium.symbol.downcase,
+        )
+      end
+
+      it "rejects reactivating the consortium itself" do
+        put "/providers/#{consortium.symbol}",
+            {
+              "data" => {
+                "type" => "providers",
+                "attributes" => { "isActive" => true },
+              },
+            },
+            headers
+
+        expect(last_response.status).to eq(403)
+        expect(consortium.reload.is_active).to eq("\x00")
+      end
+
+      it "rejects updating a child organization isActive" do
+        put "/providers/#{provider.symbol}",
+            {
+              "data" => {
+                "type" => "providers",
+                "attributes" => { "isActive" => false },
+              },
+            },
+            headers
+
+        expect(last_response.status).to eq(403)
+      end
+    end
+
     context "invalid globus_uuid" do
       let(:params) do
         {


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
`is_active` is stored as binary(1) ("\x01"/"\x00"). `set_defaults` used Ruby truthiness, and "\x00" is truthy, so deactivating a provider or client was immediately undone on the next validation (e.g. any later update).

Fixes datacite/product-backlog#912

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->
Normalize via `BinaryActiveFlag` and cover Provider/Client model and request specs for deactivate + stay-inactive.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
