### PR TITLE
Set up native Cursor Cloud dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ doc/dependencies*
 !.env.example
 !.env.travis
 !.env.build
+
+# Local-only lockfile for the native dev-server Gemfile (Gemfile.dev)
+/Gemfile.dev.lock
 docker-compose.override.yml
 .vscode
 .solargraph.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the DataCite REST API ("Lupo"), a Ruby on Rails 8.1 API-only app
+(Ruby 4.0.1, Bundler). Upstream development uses Docker Compose + Passenger (see
+`README.md`), but in Cursor Cloud it is set up to run **natively, without Docker**:
+Ruby 4.0.1 is installed via `rbenv`, and MySQL 8.0, Memcached, and OpenSearch 2
+run as local services on `localhost`.
+
+### Backing services (start these at the start of a session — not auto-started)
+
+- MySQL: `sudo service mysql start` — `127.0.0.1:3306`, user `root`, empty password.
+- Memcached: `sudo service memcached start` — `127.0.0.1:11211`.
+- OpenSearch 2 (single-node, security plugin disabled): first set the kernel limit
+  once per boot with `sudo sysctl -w vm.max_map_count=262144`, then start it in a
+  tmux session: `cd ~/opensearch && OPENSEARCH_JAVA_OPTS="-Xms1g -Xmx1g" ./bin/opensearch`.
+  Verify with `curl -s localhost:9200`.
+
+The MySQL data (databases `datacite` and `datacite_test`) and the OpenSearch data
+persist in the VM snapshot, so you normally do not need to recreate them. If you do:
+`bundle exec rake db:setup RAILS_ENV=development`, `... db:create db:schema:load RAILS_ENV=test`,
+and `bundle exec rake elasticsearch:create_all_indexes RAILS_ENV=development`.
+
+### Environment
+
+- `rbenv` is initialized from `~/.bashrc`, so interactive shells get Ruby 4.0.1.
+  In non-interactive contexts, call the shims directly (e.g. `~/.rbenv/shims/bundle`).
+- A git-ignored `.env` (created during setup) overrides the Docker service
+  hostnames (`mysql`/`elasticsearch`/`memcached`) with `localhost`. It also sets
+  `ELASTIC_PASSWORD` (the ES client hardcodes user `elastic`, so a non-nil password
+  is required even though OpenSearch security is disabled) and the RSA `JWT_PRIVATE_KEY`
+  / `JWT_PUBLIC_KEY` (the `spec/fixtures/certs` keys) so auth tokens work in dev.
+  If `.env` is missing, recreate those overrides.
+
+### Lint / test / run
+
+- Lint: `bundle exec rubocop --parallel` (security: `bundle exec brakeman`,
+  `bundle exec bundle-audit check --update`).
+- Tests: `bundle exec rspec` (RSpec; test DB is `datacite_test`). The test ES indexes
+  are created automatically by the suite's `before(:suite)` hook — no manual step.
+- Run the API in development: the committed `Gemfile` has **no app-server gem**
+  (production uses Passenger inside Docker). To run natively, use the git-ignored
+  `Gemfile.dev`, which layers Puma on top of the real Gemfile:
+  `BUNDLE_GEMFILE=Gemfile.dev bundle exec rails server -b 0.0.0.0 -p 3000`
+  (run `BUNDLE_GEMFILE=Gemfile.dev bundle install` once if Puma is not installed).
+  Serves on `http://localhost:3000`; health check: `GET /heartbeat` → `OK`.
+
+### Gotchas
+
+- Listing endpoints (`/dois`, `/providers`, `/clients`) read from **OpenSearch**, not
+  MySQL. After seeding/importing, index the data: `rake datacite_doi:import`,
+  `rake provider:import`, `rake client:import` (or reindex a model directly, e.g.
+  `DataciteDoi.__elasticsearch__.import(refresh: true)`). Only `findable` DOIs appear
+  in the public `/dois` list; `draft` DOIs do not.
+- Creating a Provider via the API sends a Mailgun welcome email; with placeholder
+  Mailgun credentials this returns HTTP 500 even though the provider row is created.
+  Creating DOIs does not send email.
+- Generate an admin bearer token for authenticated API calls with
+  `rake user:generate_jwt` (defaults to a `staff_admin` token).

--- a/Gemfile.dev
+++ b/Gemfile.dev
@@ -1,0 +1,8 @@
+# Untracked, local-only Gemfile for running a native development server.
+# On `master` the app is served by Passenger inside Docker, so no server gem is
+# in the main Gemfile. This layers Puma (the Rails default dev server) on top of
+# the real Gemfile without modifying the committed Gemfile/Gemfile.lock.
+#
+# Usage: BUNDLE_GEMFILE=Gemfile.dev bundle exec rails server
+eval_gemfile "Gemfile"
+gem "puma", "~> 6.4"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the DataCite REST API ("Lupo") to run **natively** in the Cursor Cloud VM (no Docker), and adds durable instructions for future agents. No application code was modified.

The stack is Ruby 4.0.1 (via rbenv) + Rails 8.1, backed by MySQL 8.0, Memcached, and OpenSearch 2 running locally. Environment-specific files (`.env`, `.bundle/config`, `Gemfile.dev.lock`) are git-ignored and persisted via the VM snapshot.

## Changes

- `Gemfile.dev` — a local-only Gemfile that layers Puma on top of the real `Gemfile` (the committed `Gemfile` has no app-server gem because production uses Passenger in Docker). Lets us run `rails server` natively without touching `Gemfile`/`Gemfile.lock`.
- `.gitignore` — ignore the generated `Gemfile.dev.lock`.
- `AGENTS.md` — Cursor Cloud specific instructions: how to start the backing services, environment/`.env` notes, and lint/test/run commands plus non-obvious gotchas.

## Verification

| Task | Command | Result |
| --- | --- | --- |
| Lint | `bundle exec rubocop --parallel` | 677 files, **no offenses** |
| Test | `bundle exec rspec spec/models/prefix_spec.rb` | **4 examples, 0 failures** |
| Run | `BUNDLE_GEMFILE=Gemfile.dev bundle exec rails server` | Boots in development mode; `GET /heartbeat` → `OK` |

**Hello-world (core functionality):** created a draft DOI via the authenticated REST API and read it back:
- `POST /dois` (staff_admin JWT) → `HTTP 201`, `state: draft`, linked to client `datacite.testuser`
- `GET /dois/10.14454/cursor-hello-17194` → `HTTP 200`; confirmed persisted in MySQL
- `/providers` and `/dois` listing endpoints serve indexed data from OpenSearch

[lupo_api_dev_server_demo.mp4](https://cursor.com/agents/bc-cf9e3754-ded5-41ac-a34c-ecff7f78f30e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flupo_api_dev_server_demo.mp4)

[/providers showing the created organization](https://cursor.com/agents/bc-cf9e3754-ded5-41ac-a34c-ecff7f78f30e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_providers_cursor_org.webp)
[/dois listing served from OpenSearch](https://cursor.com/agents/bc-cf9e3754-ded5-41ac-a34c-ecff7f78f30e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_dois_listing.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf9e3754-ded5-41ac-a34c-ecff7f78f30e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf9e3754-ded5-41ac-a34c-ecff7f78f30e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

