### PR TITLE
nameIdentifier can be null

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,7 @@ GEM
     google-protobuf (4.34.1-x86_64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    graphql (2.6.7)
+    graphql (2.6.10)
       base64
       fiber-storage
       logger

--- a/app/models/schemas/doi/name_identifier.json
+++ b/app/models/schemas/doi/name_identifier.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "nameIdentifier": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "nameIdentifierScheme": {
       "type": ["string", "null"]


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Due to the following bug. `nameIdentifier` should be able to be sent as null: 

https://github.com/datacite/datacite/issues/2514

However, in the current JSON Schema, `nameIdentifier` cannot be null. This PR corrects that. 

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
