### PR TITLE
Nested values should be indexed with original attributes if enriched record is invalid

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,7 @@ GEM
     google-protobuf (4.34.1-x86_64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    graphql (2.6.3)
+    graphql (2.6.7)
       base64
       fiber-storage
       logger

--- a/app/jobs/enriched_doi_index_job.rb
+++ b/app/jobs/enriched_doi_index_job.rb
@@ -29,7 +29,7 @@ class EnrichedDoiIndexJob < ApplicationJob
 
     return unless source_doi.has_enrichments
 
-    original_source_attributes = source_doi.attributes
+    original_source_attributes = source_doi.attributes.deep_dup
 
     source_doi.only_validate = true
     source_doi.regenerate = true

--- a/spec/requests/datacite_dois/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois/datacite_dois_spec.rb
@@ -2373,7 +2373,7 @@ describe DataciteDoisController, type: :request, vcr: true do
         doi_record.update_column(:url, "http://example.com/invalid with space")
       end
     end
-    let!(:enrichment_for_doi_with_invalid_url) { create(:enrichment, doi: doi_with_invalid_url.doi)}
+    let!(:enrichment_for_doi_with_invalid_url) { create(:enrichment, doi: doi_with_invalid_url.doi) }
     let(:doi_with_contributor) do
       create(:doi, client: client, aasm_state: "findable", contributors: [{
         "name" => "Arslan, M.",
@@ -2383,7 +2383,7 @@ describe DataciteDoisController, type: :request, vcr: true do
         "affiliation" => [],
       }])
     end
-    let!(:enrichment_with_invalid_contributor) { create(:enrichment, 
+    let!(:enrichment_with_invalid_contributor) { create(:enrichment,
       doi: doi_with_contributor.doi,
       field: "contributors",
       original_value: doi_with_contributor.contributors.first,

--- a/spec/requests/datacite_dois/datacite_dois_spec.rb
+++ b/spec/requests/datacite_dois/datacite_dois_spec.rb
@@ -2363,9 +2363,52 @@ describe DataciteDoisController, type: :request, vcr: true do
         "familyName" => "Arslan",
         "affiliation" => [],
       }]) }
+    let(:doi_with_invalid_url) do
+      create(:doi, doi: "10.14454/invalid", client: client, aasm_state: "findable", creators: [{
+        "name" => "Arslan, M.",
+        "givenName" => "M.",
+        "familyName" => "Arslan",
+        "affiliation" => [],
+      }]).tap do |doi_record|
+        doi_record.update_column(:url, "http://example.com/invalid with space")
+      end
+    end
+    let!(:enrichment_for_doi_with_invalid_url) { create(:enrichment, doi: doi_with_invalid_url.doi)}
+    let(:doi_with_contributor) do
+      create(:doi, client: client, aasm_state: "findable", contributors: [{
+        "name" => "Arslan, M.",
+        "givenName" => "M.",
+        "familyName" => "Arslan",
+        "contributorType" => "ContactPerson",
+        "affiliation" => [],
+      }])
+    end
+    let!(:enrichment_with_invalid_contributor) { create(:enrichment, 
+      doi: doi_with_contributor.doi,
+      field: "contributors",
+      original_value: doi_with_contributor.contributors.first,
+      enriched_value: {
+        "name" => "Arslan, M.",
+        "givenName" => "M.",
+        "familyName" => "Arslan",
+        "contributorType" => "Funder",
+        "affiliation" => [
+          {
+            "name": "UNSW Sydney, neilcmalan@gmail.com",
+            "schemeUri": "https://ror.org",
+            "affiliationIdentifier": "https://ror.org/03r8z3t63",
+            "affiliationIdentifierScheme": "ROR"
+          }
+        ],
+        "nameIdentifiers" => [],
+      }) }
 
     before do
       IndexJobDoiRegistration.perform_now(doi)
+      IndexJobDoiRegistration.perform_now(doi_with_invalid_url)
+      IndexJobDoiRegistration.perform_now(doi_with_contributor)
+      EnrichedDoiIndexJob.perform_now(doi_with_invalid_url.doi)
+      EnrichedDoiIndexJob.perform_now(doi_with_contributor.doi)
       import_doi_index
       refresh_enriched_doi_index
     end
@@ -2421,6 +2464,69 @@ describe DataciteDoisController, type: :request, vcr: true do
         expect(json.dig("data", 0, "attributes", "doi")).to eq(doi.doi.downcase)
         expect(json.dig("data", 0, "attributes", "titles")).to eq(updated_titles)
         expect(json.dig("data", 0, "attributes", "creators", 0)).to eq(enrichment.enriched_value)
+      end
+    end
+
+    context "when a doi record has an invalid url" do
+      it "returns the original value at /dois" do
+        get "/dois?query=doi:#{doi_with_invalid_url.doi}", nil, headers
+        expect(last_response.status).to eq(200)
+        expect(json.dig("data").size).to eq(1)
+        expect(json.dig("data", 0, "attributes", "doi")).to eq(doi_with_invalid_url.doi.downcase)
+        expect(json.dig("data", 0, "attributes", "creators")).to eq([{
+          "name" => "Arslan, M.",
+          "givenName" => "M.",
+          "familyName" => "Arslan",
+          "affiliation" => [],
+          "nameIdentifiers" => [],
+        }])
+      end
+
+      it "returns the original value at /dois?enriched=true" do
+        get "/dois?query=doi:#{doi_with_invalid_url.doi}&enriched=true", nil, headers
+        expect(last_response.status).to eq(200)
+        expect(json.dig("data").size).to eq(1)
+        expect(json.dig("data", 0, "attributes", "doi")).to eq(doi_with_invalid_url.doi.downcase)
+        expect(json.dig("data", 0, "attributes", "creators")).to eq([{
+          "name" => "Arslan, M.",
+          "givenName" => "M.",
+          "familyName" => "Arslan",
+          "affiliation" => [],
+          "nameIdentifiers" => [],
+        }])
+        expect(json.dig("data", 0, "relationships", "enrichments", "data")).to eq([])
+      end
+    end
+
+    context "when an enrichment record has an invalid contributor" do
+      it "returns the original value at /dois" do
+        get "/dois?query=doi:#{doi_with_contributor.doi}", nil, headers
+        expect(last_response.status).to eq(200)
+        expect(json.dig("data").size).to eq(1)
+        expect(json.dig("data", 0, "attributes", "doi")).to eq(doi_with_contributor.doi.downcase)
+        expect(json.dig("data", 0, "attributes", "contributors")).to eq([{
+          "name" => "Arslan, M.",
+          "givenName" => "M.",
+          "familyName" => "Arslan",
+          "contributorType" => "ContactPerson",
+          "affiliation" => [],
+          "nameIdentifiers" => [],
+        }])
+      end
+
+      it "returns the original value at /dois?enriched=true" do
+        get "/dois?query=doi:#{doi_with_contributor.doi}&enriched=true", nil, headers
+        expect(last_response.status).to eq(200)
+        expect(json.dig("data").size).to eq(1)
+        expect(json.dig("data", 0, "attributes", "doi")).to eq(doi_with_contributor.doi.downcase)
+        expect(json.dig("data", 0, "attributes", "contributors")).to eq([{
+          "name" => "Arslan, M.",
+          "givenName" => "M.",
+          "familyName" => "Arslan",
+          "contributorType" => "ContactPerson",
+          "affiliation" => [],
+          "nameIdentifiers" => [],
+        }])
       end
     end
   end


### PR DESCRIPTION

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

 Currently, nested fields appear with their enriched values in OpenSearch even if `source_doi.invalid?`. A `deep_dup` is necessary to substitute original values in nested fields like `affiliation` when `source_doi.invalid?`.

closes: https://github.com/datacite/product-backlog/issues/921

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
