### PR TITLE
Allow other names and nameIdentifiers to be string or null (as in nameIdentifier from PR1588)

### DIFF
--- a/app/models/schemas/doi/contributor_base.json
+++ b/app/models/schemas/doi/contributor_base.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "name": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "nameType": {
       "anyOf": [

--- a/app/models/schemas/doi/creator_base.json
+++ b/app/models/schemas/doi/creator_base.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "name": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "nameType": {
       "anyOf": [

--- a/app/models/schemas/doi/format.json
+++ b/app/models/schemas/doi/format.json
@@ -2,5 +2,5 @@
   "title": "Format",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Technical format of the resource.",
-  "type": "string"
+  "type": ["string", "null"]
 }

--- a/app/models/schemas/doi/related_identifier.json
+++ b/app/models/schemas/doi/related_identifier.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "relatedIdentifier": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "resourceTypeGeneral": {
       "anyOf": [

--- a/app/models/schemas/doi/related_item_identifier.json
+++ b/app/models/schemas/doi/related_item_identifier.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "relatedItemIdentifier": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "relatedItemIdentifierType": {
       "anyOf": [

--- a/app/models/schemas/doi/resource_type.json
+++ b/app/models/schemas/doi/resource_type.json
@@ -4,7 +4,7 @@
   "type": "object",
   "properties": {
     "resourceType": { 
-      "type": "string" 
+      "type": [ "string", "null" ] 
     },
     "resourceTypeGeneral": { 
       "$ref": "controlled_vocabularies/resource_type_general.json" 

--- a/app/models/schemas/doi/title.json
+++ b/app/models/schemas/doi/title.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "title": { 
-      "type": [ "string" ]
+      "type": [ "string", "null" ]
     },
     "titleType": {
       "anyOf": [


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Following the same pattern as nameIdentifier where string fields can be null.

related to: PR https://github.com/datacite/lupo/pull/1588

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
