### PR TITLE
Remove software enum from openapi.yaml (now allows free text)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -191,7 +191,7 @@ paths:
         - in: query
           name: software
           schema:
-            $ref: '#/components/schemas/software'
+            type: string
         - in: query
           name: client-type
           schema:
@@ -439,7 +439,6 @@ paths:
                             $ref: '#/components/schemas/repositoryType'
                         software:
                           type: string
-                          $ref: '#/components/schemas/software'
                         isActive:
                           description: Set to true if this account can register and update DOIs.
                           type: boolean
@@ -575,7 +574,6 @@ paths:
                             $ref: '#/components/schemas/repositoryType'
                         software:
                           type: string
-                          $ref: '#/components/schemas/software'
                         isActive:
                           description: Set to true if this account can register and update DOIs.
                           type: boolean
@@ -2189,7 +2187,6 @@ components:
               type: string
             software:
               type: string
-              $ref: '#/components/schemas/software'
             subjects:
               type: array
               items:
@@ -3591,36 +3588,6 @@ components:
         - multidisciplinary
         - project-related
         - other
-    software:
-      type: string
-      enum:
-        - Archipelago
-        - Cayuse
-        - CKAN
-        - CSTR & DOI Registration API
-        - Dataverse
-        - dLibra
-        - DSpace
-        - EPrints
-        - Ex Libris Esploro
-        - Fedora
-        - Invenio
-        - Islandora
-        - Medad
-        - MyCoRe
-        - Nesstar
-        - Omega-PSIR
-        - Omeka S
-        - Open Journal Systems (OJS)
-        - OPUS
-        - Pubman
-        - Pure
-        - Redivis
-        - RSpace
-        - Samvera
-        - SESAR
-        - Ubiquity
-        - Other
     relationType:
       description: '[DataCite Metadata Schema: relationType](https://datacite-metadata-schema.readthedocs.io/en/4/appendices/appendix-1/relationType/)'
       type: string


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

The repository (client) "software" field now allows free text, implemented in https://github.com/datacite/product-backlog/issues/647. API users should no longer expect values to conform to a set list.

closes: https://github.com/datacite/product-backlog/issues/930

## Approach
<!--- _How does this change address the problem?_ -->
As discussed in https://github.com/datacite/lupo/pull/1537, remove the software enum and allow any string.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
